### PR TITLE
Scan pre destructure ast macros

### DIFF
--- a/SRC/macro-table.lsts
+++ b/SRC/macro-table.lsts
@@ -1,10 +1,11 @@
 
-let index-macro-table = {} :: HashtableEq<CString,List<(Type,AST)>>;
+let index-macro-table = {} :: HashtableEq<CString,List<(Type,Type,AST)>>;
 
 let bind-new-macro(mname: CString, mterm: AST): Nil = (
    print("Bind New Macro: \{mname} = \{mterm}\n");
-   let row = index-macro-table.lookup(mname, [] :: List<(Type,AST)>);
-   row = cons( (param-types-of-macro(mterm),mterm) , row);
+   let row = index-macro-table.lookup(mname, [] :: List<(Type,Type,AST)>);
+   let mtype = param-types-of-macro(mterm);
+   row = cons( (mtype, macro-type-peep-holes(mtype), mterm), row);
    index-macro-table = index-macro-table.bind(mname, row);
 );
 
@@ -13,5 +14,27 @@ let param-types-of-macro(mterm: AST): Type = (
       Abs{lhs=lhs} => param-types-of-macro(lhs);
       App{ rst=left, right:App{left:Lit{key:c":"}, right:App{right:AType{tt=tt}}}  } => t3(c"Cons",param-types-of-macro(rst),tt);
       App{left:Lit{key:c":"}, right:App{right:AType{tt=tt}}} => tt;
+   }
+);
+
+# A peep-hole determines whether an expression needs to be typechecked or not
+# Yes => means needs to be typechecked
+# ?   => means does not need to be typechecked
+# Rules for whether a type needs to be typechecked
+# a     => no
+# T     => yes
+# T+... => yes
+let macro-type-peep-holes(mtype: Type): Type = (
+   match mtype {
+      TGround{tag:c"Cons", parameters:[p2.. p1..]} => t3(c"Cons",macro-type-peep-holes(p1),macro-type-peep-holes(p2));
+      TGround{} => t1(c"Yes");
+      TAnd{conjugate=conjugate} => (
+         let peep = ta;
+         for vector c in conjugate {
+            peep = peep || macro-type-peep-holes(c);
+         };
+         peep;
+      );
+      _ => ta;
    }
 );

--- a/SRC/macro-table.lsts
+++ b/SRC/macro-table.lsts
@@ -1,9 +1,17 @@
 
-let index-macro-table = {} :: HashtableEq<CString,List<AST>>;
+let index-macro-table = {} :: HashtableEq<CString,List<(Type,AST)>>;
 
 let bind-new-macro(mname: CString, mterm: AST): Nil = (
    print("Bind New Macro: \{mname} = \{mterm}\n");
-   let row = index-macro-table.lookup(mname, [] :: List<AST>);
-   row = cons(mterm, row);
+   let row = index-macro-table.lookup(mname, [] :: List<(Type,AST)>);
+   row = cons( (param-types-of-macro(mterm),mterm) , row);
    index-macro-table = index-macro-table.bind(mname, row);
+);
+
+let param-types-of-macro(mterm: AST): Type = (
+   match mterm {
+      Abs{lhs=lhs} => param-types-of-macro(lhs);
+      App{ rst=left, right:App{left:Lit{key:c":"}, right:App{right:AType{tt=tt}}}  } => t3(c"Cons",param-types-of-macro(rst),tt);
+      App{left:Lit{key:c":"}, right:App{right:AType{tt=tt}}} => tt;
+   }
 );

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -23,11 +23,15 @@ let std-infer-expr(tctx: Maybe<TContext>, term: AST, is-scoped: Bool, used: IsUs
                _ => ();
             }};
 
-            tctx = infer-expr(tctx, l, Unscoped, TAny, used);
-            if typeof(l).is-arrow {
-               tctx = infer-expr(tctx, r, Unscoped, TAny, Call);            
+            if index-macro-table.has(var-name-if-var(l)) {
+               tctx = std-infer-macro(tctx, term);
             } else {
-               tctx = infer-expr(tctx, r, Unscoped, TAny, Used);
+               tctx = infer-expr(tctx, l, Unscoped, TAny, used);
+               if typeof(l).is-arrow {
+                  tctx = infer-expr(tctx, r, Unscoped, TAny, Call);            
+               } else {
+                  tctx = infer-expr(tctx, r, Unscoped, TAny, Used);
+               };
             };
 
             rt = if typeof(l).is-arrow && non-zero(var-name-if-var(l)) {

--- a/SRC/std-infer-macro.lsts
+++ b/SRC/std-infer-macro.lsts
@@ -3,10 +3,29 @@ let std-infer-macro(tctx: Maybe<TContext>, t: AST): Maybe<TContext> = (
    print("Infer macro: \{t}\n");
    match t {
       App{left:Var{mname=key}, r=right} => (
-         let row = index-macro-table.lookup(mname, [] :: List<(Type,AST)>);
-         for Tuple{mtype=first, mterm=second} in row {
-            print("Candidate: \{mname}(\{mtype}) => \{mterm}\n");
+         let row = index-macro-table.lookup(mname, [] :: List<(Type,Type,AST)>);
+         let peep-holes = TAny;
+         let peeped = TAny;
+         for Tuple{mtype=first, peep=second, mterm=third} in row {
+            if non-zero(peep-holes) {
+               if peep-holes != peep then fail("Invalid attempt to peep macro\n\{mname} : \{peeped}\n\{mname} : \{mtype}\n");
+            } else {
+               peep-holes = peep;
+               peeped = mtype;
+            };
          };
+         print("Peep: \{peep-holes}\n");
+         #let dominant-type = TAny;
+         #let candidates = [] :: List<(Type,AST)>;
+         #for Tuple{mtype=first, mterm=second} in row {
+         #   if non-zero(dominant-type) {
+         #   } else {
+         #      dominant-type = 
+         #   }
+         #};
+         #for Tuple{mtype=first, mterm=second} in candidates {
+         #   print("Candidate: \{mname}(\{mtype}) => \{mterm}\n");
+         #}
       );
    };
    tctx

--- a/SRC/std-infer-macro.lsts
+++ b/SRC/std-infer-macro.lsts
@@ -1,5 +1,13 @@
 
 let std-infer-macro(tctx: Maybe<TContext>, t: AST): Maybe<TContext> = (
    print("Infer macro: \{t}\n");
+   match t {
+      App{left:Var{mname=key}, r=right} => (
+         let row = index-macro-table.lookup(mname, [] :: List<(Type,AST)>);
+         for Tuple{mtype=first, mterm=second} in row {
+            print("Candidate: \{mname}(\{mtype}) => \{mterm}\n");
+         };
+      );
+   };
    tctx
 );

--- a/SRC/std-infer-macro.lsts
+++ b/SRC/std-infer-macro.lsts
@@ -8,13 +8,15 @@ let std-infer-macro(tctx: Maybe<TContext>, t: AST): Maybe<TContext> = (
          let peeped = TAny;
          for Tuple{mtype=first, peep=second, mterm=third} in row {
             if non-zero(peep-holes) {
-               if peep-holes != peep then fail("Invalid attempt to peep macro\n\{mname} : \{peeped}\n\{mname} : \{mtype}\n");
+               if peep-holes != peep then fail("Error: Macros must have the same pre-inference expectation.\n\{mname} : \{peeped}\n\{mname} : \{mtype}\n");
             } else {
                peep-holes = peep;
                peeped = mtype;
             };
          };
+         let peeped-type = std-infer-peeped-arguments(tctx, r, peep-holes);
          print("Peep: \{peep-holes}\n");
+         print("Peeped Type: \{peeped-type}\n");
          #let dominant-type = TAny;
          #let candidates = [] :: List<(Type,AST)>;
          #for Tuple{mtype=first, mterm=second} in row {
@@ -29,4 +31,22 @@ let std-infer-macro(tctx: Maybe<TContext>, t: AST): Maybe<TContext> = (
       );
    };
    tctx
+);
+
+let std-infer-peeped-arguments(tctx: Maybe<TContext>, t: AST, peep: Type): Type = (
+   match peep {
+      TGround{tag:c"Cons", parameters:[p2.. p1..]} => (
+         match t {
+            App{left=left, right=right} => (
+               t3(c"Cons",
+                  std-infer-peeped-arguments(tctx, left, p1),
+                  std-infer-peeped-arguments(tctx, right, p2)
+               )
+            );
+            _ => fail("std-infer-peeped-arguments expected cons term: \{t}\n");
+         }
+      );
+      TAny{} => ta;
+      _ => ( infer-expr(tctx, t, Unscoped, TAny, Used); typeof(t) );
+   }
 );

--- a/SRC/std-infer-macro.lsts
+++ b/SRC/std-infer-macro.lsts
@@ -1,0 +1,5 @@
+
+let std-infer-macro(tctx: Maybe<TContext>, t: AST): Maybe<TContext> = (
+   print("Infer macro: \{t}\n");
+   tctx
+);

--- a/SRC/unit-orphans.lsts
+++ b/SRC/unit-orphans.lsts
@@ -13,3 +13,4 @@ import SRC/std-infer-expr.lsts;
 import SRC/apply-and-specialize.lsts;
 import SRC/decorate-var-to-def.lsts;
 import SRC/macro-table.lsts;
+import SRC/std-infer-macro.lsts;


### PR DESCRIPTION
## Describe your changes
Features:
* implemented the "peep" type phase in AST macro selection
* this is all the typechecking that needs to happen *before* macro resolution
* this will determine which macro cases are applied and which are ignored
* Specialization applies during this phase, so arbitrary conjugates can be matched and subsumed

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1468

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
