### PR TITLE
replace some regex patterns with more tpre friendlier ones

### DIFF
--- a/PLUGINS/FRONTEND/C/c-smart-tokenize.lsts
+++ b/PLUGINS/FRONTEND/C/c-smart-tokenize.lsts
@@ -12,14 +12,11 @@ let std-c-tokenize-string(file-path: String, text: String): List<Token> = (
       "\t".. rest => text = rest;
       "\n".. rest => text = rest;
 
-      (comment=r/^\/\/[^\n]*/).. rest => (
+      (comment=r/^\/\/.*?(?:\r\n|\n|$)/).. rest => (
          text = rest;
       );
 
-      # TODO, allow * character in block comments
-      # posix extended regular expressions don't do well here
-      # this isn't very important though because cpp should remove comments
-      (comment=r/\/[*]([^*])*[*]\//).. rest => (
+      (comment=r/^\/\*(?:.|\s)*?\*\//).. rest => (
          text = rest;
       );
 
@@ -72,23 +69,23 @@ let std-c-tokenize-string(file-path: String, text: String): List<Token> = (
       ".".. rest => (tokens = cons(text[:".".length], tokens); text = rest;);
       "-".. rest => (tokens = cons(text[:"-".length], tokens); text = rest;);
 
-      (cl=r/^[0][x][0-9a-fA-F]+([.][0-9a-fA-F]+)?([eE][0-9a-fA-F]+)?([pP][0-9]+)(fF)?/).. rest => (
+      (cl=r/^[0][x][0-9a-fA-F]+(\.[0-9a-fA-F]+)?([eE][0-9a-fA-F]+)?([pP][0-9]+)(fF)?/).. rest => (
          tokens = cons(text[:cl.length], tokens); text = rest;
       );
-      (cl=r/^[0][x][0-9a-fA-F]+([uU]|[lL]|wb|WB)*/).. rest => (
+      (cl=r/^[0][x][0-9a-fA-F]+?([uU]|[lL]|wb|WB)*/).. rest => (
          tokens = cons(text[:cl.length], tokens); text = rest;
       );
-      (cl=r/^[0][bB][01]+([uU]|[lL]|wb|WB)*/).. rest => (
+      (cl=r/^[0][bB][01]+?([uU]|[lL]|wb|WB)*/).. rest => (
          tokens = cons(text[:cl.length], tokens); text = rest;
       );
-      (cl=r/^[0-9]+([uU]|[lL]|wb|WB)*([.][0-9]+)?([eE][0-9]+)?[fF]?/).. rest => (
+      (cl=r/^[0-9]+?([uU]|[lL]|wb|WB)*?(\.[0-9]+?)?([eE][0-9]+?)?[fF]?/).. rest => (
          tokens = cons(text[:cl.length], tokens); text = rest;
       );
-      (cl=r/^(u8|u|U|L)?[']([^']|([\\][']))+[']/).. rest => (
+      (cl=r/^(u8|u|U|L)?[']([^']|([\\][']))+?[']/).. rest => (
          tokens = cons(text[:cl.length], tokens); text = rest;
       );
 
-      (lit=r/^[RLuU8]*["]([^"\\]|([\\].))*["]/).. rest => (
+      (lit=r/^[RLuU8]*?["]([^"\\]|([\\].))*?["]/).. rest => (
          tokens = cons(text[:lit.length], tokens); text = rest;
       );
 

--- a/PLUGINS/FRONTEND/LSTS/lsts-smart-tokenize.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-smart-tokenize.lsts
@@ -69,15 +69,15 @@ let lsts-tokenize-string(file-path: String, text: String): List<Token> = (
          push-newline = 1;
       );
 
-      (lit=r/^[cl]?["]([^"\\]|([\\].))*["]/).. rest => (
+      (lit=r/^[cl]?["]([^"\\]|([\\].))*?["]/).. rest => (
          tokens = cons(text[:lit.length], tokens); text = rest;
       );
 
-      (rgx=r/^r[\/]([^\/]|([\\].))*[\/]/).. rest => (
+      (rgx=r/^r[\/]([^\/]|([\\].))*?[\/]/).. rest => (
          tokens = cons(text[:rgx.length], tokens); text = rest;
       );
 
-      (id=r/^[$]["]([^"\\]|([\\].))*["]/).. rest => (
+      (id=r/^[$]["]([^"\\]|([\\].))*?["]/).. rest => (
          tokens = cons(text[:id.length], tokens); text = rest;
       );
 
@@ -85,7 +85,7 @@ let lsts-tokenize-string(file-path: String, text: String): List<Token> = (
          tokens = cons(text[:id.length], tokens); text = rest;
       );
 
-      (comment=r/^#[^\n]*[\n]/).. rest => (
+      (comment=r/^#[^\n]*?[\n]/).. rest => (
          text = rest;
       );
 


### PR DESCRIPTION

currently tpre can't match most regex patterns used in LM, but with the soon-to-be-implemented planned feature set, it will be able to match all of these, as long as there are no greedy repeats (except for when it is the last pattern, which will be ok)