### PR TITLE
Strict codegen 35 sanity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_mountain"
-version = "1.12.34"
+version = "1.12.35"
 authors = ["Andrew <andrew@subarctic.org>"]
 license = "MIT"
 description = "Lambda Mountain"

--- a/STRICT/assemble.lm
+++ b/STRICT/assemble.lm
@@ -156,7 +156,7 @@ compile-finish := λ. (: (tail(
    (set output (SCons( (close output) (close assemble-text-section) )))
    (set output (SCons( (close output) (compile-data-header()) )))
    (set output (SCons( (close output) (close assemble-data-section) )))
-   (set assemble-final (clone-rope(escape-string output)))
+   (set assemble-final (clone-rope(maybe-deref(escape-string output))))
 )) Nil);
 
 compile-write := λ. (: (tail(

--- a/STRICT/assemble.lm
+++ b/STRICT/assemble.lm
@@ -156,7 +156,7 @@ compile-finish := λ. (: (tail(
    (set output (SCons( (close output) (close assemble-text-section) )))
    (set output (SCons( (close output) (compile-data-header()) )))
    (set output (SCons( (close output) (close assemble-data-section) )))
-   (set assemble-final (escape-string-simple(clone-rope output)))
+   (set assemble-final (clone-rope(escape-string-simple output)))
 )) Nil);
 
 compile-write := λ. (: (tail(

--- a/STRICT/assemble.lm
+++ b/STRICT/assemble.lm
@@ -156,7 +156,7 @@ compile-finish := λ. (: (tail(
    (set output (SCons( (close output) (close assemble-text-section) )))
    (set output (SCons( (close output) (compile-data-header()) )))
    (set output (SCons( (close output) (close assemble-data-section) )))
-   (set assemble-final (clone-rope(escape-string-simple output)))
+   (set assemble-final (clone-rope(escape-string output)))
 )) Nil);
 
 compile-write := λ. (: (tail(

--- a/STRICT/codegen.lm
+++ b/STRICT/codegen.lm
@@ -329,8 +329,8 @@ compile-stack-call := λ(: ctx CCContext)(: function-name String)(: args AST)(: 
    (let push-args (maybe-deref(compile-stack-call-push-args( ctx args offset 0_i64 ))))
    (let call SNil)
 
-   (set call (SCons( (close call) (close(SAtom 'push\s%rbp\n_s)) ))) # live test
-#   (set call (SCons( (close call) (close(SAtom 'mov\s%rsp,\s%rbp\n_s)) )))
+   (set call (SCons( (close call) (close(SAtom 'push\s%rbp\n_s)) ))) # live test (OK)
+   (set call (SCons( (close call) (close(SAtom 'mov\s%rsp,\s%rbp\n_s)) ))) # live test ?
 #   (set call (SCons( (close call) (ccfragment::get( push-args 'program_s )) )))
    (set call (SCons( (close call) (close(SAtom function-name)) )))
    (set call (SCons( (close call) (close(SAtom '\n_s)) )))

--- a/STRICT/codegen.lm
+++ b/STRICT/codegen.lm
@@ -329,6 +329,8 @@ compile-stack-call := λ(: ctx CCContext)(: function-name String)(: args AST)(: 
    (let push-args (maybe-deref(compile-stack-call-push-args( ctx args offset 0_i64 ))))
    (let call SNil)
 
+   (print 'ConsTail:\s_s)(print cons-page-tail)(print '\n_s)
+
    (set call (SCons( (close call) (close(SAtom 'push\s%rbp\n_s)) ))) # live test (OK)
    (set call (SCons( (close call) (close(SAtom 'mov\s%rsp,\s%rbp\n_s)) ))) # live test (OK)
 #   (set call (SCons( (close call) (ccfragment::get( push-args 'program_s )) )))

--- a/STRICT/codegen.lm
+++ b/STRICT/codegen.lm
@@ -330,12 +330,12 @@ compile-stack-call := λ(: ctx CCContext)(: function-name String)(: args AST)(: 
    (let call SNil)
 
    (set call (SCons( (close call) (close(SAtom 'push\s%rbp\n_s)) ))) # live test (OK)
-   (set call (SCons( (close call) (close(SAtom 'mov\s%rsp,\s%rbp\n_s)) ))) # live test ?
+   (set call (SCons( (close call) (close(SAtom 'mov\s%rsp,\s%rbp\n_s)) ))) # live test (OK)
 #   (set call (SCons( (close call) (ccfragment::get( push-args 'program_s )) )))
    (set call (SCons( (close call) (close(SAtom function-name)) )))
    (set call (SCons( (close call) (close(SAtom '\n_s)) )))
 #   (set call (SCons( (close call) (ccfragment::get( push-args 'unframe_s )) )))
-#   (set call (SCons( (close call) (close(SAtom 'mov\s%rbp,\s%rsp\n_s)) )))
+   (set call (SCons( (close call) (close(SAtom 'mov\s%rbp,\s%rsp\n_s)) ))) # live test ?
 #   (set call (SCons( (close call) (close(SAtom 'pop\s%rbp\n_s)) )))
 
    (let r-2 (maybe-deref(ccfragment::set( r 'program_s call ))))(set r r-2)

--- a/STRICT/codegen.lm
+++ b/STRICT/codegen.lm
@@ -331,14 +331,14 @@ compile-stack-call := λ(: ctx CCContext)(: function-name String)(: args AST)(: 
 
    (print 'ConsTail:\s_s)(print cons-page-tail)(print '\n_s)
 
-   (set call (SCons( (close call) (close(SAtom 'push\s%rbp\n_s)) ))) # live test (OK)
-   (set call (SCons( (close call) (close(SAtom 'mov\s%rsp,\s%rbp\n_s)) ))) # live test (OK)
-#   (set call (SCons( (close call) (ccfragment::get( push-args 'program_s )) )))
+   (set call (SCons( (close call) (close(SAtom 'push\s%rbp\n_s)) )))
+   (set call (SCons( (close call) (close(SAtom 'mov\s%rsp,\s%rbp\n_s)) )))
+   (set call (SCons( (close call) (ccfragment::get( push-args 'program_s )) )))
    (set call (SCons( (close call) (close(SAtom function-name)) )))
    (set call (SCons( (close call) (close(SAtom '\n_s)) )))
-#   (set call (SCons( (close call) (ccfragment::get( push-args 'unframe_s )) )))
-   (set call (SCons( (close call) (close(SAtom 'mov\s%rbp,\s%rsp\n_s)) ))) # live test ?
-#   (set call (SCons( (close call) (close(SAtom 'pop\s%rbp\n_s)) )))
+   (set call (SCons( (close call) (ccfragment::get( push-args 'unframe_s )) )))
+   (set call (SCons( (close call) (close(SAtom 'mov\s%rbp,\s%rsp\n_s)) )))
+   (set call (SCons( (close call) (close(SAtom 'pop\s%rbp\n_s)) )))
 
    (let r-2 (maybe-deref(ccfragment::set( r 'program_s call ))))(set r r-2)
    (close r)

--- a/STRICT/codegen.lm
+++ b/STRICT/codegen.lm
@@ -264,7 +264,7 @@ compile-expr := λ(: ctx CCContext)(: term AST)(: stack-offset I64)(: used Used)
                (match f (
                   ()
                   ( (Var fname) (tail(
-                     (let e1 (maybe-deref(compile-stack-call( ctx fname a stack-offset ))))
+                     (let e1 (maybe-deref(compile-stack-call( ctx fname (maybe-deref(typecheck-lookup f)) a stack-offset ))))
                      (set e e1)
                   )))
                   ( (Lit fname) (tail(
@@ -322,19 +322,21 @@ compile-destructure-args := λ(: ctx CCContext)(: lhs AST)(: offset I64). (: (ta
    (close ctx)
 )) CCContext[]);
 
-compile-stack-call := λ(: ctx CCContext)(: function-name String)(: args AST)(: offset I64). (: (tail(
+compile-stack-call := λ(: ctx CCContext)(: function-name String)(: function-type Type)(: args AST)(: offset I64). (: (tail(
    (let r (maybe-deref(ccfragment::new())))
    (let r-1 (maybe-deref(ccfragment::set-context( r ctx ))))(set r r-1)
    (let f (maybe-deref(cccontext::lookup( ctx function-name (maybe-deref(typecheck-lookup args)) args ))))
    (let push-args (maybe-deref(compile-stack-call-push-args( ctx args offset 0_i64 ))))
    (let call SNil)
+   (let function-id (mangle-identifier( function-name function-type )))
 
    (print 'ConsTail:\s_s)(print cons-page-tail)(print '\n_s)
 
    (set call (SCons( (close call) (close(SAtom 'push\s%rbp\n_s)) )))
    (set call (SCons( (close call) (close(SAtom 'mov\s%rsp,\s%rbp\n_s)) )))
    (set call (SCons( (close call) (ccfragment::get( push-args 'program_s )) )))
-   (set call (SCons( (close call) (close(SAtom function-name)) )))
+   (set call (SCons( (close call) (close(SAtom '\tcall\s_s)) )))
+   (set call (SCons( (close call) (close(SAtom function-id)) )))
    (set call (SCons( (close call) (close(SAtom '\n_s)) )))
    (set call (SCons( (close call) (ccfragment::get( push-args 'unframe_s )) )))
    (set call (SCons( (close call) (close(SAtom 'mov\s%rbp,\s%rsp\n_s)) )))

--- a/STRICT/codegen.lm
+++ b/STRICT/codegen.lm
@@ -329,14 +329,14 @@ compile-stack-call := λ(: ctx CCContext)(: function-name String)(: args AST)(: 
    (let push-args (maybe-deref(compile-stack-call-push-args( ctx args offset 0_i64 ))))
    (let call SNil)
 
-   (set call (SCons( (close call) (close(SAtom 'push\s%rbp\n_s)) )))
-   (set call (SCons( (close call) (close(SAtom 'mov\s%rsp,\s%rbp\n_s)) )))
-   (set call (SCons( (close call) (ccfragment::get( push-args 'program_s )) )))
+   (set call (SCons( (close call) (close(SAtom 'push\s%rbp\n_s)) ))) # live test
+#   (set call (SCons( (close call) (close(SAtom 'mov\s%rsp,\s%rbp\n_s)) )))
+#   (set call (SCons( (close call) (ccfragment::get( push-args 'program_s )) )))
    (set call (SCons( (close call) (close(SAtom function-name)) )))
    (set call (SCons( (close call) (close(SAtom '\n_s)) )))
-   (set call (SCons( (close call) (ccfragment::get( push-args 'unframe_s )) )))
-   (set call (SCons( (close call) (close(SAtom 'mov\s%rbp,\s%rsp\n_s)) )))
-   (set call (SCons( (close call) (close(SAtom 'pop\s%rbp\n_s)) )))
+#   (set call (SCons( (close call) (ccfragment::get( push-args 'unframe_s )) )))
+#   (set call (SCons( (close call) (close(SAtom 'mov\s%rbp,\s%rsp\n_s)) )))
+#   (set call (SCons( (close call) (close(SAtom 'pop\s%rbp\n_s)) )))
 
    (let r-2 (maybe-deref(ccfragment::set( r 'program_s call ))))(set r r-2)
    (close r)

--- a/STRICT/codegen.lm
+++ b/STRICT/codegen.lm
@@ -328,9 +328,16 @@ compile-stack-call := λ(: ctx CCContext)(: function-name String)(: args AST)(: 
    (let f (maybe-deref(cccontext::lookup( ctx function-name (maybe-deref(typecheck-lookup args)) args ))))
    (let push-args (maybe-deref(compile-stack-call-push-args( ctx args offset 0_i64 ))))
    (let call SNil)
-   (set call (SCons( (close call) (close(SAtom '\o\scall\s_s)) )))
+
+   (set call (SCons( (close call) (close(SAtom 'push\s%rbp\n_s)) )))
+   (set call (SCons( (close call) (close(SAtom 'mov\s%rsp,\s%rbp\n_s)) )))
+   (set call (SCons( (close call) (ccfragment::get( push-args 'program_s )) )))
    (set call (SCons( (close call) (close(SAtom function-name)) )))
    (set call (SCons( (close call) (close(SAtom '\n_s)) )))
+   (set call (SCons( (close call) (ccfragment::get( push-args 'unframe_s )) )))
+   (set call (SCons( (close call) (close(SAtom 'mov\s%rbp,\s%rsp\n_s)) )))
+   (set call (SCons( (close call) (close(SAtom 'pop\s%rbp\n_s)) )))
+
    (let r-2 (maybe-deref(ccfragment::set( r 'program_s call ))))(set r r-2)
    (close r)
 

--- a/STRICT/utility.lm
+++ b/STRICT/utility.lm
@@ -338,7 +338,7 @@ mangle-identifier := λ(: k String)(: kt Type). (: (tail(
    (clone-rope cs)
 )) String);
 
-escape-string-simple := λ(: s String). (: (tail(
+escape-string := λ(: s String). (: (tail(
    (let e SNil)
    (while (head-string s) (
       (if (==( (head-string s) 92_u8 )) (tail(
@@ -362,3 +362,15 @@ escape-string-simple := λ(: s String). (: (tail(
    (clone-rope e)
 )) String);
 
+escape-string := λ(: s S). (: (tail(
+   (match s (
+      ()
+      ( (SAtom a) (set s (SAtom(escape-string a)) )
+      ( (SCons( l r )) (set s (SCons(
+         (escape-string l)
+         (escape-string r)
+      ))))
+      ( _ () )
+   ))
+   (close s)
+)) S[]);

--- a/STRICT/utility.lm
+++ b/STRICT/utility.lm
@@ -362,4 +362,3 @@ escape-string-simple := λ(: s String). (: (tail(
    (clone-rope e)
 )) String);
 
-

--- a/STRICT/utility.lm
+++ b/STRICT/utility.lm
@@ -365,7 +365,7 @@ escape-string := λ(: s String). (: (tail(
 escape-string := λ(: s S). (: (tail(
    (match s (
       ()
-      ( (SAtom a) (set s (SAtom(escape-string a)) )
+      ( (SAtom a) (set s (SAtom(escape-string a))) )
       ( (SCons( l r )) (set s (SCons(
          (escape-string l)
          (escape-string r)


### PR DESCRIPTION
Features:
* use exponentially less stack space during text assembly