### PR TITLE
undefine some weird macro to make some C stdlib impls work

### DIFF
--- a/PLUGINS/FRONTEND/C/c-parse-all.lm
+++ b/PLUGINS/FRONTEND/C/c-parse-all.lm
@@ -36,7 +36,8 @@ c-parse-all := λ(: fps List<String>). (: (
       (set[]( argv 1_u64 (as '/dev/null_s U8[])))
       (set[]( argv 2_u64 (as '-o_s U8[])))
       (set[]( argv 3_u64 (as tmp U8[])))
-      (let argvi 4_u64)
+      (set[]( argv 4_u64 (as '-U__USE_MISC_s U8[])))
+      (let argvi 5_u64)
       (for-each (fp in fps) (
          (set[]( argv argvi (as '-include_s U8[])))
          (set[]( argv (+( argvi 1_u64 )) (as fp U8[])))


### PR DESCRIPTION
## Describe your changes
I'm on a system with GLibC and Clang, where `stdio.h` includes a ton of random trash that we don't need.
The problem with that is that a lot of these things use non-standard C features which the C frontend does not support. Undefining the `__USE_MISC` macro via CPP seems to solve the issue

##  Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
