### PR TITLE
fix-ish umbra strings

### DIFF
--- a/PLATFORM/C/LIB/umbra.lsts
+++ b/PLATFORM/C/LIB/umbra.lsts
@@ -66,9 +66,8 @@ let $"set[]"(s: Umbra, i: U64, v: U8): Umbra = (
       UmbraLong { prefix=prefix, raw ptr=ptr } => (
          if i < 4 {
             prefix[i] = v;
-         } else {
-            ptr[i] = v;
          };
+         ptr[i] = v;
       );
    };
    s
@@ -140,7 +139,30 @@ let .has-prefix(base: Umbra, pfx: t): U64 = (
     if pfxlen > base.length() {
         0
     } else {
-        view-len(base, pfxlen) == pfx
+        # this seems unoptimal, but trust me, this is extremly fast
+        # do NOT add a break into the whole loops (bc vectorization)
+        if pfxlen > 4 {
+            let a = addr(base);
+            let matches = 1;
+            let i = 0;
+            while i < pfxlen {
+                if pfx[i] != a[i] {
+                    matches = 0;
+                };
+                i = i + 1;
+            };
+            matches
+        } else {
+            let i = 0;
+            let matches = 1;
+            while i < pfxlen {
+                if pfx[i] != base[i] {
+                    matches = 0;
+                };
+                i = i + 1;
+            };
+            matches
+        }
     }
 );
 
@@ -200,7 +222,7 @@ let to-umbra(s: t): Umbra = (
 );
 
 # clones input to umbra string BUT only includes the first [len] characters
-let to-umbra(s: Umbra, len: U64): Umbra = (
+let to-umbra(s: t, len: U64): Umbra = (
     let out = new-umbra(len);
     let i = 0;
     while i < len {

--- a/tests/lib/umbra.lsts
+++ b/tests/lib/umbra.lsts
@@ -1,0 +1,20 @@
+
+import LIB/default.lm;
+
+# UmbraShort
+let a = to-umbra("Hey");
+assert( a.length == 3 );
+assert( a[0] == "H"[0] );
+assert( a[1] == "e"[0] );
+assert( a[2] == "y"[0] );
+assert( a == "Hey" );
+a = to-umbra(a);
+assert( a.length == 3 );
+assert( a == "Hey" );
+a = a + "!";
+let hash = deep-hash(a);
+assert( a.length == 4 );
+assert( a == "Hey!" );
+assert( a != "Hey" );
+assert( a.has-prefix("He") );
+assert( not(a.has-prefix("Ho")) );


### PR DESCRIPTION
the test fails in the second assert already, so I checked the generated C code, and I found this (edited for readability):
```c
// field_0 is probably the union variant
typedef struct {
  long field_0;
  union {
    // this is UmbraLong, where one of the two fields should be an array
    struct {char* field_1; char* field_2;};

    // this is for UmbraShort, where the field should be a U8[12]
    struct {char* field_1001;};
  };
} LM_UmbraShortLong;

// my guess is that field_2 is the length, and field_0 is the variant of that union (which only has one possible variant. wtf?)
typedef struct {
  long field_0;
  union {
    struct { LM_UmbraShortLong field_1; unsigned int field_2; };
  };
} LM_Umbra;
```

This was generated for 
```
type UmbraShortLong = UmbraShort { arr: U8[12] } | UmbraLong { prefix: U8[4], ptr: U8[] };
type Umbra = Umbra { len: U32, backing: UmbraShortLong };
```

am I doing something wrong or is this a bug?