### PR TITLE
Instruction fragment macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_mountain"
-version = "1.16.5"
+version = "1.16.6"
 authors = ["Andrew <andrew@subarctic.org>"]
 license = "MIT"
 description = "Typed Macro Assembler (backed by Coq proofs-of-correctness)"

--- a/LIB/default-instruction-set.lm
+++ b/LIB/default-instruction-set.lm
@@ -5,12 +5,21 @@ fragment type Reg32 EAX | EBX | ECX | EDX | ESI | EDI | EBP | ESP | R8D | R9D | 
 fragment type Reg64 RAX | RBX | RCX | RDX | RSI | RDI | RBP | RSP | R8  | R9  | R10  | R11  | R12  | R13  | R14  | R15;  size Reg64 8;
 
 macro ('declare-simple-instruction-alias-64 (op-alias op-code op-type)) (
-   fragment op-alias := λ(: l op-type+Reg64)(: r op-type+Reg64). (: (
-      (.program(
-         \t op-code \s '% (.expression l) , \s '% (.expression r) \n
-      ))
-      (.expression( (.expression r) ))
-   ) op-type+Reg64);
+#   fragment op-alias := λ(: l op-type+Reg64)(: r op-type+Reg64). (: (
+#      (.program(
+#         (if-eq (.expression l) (.expression 
+#         (.program l)
+#         \t 'pushq \s '% (.expression l) \n
+#         (.program r)
+#         \t 'movq \s '% (.expression r) , '% (.expression 
+#         \t op-code \s '% (.expression l) , \s '% (.expression r) \n
+#      ))
+#      (.data( (.data l) (.data r) ))
+#      (.frame( (.text l) (.text r) ))
+#      (.frame( (.frame l) (.frame r) ))
+#      (.unframe( (.unframe l) (.frame r) ))
+#      (.expression( (.expression r) ))
+#   ) op-type+Reg64);
 );
 
 fragment : DontChain syscall := λ. (: (.program( \t 'syscall \n )) Nil);

--- a/LIB/default-instruction-set.lm
+++ b/LIB/default-instruction-set.lm
@@ -5,38 +5,10 @@ fragment type Reg32 EAX | EBX | ECX | EDX | ESI | EDI | EBP | ESP | R8D | R9D | 
 fragment type Reg64 RAX | RBX | RCX | RDX | RSI | RDI | RBP | RSP | R8  | R9  | R10  | R11  | R12  | R13  | R14  | R15;  size Reg64 8;
 
 macro ('declare-simple-instruction-alias-64 (op-alias op-code op-type)) (
-#   fragment op-alias := λ(: l op-type+Reg64)(: r op-type+Reg64). (: (
-#      (.program(
-#         (if-eq (.expression l) (.expression r) (
-#            (.program l)
-#            \t 'pushq \s '% (.expression l) \n
-#            (.program r)
-#            \t 'pushq \s '% (.expression r) \n
-#            \t 'popq \s '%r9 \n
-#            \t 'popq \s '%r8 \n
-#            \t op-code \s '%r8 , \s '%r9 \n
-#         ))
-#         (if-neq (.expression l) (.expression r) (
-#            \t op-code \s '% (.expression l) , \s '% (.expression r) \n
-#         ))
-#      ))
-#      (.data( (.data l) (.data r) ))
-#      (.frame( (.text l) (.text r) ))
-#      (.frame( (.frame l) (.frame r) ))
-#      (.unframe( (.unframe l) (.frame r) ))
-#      (.expression(
-#         (if-eq (.expression l) (.expression r) (
-#            'R9
-#         ))
-#         (if-neq (.expression l) (.expression r) (
-#            (.expression r)
-#         ))
-#      ))
-#   ) op-type+Reg64);
    fragment : DontChain op-alias := λ(: l op-type+Constant)(: r op-type+Reg64). (: (
       (.program(
          (.program r)
-         \t op-code \s '$ (.expression l) , \s '% (.expression r) \o 'op-left \n
+         \t op-code \s '$ (.expression l) , \s '% (.expression r) \n
       ))
       (.data( (.data l) (.data r) ))
       (.frame( (.text l) (.text r) ))
@@ -49,7 +21,7 @@ macro ('declare-simple-instruction-alias-64 (op-alias op-code op-type)) (
    fragment : DontChain op-alias := λ(: l op-type+Reg64)(: r op-type+Constant). (: (
       (.program(
          (.program l)
-         \t op-code \s '$ (.expression r) , \s '% (.expression l) \o 'op-right \n
+         \t op-code \s '$ (.expression r) , \s '% (.expression l) \n
       ))
       (.data( (.data l) (.data r) ))
       (.frame( (.text l) (.text r) ))

--- a/LIB/default-instruction-set.lm
+++ b/LIB/default-instruction-set.lm
@@ -7,19 +7,58 @@ fragment type Reg64 RAX | RBX | RCX | RDX | RSI | RDI | RBP | RSP | R8  | R9  | 
 macro ('declare-simple-instruction-alias-64 (op-alias op-code op-type)) (
 #   fragment op-alias := λ(: l op-type+Reg64)(: r op-type+Reg64). (: (
 #      (.program(
-#         (if-eq (.expression l) (.expression 
-#         (.program l)
-#         \t 'pushq \s '% (.expression l) \n
-#         (.program r)
-#         \t 'movq \s '% (.expression r) , '% (.expression 
-#         \t op-code \s '% (.expression l) , \s '% (.expression r) \n
+#         (if-eq (.expression l) (.expression r) (
+#            (.program l)
+#            \t 'pushq \s '% (.expression l) \n
+#            (.program r)
+#            \t 'pushq \s '% (.expression r) \n
+#            \t 'popq \s '%r9 \n
+#            \t 'popq \s '%r8 \n
+#            \t op-code \s '%r8 , \s '%r9 \n
+#         ))
+#         (if-neq (.expression l) (.expression r) (
+#            \t op-code \s '% (.expression l) , \s '% (.expression r) \n
+#         ))
 #      ))
 #      (.data( (.data l) (.data r) ))
 #      (.frame( (.text l) (.text r) ))
 #      (.frame( (.frame l) (.frame r) ))
 #      (.unframe( (.unframe l) (.frame r) ))
-#      (.expression( (.expression r) ))
+#      (.expression(
+#         (if-eq (.expression l) (.expression r) (
+#            'R9
+#         ))
+#         (if-neq (.expression l) (.expression r) (
+#            (.expression r)
+#         ))
+#      ))
 #   ) op-type+Reg64);
+   fragment : DontChain op-alias := λ(: l op-type+Constant)(: r op-type+Reg64). (: (
+      (.program(
+         (.program r)
+         \t op-code \s '$ (.expression l) , \s '% (.expression r) \o 'op-left \n
+      ))
+      (.data( (.data l) (.data r) ))
+      (.frame( (.text l) (.text r) ))
+      (.frame( (.frame l) (.frame r) ))
+      (.unframe( (.unframe l) (.frame r) ))
+      (.expression(
+         (.expression r)
+      ))
+   ) op-type+Reg64);
+   fragment : DontChain op-alias := λ(: l op-type+Reg64)(: r op-type+Constant). (: (
+      (.program(
+         (.program l)
+         \t op-code \s '$ (.expression r) , \s '% (.expression l) \o 'op-right \n
+      ))
+      (.data( (.data l) (.data r) ))
+      (.frame( (.text l) (.text r) ))
+      (.frame( (.frame l) (.frame r) ))
+      (.unframe( (.unframe l) (.frame r) ))
+      (.expression(
+         (.expression l)
+      ))
+   ) op-type+Reg64);
 );
 
 fragment : DontChain syscall := λ. (: (.program( \t 'syscall \n )) Nil);

--- a/LIB/default-stdlib.lm
+++ b/LIB/default-stdlib.lm
@@ -81,6 +81,10 @@ non-zero := λ(: s String). (: (
    r
 ) U64);
 
+!= := λ(: ls S)(: rs S). (: (
+   (not(==( ls rs )))
+) U64);
+
 print := λ(: x S). (: (
    (match x (
       ()

--- a/LIB/default-u64.lm
+++ b/LIB/default-u64.lm
@@ -7,6 +7,6 @@ meta
 ;
 fragment type U64;    size U64 8;    atom suffix U64    _u64;
 
-#(declare-simple-instruction-alias-64( && 'anddd U64 ));
-#(declare-simple-instruction-alias-64( + 'addd U64 ));
+(declare-simple-instruction-alias-64( && 'andq U64 ));
+(declare-simple-instruction-alias-64( + 'addq U64 ));
 

--- a/LIB/default-u64.lm
+++ b/LIB/default-u64.lm
@@ -7,4 +7,6 @@ meta
 ;
 fragment type U64;    size U64 8;    atom suffix U64    _u64;
 
-(declare-simple-instruction-alias-64( && 'and U64 ));
+#(declare-simple-instruction-alias-64( && 'anddd U64 ));
+#(declare-simple-instruction-alias-64( + 'addd U64 ));
+

--- a/SRC/stable-fragment.lm
+++ b/SRC/stable-fragment.lm
@@ -420,6 +420,20 @@ fragment::render-impl := λ(: s S). (: (
       ( (SCons( (SAtom 'App_s) (SCons(
          (SCons( (SAtom 'App_s) (SCons(
             (SCons( (SAtom 'App_s) (SCons(
+               (SCons( (SAtom 'Var_s) (SAtom 'if-neq_s) )) lc
+            )) )) rc
+         )) )) body
+      )) )) (
+         (let lt (fragment::render-impl( lc )))
+         (let rt (fragment::render-impl( rc )))
+         (if (!=( lt rt )) (
+            (let bodyt (fragment::render-impl( body )))
+            (set r bodyt)
+         ) ())
+      ))
+      ( (SCons( (SAtom 'App_s) (SCons(
+         (SCons( (SAtom 'App_s) (SCons(
+            (SCons( (SAtom 'App_s) (SCons(
                (SCons( (SAtom 'App_s) (SCons(
                   (SCons( (SAtom 'Var_s) (SAtom 'for_s) ))
                   (SCons( (SAtom 'Var_s) (SAtom binding) ))

--- a/SRC/stable-preprocess.lm
+++ b/SRC/stable-preprocess.lm
@@ -470,13 +470,13 @@ apply := λ(: ctx Context)(: term AST). (: (
       ))
       ( (Glb( k vr )) (
          (set return (Glb(
-            k
+            (substitute( ctx k ))
             (close(apply( ctx vr )))
          )))
       ))
       ( (Frg( k vr tlt )) (
          (set return (Frg(
-            k
+            (substitute( ctx k ))
             (close(apply( ctx vr )))
             tlt
          )))
@@ -745,3 +745,27 @@ extract-uuids := λ(: loc SourceLocation)(: ctx Context)(: term AST). (: (
    ))
    return
 ) Context);
+
+substitute := λ(: ctx Context)(: v Token). (: (
+   (let vk (key-of v))
+   (while (non-zero ctx) (match ctx (
+      ()
+      ( CtxNil (set ctx CtxEOF) )
+      ( (CtxBind( rst tk (Lit( _ tv )) )) (
+         (if (==( tk vk )) (
+            (set v tv)
+            (set ctx CtxEOF)
+         ) (set ctx rst))
+      ))
+      ( (CtxBind( rst tk (Var( _ tv )) )) (
+         (if (==( tk vk )) (
+            (set v tv)
+            (set ctx CtxEOF)
+         ) (set ctx rst))
+      ))
+      ( (CtxBind( rst tk tv )) (
+         (set ctx rst)
+      ))
+   )))
+   v
+) Token);

--- a/SRC/stable-types.lm
+++ b/SRC/stable-types.lm
@@ -279,6 +279,12 @@ substitute := λ(: tctx Context)(: tt Type). (: (
                   (set tctx CtxEOF)
                ) (set tctx rst))
             ))
+            ( (CtxBind( rst tk (Var( tv _ )) )) (
+               (if (==( tk v )) (
+                  (set tt (parse-type tv))
+                  (set tctx CtxEOF)
+               ) (set tctx rst))
+            ))
             ( (CtxBind( rst tk tv )) (
                (set tctx rst)
             ))


### PR DESCRIPTION
Features:
* fragment specialization is now good enough to reduce most arithmetic operations down to single instructions
* this would be a significant performance improvement over arithmetic functions
* now using macros to define some fragment specialization forms for U64 `+` and `&&`