### PR TITLE
Port more to type2 fffffdd

### DIFF
--- a/PLATFORM/C/LIB/bool.lsts
+++ b/PLATFORM/C/LIB/bool.lsts
@@ -1,5 +1,5 @@
 
-type alias Bool = U64;
+type2 alias Bool = U64;
 
 let true = 1_u64;
 let false = 0_u64;

--- a/PLATFORM/C/LIB/bool.lsts
+++ b/PLATFORM/C/LIB/bool.lsts
@@ -1,5 +1,5 @@
 
-type alias Bool = U8;
+type alias Bool = U64;
 
-let true = 1_u8;
-let false = 0_u8;
+let true = 1_u64;
+let false = 0_u64;

--- a/PLATFORM/C/LIB/list.lm
+++ b/PLATFORM/C/LIB/list.lm
@@ -2,7 +2,6 @@
 ## linked list
 ##
 ## consider using [type(Vector<x>)] instead
-type List<x> LEOF | (LCons( head:x , tail:List<x>[] )); zero List<x> LEOF;
 
 cons := λ(: hd x)(: tl List<x>). (: (
    (set tl (LCons( hd (close tl) )))

--- a/PLATFORM/C/LIB/list.lsts
+++ b/PLATFORM/C/LIB/list.lsts
@@ -1,4 +1,8 @@
 
+type List<x> = LEOF
+              | LCons{ head:x , tail:List<x>[] };
+zero List<x> = LEOF;
+
 let cmp(ls: List<x>, rs: List<x>): Ord = (
    let diff = Equal;
    while is(diff, Equal) && non-zero(ls) && non-zero(rs) {

--- a/PLATFORM/C/LIB/tuple.lsts
+++ b/PLATFORM/C/LIB/tuple.lsts
@@ -1,7 +1,7 @@
 
-type Tuple<x,y> = Tuple { first: x, second: y };
-type Tuple<x,y,z> = Tuple { first: x, second: y, third: z };
-type Tuple<w,x,y,z> = Tuple { first: w, second: x, third: y, fourth: z };
+type Tuple<x,y> = Tuple{ first: x, second: y };
+type Tuple<x,y,z> = Tuple{ first: x, second: y, third: z };
+type Tuple<w,x,y,z> = Tuple{ first: w, second: x, third: y, fourth: z };
 
 let cmp(l: Tuple<x,y>, r: Tuple<x,y>): Ord = (
    cmp(l.first, r.first) && cmp(l.second, r.second)

--- a/PLATFORM/C/LIB/tuple.lsts
+++ b/PLATFORM/C/LIB/tuple.lsts
@@ -1,7 +1,7 @@
 
-type Tuple<x,y> = Tuple{ first: x, second: y };
-type Tuple<x,y,z> = Tuple{ first: x, second: y, third: z };
-type Tuple<w,x,y,z> = Tuple{ first: w, second: x, third: y, fourth: z };
+type2 Tuple<x,y> = { first: x, second: y };
+type2 Tuple<x,y,z> = { first: x, second: y, third: z };
+type2 Tuple<w,x,y,z> = { first: w, second: x, third: y, fourth: z };
 
 let cmp(l: Tuple<x,y>, r: Tuple<x,y>): Ord = (
    cmp(l.first, r.first) && cmp(l.second, r.second)

--- a/PLATFORM/C/LIB/vector.lsts
+++ b/PLATFORM/C/LIB/vector.lsts
@@ -1,7 +1,7 @@
 
 ## faster than [type(List<t>)]. should be used when you append or remove data a lot
-type Vector<t> = Vector { data: t[], _length: U32, capacity: U32 };
-type Vector<t> implements Collection<t>;
+type2 Vector<t> implements Collection<t>
+                = { data: t[], _length: U32, capacity: U32 };
 
 let .length(v: Vector<t>): U64 = (
    v._length

--- a/PLUGINS/BACKEND/C/std-c-compile-type2-typedef.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-type2-typedef.lsts
@@ -15,12 +15,12 @@ let std-c-compile-type2-typedef(td: AST): Nil = (
       assemble-header-section = assemble-header-section + SAtom{c"typedef struct "} + mangle-c-type(concrete-type, td)
                               + SAtom{c" "} + mangle-c-type(concrete-type, td) + SAtom{c";\n"};
       let tctx = unify(lhs-type, concrete-type);
-      continue-compile-c-typedefs-concrete = cons( (tctx, lhs-type, td), continue-compile-c-typedefs-concrete );
+      continue-compile-c-typedefs-concrete = cons( (tctx, concrete-type, td), continue-compile-c-typedefs-concrete );
    };
 );
 
-let std-c-compile-type2-typedef-concrete(tctx: Maybe<TContext>, lhs-type: Type, td: AST): Nil = (
-   match td { Typedef2{} => (); _ => (fail("Invalid compile type2 \{lhs-type} \{td}\n"); ()); };
+let std-c-compile-type2-typedef-concrete(tctx: Maybe<TContext>, concrete-type: Type, td: AST): Nil = (
+   match td { Typedef2{} => (); _ => (fail("Invalid compile type2 \{concrete-type} \{td}\n"); ()); };
    let location = (td as Tag::Typedef2).location;
    let implements = (td as Tag::Typedef2).implements;
    let implies = (td as Tag::Typedef2).implies;
@@ -40,9 +40,8 @@ let std-c-compile-type2-typedef-concrete(tctx: Maybe<TContext>, lhs-type: Type, 
       }
    };
    if is-incomplete {
-      continue-compile-c-typedefs-concrete = cons( (tctx, lhs-type, td), continue-compile-c-typedefs-concrete );
+      continue-compile-c-typedefs-concrete = cons( (tctx, concrete-type, td), continue-compile-c-typedefs-concrete );
    } else {
-      let concrete-type = substitute(tctx, lhs-type);
       is-cstruct-hard-compiled-index = is-cstruct-hard-compiled-index.bind(concrete-type, 1_u64);
 
       assemble-types-section = assemble-types-section + SAtom{c"struct "} + mangle-c-type(concrete-type, td) + SAtom{c"{\n"};

--- a/PLUGINS/BACKEND/C/std-c-compile-type2-typedef.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-type2-typedef.lsts
@@ -20,7 +20,7 @@ let std-c-compile-type2-typedef(td: AST): Nil = (
 );
 
 let std-c-compile-type2-typedef-concrete(tctx: Maybe<TContext>, lhs-type: Type, td: AST): Nil = (
-   match td { Typedef2{} => (); };
+   match td { Typedef2{} => (); _ => (fail("Invalid compile type2 \{lhs-type} \{td}\n"); ()); };
    let location = (td as Tag::Typedef2).location;
    let implements = (td as Tag::Typedef2).implements;
    let implies = (td as Tag::Typedef2).implies;

--- a/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
+++ b/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
@@ -23,6 +23,7 @@ let std-c-mangle-type-internal(tt: Type, blame: AST): S = (
       );
       TAny{} => SNil;
       TGround{tag:c"Nil", parameters:[]} => SAtom{c"void"};
+      TGround{tag:c"Never", parameters:[]} => SAtom{c"void"};
       TGround{tag:c"Type", parameters:[inner-tt..]} => std-c-mangle-type-internal(inner-tt, blame);
       TGround{tag:c"Array", parameters:[_.. array-base..]} => (
          if array-base.is-arrow
@@ -78,6 +79,8 @@ let std-c-mangle-type-simple(tt: Type, blame: AST): S = (
          };
          result;
       );
+      TGround{tag:c"Nil", parameters:[]} => SAtom{c"void"};
+      TGround{tag:c"Never", parameters:[]} => SAtom{c"void"};
       TGround{tag=tag, parameters=parameters} => (
          let r = mangle-identifier(tag);
          if parameters.length > 0 {

--- a/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
+++ b/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
@@ -51,7 +51,7 @@ let std-c-mangle-type-internal(tt: Type, blame: AST): S = (
             let pi = 0;
             for p in parameters {
                if pi > 0 then r = r + mangle-identifier(c",");
-               r = r + std-c-mangle-type-internal(p, blame);
+               r = r + mangle-identifier(clone-rope(std-c-mangle-type-internal(p, blame)));
                pi = pi + 1;
             };
             r = r + mangle-identifier(c">");

--- a/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
+++ b/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
@@ -22,6 +22,7 @@ let std-c-mangle-type-internal(tt: Type, blame: AST): S = (
          result;
       );
       TAny{} => SNil;
+      TGround{tag:c"Nil", parameters:[]} => SAtom{c"void"};
       TGround{tag:c"Type", parameters:[inner-tt..]} => std-c-mangle-type-internal(inner-tt, blame);
       TGround{tag:c"Array", parameters:[_.. array-base..]} => (
          if array-base.is-arrow
@@ -51,7 +52,40 @@ let std-c-mangle-type-internal(tt: Type, blame: AST): S = (
             let pi = 0;
             for p in parameters {
                if pi > 0 then r = r + mangle-identifier(c",");
-               r = r + mangle-identifier(clone-rope(std-c-mangle-type-internal(p, blame)));
+               r = r + std-c-mangle-type-simple(p, blame);
+               pi = pi + 1;
+            };
+            r = r + mangle-identifier(c">");
+         };
+         r;
+      );
+      _ => SNil;
+   }
+);
+
+let std-c-mangle-type-simple(tt: Type, blame: AST): S = (
+   match tt {
+      TAnd{ conjugate=conjugate } => (
+         let is-c = can-unify(t2(c"C",ta), tt);
+         let result = SNil;
+         for vector c in conjugate {
+            if is-c && c.simple-tag != c"C" {} else {
+               let rt = std-c-mangle-type-internal(c, blame);
+               result = if non-zero(result) && non-zero(rt) then result + SAtom{c" "} + rt
+               else if non-zero(result) then result
+               else rt;
+            }
+         };
+         result;
+      );
+      TGround{tag=tag, parameters=parameters} => (
+         let r = mangle-identifier(tag);
+         if parameters.length > 0 {
+            r = r + mangle-identifier(c"<");
+            let pi = 0;
+            for p in parameters {
+               if pi > 0 then r = r + mangle-identifier(c",");
+               r = r + std-c-mangle-type-simple(p, blame);
                pi = pi + 1;
             };
             r = r + mangle-identifier(c">");

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -769,8 +769,9 @@ let lsts-parse-typedef2(tokens: List<Token>): (AST, List<Token>) = (
       lsts-parse-expect(c"phi", tokens); tokens = tail(tokens);
       misc-type = misc-type && t1(c"Phi");
    };
-   lsts-parse-expect(c"[Typename]", lsts-is-enum-head(lsts-parse-head(tokens)), tokens);
+   lsts-parse-expect(c"[Typename]", lsts-is-enum-head(lsts-parse-head(tokens)) || lsts-parse-head(tokens).has-suffix(c"_ss"), tokens);
    let typename = lsts-parse-head(tokens); tokens = tail(tokens);
+   if typename.has-suffix(c"_ss") then typename = typename.remove-suffix(c"_ss");
    let typeconstraints = mk-vector(type((CString,Type)));
    let lhs-type = if lsts-parse-head(tokens)==c"<" {
       let pars = [] :: List<Type>;

--- a/SRC/ast-definitions.lsts
+++ b/SRC/ast-definitions.lsts
@@ -24,3 +24,7 @@ type alias TContext = List<Tuple<CString,Type,AST>>;
 type alias AContext = List<Tuple<CString,AST>>;
 
 type2 StackToSpecialize = { key:CString, pre-type:Type, ctx:Maybe<TContext>, post-type:Type };
+
+type2 ParsePartial = PME{ term:AST , remainder:List<Token> };
+
+type2 ApplyResult = { function-type:Type , return-type:Type };

--- a/SRC/class-info-index.lsts
+++ b/SRC/class-info-index.lsts
@@ -1,7 +1,7 @@
 
 type StructLayout = LM1Style | CStyle | FragmentStyle | UnknownStyle;
 
-type ClassInfo = ClassInfo { layout: StructLayout, lhs: Type, cases: List<Tuple<CString,Type>> };
+type2 ClassInfo = { layout: StructLayout, lhs: Type, cases: List<Tuple<CString,Type>> };
 let class-info-index = {} :: HashtableEq<Tuple<CString,U64>,ClassInfo>;
 
 let class-info-default = ClassInfo{ UnknownStyle, ta, [] :: List<Tuple<CString,Type>> };

--- a/SRC/index-definitions.lm
+++ b/SRC/index-definitions.lm
@@ -9,7 +9,3 @@ type FContext FCtxEOF | (FCtxBind( remainder:FContext[] , k:String , kt:Type , k
 type Macro (Macro( AST , AST ));
 type MacroList MEOF | (MSeq( MacroList[] , Macro )); zero MacroList MEOF;
 
-type ParsePartial (PME( AST , List<Token> )); # term, remainder
-
-type ApplyResult (ApplyResult( function-type:Type , return-type:Type ));
-

--- a/SRC/infer-global-terms.lsts
+++ b/SRC/infer-global-terms.lsts
@@ -26,10 +26,28 @@ let infer-global-terms(term: AST): AST = (
    }; term
 );
 
-let infer-global-context(term: AST): Nil = (
+let infer-global-context-prim(term: AST): Nil = (
    match term {
       Seq{seq=seq} => (
-         for vector s in seq { infer-global-context(s) }
+         for vector s in seq { infer-global-context-prim(s) }
+      );
+      Glb{ k=key, frhs=val:Abs{lhs=lhs, rhs:App{left:Lit{key:c":"}, right:App{rhs=left, right:AType{return-type=tt}}}, misc-tt=tt} } => (
+         if k.key.has-prefix(c"primitive::") then {
+            let ft = t3(c"Arrow", typeof-lhs(lhs), return-type) && misc-tt;
+            mark-global-as-seen(k.key, ft, misc-tt);
+            ascript-normal(term, ft);
+            ascript-normal(frhs, ft);
+            global-type-context = global-type-context.bind(k.key, ft, term);
+         };
+      );
+      _ => ();
+   }
+);
+
+let infer-global-context-td(term: AST): Nil = (
+   match term {
+      Seq{seq=seq} => (
+         for vector s in seq { infer-global-context-td(s) }
       );
       Typedef{ lhs:Lit{base-type=key}, case-constructors=rhs } => (
          # TODO: remove when LM frontend is removed
@@ -39,8 +57,19 @@ let infer-global-context(term: AST): Nil = (
       Typedef{ lhs:AType{bt=tt}, case-constructors=rhs } => (
          infer-type-definition(bt, case-constructors, 0);
       );
+      Typedef2{} => infer-type2-definition(term);
+      _ => ();
+   }
+);
+
+let infer-global-context(term: AST): Nil = (
+   match term {
+      Seq{seq=seq} => (
+         for vector s in seq { infer-global-context(s) }
+      );
       Glb{ k=key, frhs=val:Abs{lhs=lhs, rhs:App{left:Lit{key:c":"}, right:App{rhs=left, right:AType{return-type=tt}}}, misc-tt=tt} } => (
-         if misc-tt.is-t(c"TypedMacro") then bind-new-macro(k.key, frhs)
+         if k.key.has-prefix(c"primitive::") then ()
+         else if misc-tt.is-t(c"TypedMacro") then bind-new-macro(k.key, frhs)
          else {
             let ft = t3(c"Arrow", typeof-lhs(lhs), return-type) && misc-tt;
             mark-global-as-seen(k.key, ft, misc-tt);
@@ -53,12 +82,3 @@ let infer-global-context(term: AST): Nil = (
    }
 );
 
-let infer-global-context-2(term: AST): Nil = (
-   match term {
-      Seq{seq=seq} => (
-         for vector s in seq { infer-global-context-2(s) }
-      );
-      Typedef2{} => infer-type2-definition(term);
-      _ => ();
-   }
-);

--- a/SRC/infer-type2-definition.lsts
+++ b/SRC/infer-type2-definition.lsts
@@ -13,10 +13,6 @@ let visit-field-template(field-name: CString, base-type: Type, field-type: Type,
    let field-set = substitute(ctx, find-global-callable(c"primitive::field-set", t3(c"Cons", base-type, field-type), blame));
    let field-get-indirect = substitute(ctx, find-global-callable(c"primitive::field-get-indirect", t3(c"Array",base-type,ta), blame));
    let field-set-indirect = substitute(ctx, find-global-callable(c"primitive::field-set-indirect", t3(c"Cons", t3(c"Array",base-type,ta), field-type), blame));
-   infer-global-context(field-get);
-   infer-global-context(field-set);
-   infer-global-context(field-get-indirect);
-   infer-global-context(field-set-indirect);
 
    ctx = None :: Maybe<TContext>;
    ctx = ctx.bind( c"base-type", base-type, mk-eof() );
@@ -24,7 +20,6 @@ let visit-field-template(field-name: CString, base-type: Type, field-type: Type,
    ctx = ctx.bind( c"field-name", ta, mk-lit(mangled-field-name) );
    ctx = ctx.bind( c"primitive::field-get", ta, mk-var(c"."+to-string(field-ordinal)) );
    let field-ordinal-get = substitute(ctx, find-global-callable(c"primitive::field-get", base-type, blame));
-   infer-global-context(field-ordinal-get);
 
    ast-parsed-program = ast-parsed-program + field-get + field-set + field-get-indirect + field-set-indirect + field-ordinal-get;
 );
@@ -154,7 +149,6 @@ let infer-type2-yield-constructor(base-type: Type, case-tag: CString, case-numbe
    body = mk-cons(body, mk-lit(c";})").ascript(t1(c"L")));
 
    let constructor = mk-glb( mk-token(case-tag).with-location(blame.location), mk-abs(args, body.ascript(base-type), t1(c"Blob")) );
-   infer-global-context(constructor);
    ast-parsed-program = ast-parsed-program + constructor;
 );
 

--- a/SRC/typecheck.lm
+++ b/SRC/typecheck.lm
@@ -1,7 +1,8 @@
 
 typecheck := λ. (: (
+   (infer-global-context-prim ast-parsed-program)
+   (infer-global-context-td ast-parsed-program)
    (infer-global-context ast-parsed-program)
-   (infer-global-context-2 ast-parsed-program)
    (assert-no-infinite-types())
    (set ast-parsed-program (infer-global-terms ast-parsed-program))
    (let tctx-ast (std-infer-expr( (: None Maybe<TContext>) ast-parsed-program false Used ta )))

--- a/SRC/types-definitions.lsts
+++ b/SRC/types-definitions.lsts
@@ -1,7 +1,7 @@
 
-# TGround needs to be the last type (tag 0) or else sorted unification will not work right
-type2 Type = TAny
-          | TVar { name: CString }
-          | TAnd { conjugate:Vector<Type> }
-          | TGround { tag: CString, parameters: List<Type>[] };
+# TGround needs to be the first type (tag 0) or else sorted unification will not work right
+type2 Type = TGround { tag: CString, parameters: List<Type>[] }
+           | TVar { name: CString }
+           | TAny
+           | TAnd { conjugate:Vector<Type> };
 zero Type = TAny;


### PR DESCRIPTION
## Describe your changes
Features:
* fix some random bugs with type2
* AST still doesn't want to go for some reason
* need syntax for `C<"uint_8"> implies C<"uint_16">`
* other than those two cases, things seem to work with type2
* I am getting burnt out, need to take a break for a bit
* productivity is going down

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1564

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
