### PR TITLE
type safe malloc and realloc

### DIFF
--- a/PLATFORM/C/LIB/array.lsts
+++ b/PLATFORM/C/LIB/array.lsts
@@ -26,3 +26,21 @@ declare-unop( $"&", raw-type(t), raw-type(t[]), (l"(&"; x; l")";) );
 
 declare-unop( raw, raw-type(t), raw-type(t), x );
 declare-unop( raw, raw-type(base-type[]), raw-type(base-type[]+Raw), x );
+
+let safe-alloc(len: U64, ty: Type<t>): t[] = (
+   let nb = len * sizeof(t);
+   let ptr = malloc(nb);
+   if ptr as U64 == 0_u64 {
+      fail("malloc(\{nb}) fail");
+   };
+   ptr as t[]
+);
+
+let safe-realloc(ptr: t[], len: U64, ty: Type<t>): t[] = (
+   let nb = len * sizeof(t);
+   let new_ptr = realloc(ptr as ?[], nb);
+   if new_ptr as U64 == 0_u64 {
+      fail("realloc(\{nb}) fail");
+   };
+   new_ptr as t[]
+);

--- a/PLATFORM/C/LIB/vector.lsts
+++ b/PLATFORM/C/LIB/vector.lsts
@@ -4,8 +4,7 @@ type Vector<t> = Vector { data: t[], length: U64, capacity: U64 };
 type Vector<t> implements Collection<t>;
 
 let mk-vector(type: Type<t>, capacity: U64): Vector<t> = (
-   let data-sz = sizeof(t) * capacity;
-   Vector { (malloc(data-sz) as t[]), 0_u64, capacity }
+   Vector { safe-alloc(capacity, type(t)), 0_u64, capacity }
 );
 
 ## generate a [type(Vector<t>)], in which each element is [value]
@@ -20,8 +19,7 @@ let fill-vector(value: t, len: U64): Vector<t> = (
 
 ## does not change the length length, or destroy old elements!
 let .realloc(v: Vector<t>, target-capacity: U64): Vector<t> = (
-   let data-sz = sizeof(t) * target-capacity;
-   let newp = realloc(v.data as ?[], data-sz) as t[];
+   let newp = safe-realloc(v.data, target-capacity, type(t));
    Vector { newp, v.length, target-capacity }
 );
 


### PR DESCRIPTION
TODO: replace all malloc and realloc uses in the stdlib with this

there are actually two reasons for this:
- LLVM now knows that the pointer can not be null. TODO: should also generate for loop that just loads all elements and ignores them to tell LLVM that it's safe to load. (#1409 )
- it's more type safe