### PR TITLE
Normalize ascription syntax

### DIFF
--- a/PLATFORM/C/LIB/field-accessors.lsts
+++ b/PLATFORM/C/LIB/field-accessors.lsts
@@ -1,61 +1,7 @@
 
-declare-unop( $".discriminator-case-tag", raw-type(LM2Struct+CaseNumber<cn>), raw-type(USize), ( l"("; cn :: L; l")"; ) );
+declare-unop( $".discriminator-case-tag", raw-type(LM2Struct+CaseNumber<cn>), raw-type(USize), ( l"("; cn : L; l")"; ) );
 declare-unop( $".discriminator-case-tag", raw-type(LM2Struct), raw-type(USize), ( l"("; x; l".discriminator_case_tag)"; ) );
-declare-unop( $".discriminator-case-tag", raw-type(Any[]+LMStruct+CaseNumber<cn>), raw-type(USize), ( l"("; cn :: L; l")"; ) );
-declare-unop( $".discriminator-case-tag", raw-type(LMStruct+CaseNumber<cn>), raw-type(USize), ( l"("; cn :: L; l")"; ) );
+declare-unop( $".discriminator-case-tag", raw-type(Any[]+LMStruct+CaseNumber<cn>), raw-type(USize), ( l"("; cn : L; l")"; ) );
+declare-unop( $".discriminator-case-tag", raw-type(LMStruct+CaseNumber<cn>), raw-type(USize), ( l"("; cn : L; l")"; ) );
 declare-unop( $".discriminator-case-tag", raw-type(Any[]+LMStruct), raw-type(USize), ( l"("; x; l"->field_0)"; ) );
 declare-unop( $".discriminator-case-tag", raw-type(LMStruct), raw-type(USize), ( l"("; x; l".field_0)"; ) );
-
-declare-unop( $".0", raw-type(LMStruct), raw-type(U64), ( l"("; x; l".field_0)"; ) );
-declare-unop( $".1", raw-type(CaseNumber<cn>+Field::1<a>), raw-type(a), ( l"("; x; l".field_"; 1_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".2", raw-type(CaseNumber<cn>+Field::2<a>), raw-type(a), ( l"("; x; l".field_"; 2_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".3", raw-type(CaseNumber<cn>+Field::3<a>), raw-type(a), ( l"("; x; l".field_"; 3_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".4", raw-type(CaseNumber<cn>+Field::4<a>), raw-type(a), ( l"("; x; l".field_"; 4_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".5", raw-type(CaseNumber<cn>+Field::5<a>), raw-type(a), ( l"("; x; l".field_"; 5_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".6", raw-type(CaseNumber<cn>+Field::6<a>), raw-type(a), ( l"("; x; l".field_"; 6_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".7", raw-type(CaseNumber<cn>+Field::7<a>), raw-type(a), ( l"("; x; l".field_"; 7_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".8", raw-type(CaseNumber<cn>+Field::8<a>), raw-type(a), ( l"("; x; l".field_"; 8_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".9", raw-type(CaseNumber<cn>+Field::9<a>), raw-type(a), ( l"("; x; l".field_"; 9_l + 1000_l * (cn :: L); l")"; ) );
-
-declare-binop( $"set.1", raw-type(CaseNumber<cn>+Field::1<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l".field_"; 1_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.2", raw-type(CaseNumber<cn>+Field::2<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l".field_"; 2_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.3", raw-type(CaseNumber<cn>+Field::3<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l".field_"; 3_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.4", raw-type(CaseNumber<cn>+Field::4<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l".field_"; 4_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.5", raw-type(CaseNumber<cn>+Field::5<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l".field_"; 5_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.6", raw-type(CaseNumber<cn>+Field::6<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l".field_"; 6_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.7", raw-type(CaseNumber<cn>+Field::7<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l".field_"; 7_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.8", raw-type(CaseNumber<cn>+Field::8<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l".field_"; 8_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.9", raw-type(CaseNumber<cn>+Field::9<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l".field_"; 9_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-
-declare-unop( $".0", raw-type(LMStruct[]), raw-type(U64), ( l"("; x; l"->field_0)"; ) );
-declare-unop( $".0", raw-type(base-type[]+LMStruct), raw-type(U64), ( l"("; x; l"->field_0)"; ) );
-declare-unop( $".1", raw-type(Array<?,?>+CaseNumber<cn>+Field::1<a>), raw-type(a), ( l"("; x; l"->field_"; 1_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".2", raw-type(Array<?,?>+CaseNumber<cn>+Field::2<a>), raw-type(a), ( l"("; x; l"->field_"; 2_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".3", raw-type(Array<?,?>+CaseNumber<cn>+Field::3<a>), raw-type(a), ( l"("; x; l"->field_"; 3_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".4", raw-type(Array<?,?>+CaseNumber<cn>+Field::4<a>), raw-type(a), ( l"("; x; l"->field_"; 4_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".5", raw-type(Array<?,?>+CaseNumber<cn>+Field::5<a>), raw-type(a), ( l"("; x; l"->field_"; 5_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".6", raw-type(Array<?,?>+CaseNumber<cn>+Field::6<a>), raw-type(a), ( l"("; x; l"->field_"; 6_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".7", raw-type(Array<?,?>+CaseNumber<cn>+Field::7<a>), raw-type(a), ( l"("; x; l"->field_"; 7_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".8", raw-type(Array<?,?>+CaseNumber<cn>+Field::8<a>), raw-type(a), ( l"("; x; l"->field_"; 8_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".9", raw-type(Array<?,?>+CaseNumber<cn>+Field::9<a>), raw-type(a), ( l"("; x; l"->field_"; 9_l + 1000_l * (cn :: L); l")"; ) );
-
-declare-binop( $"set.1", raw-type(Array<?,?>+CaseNumber<cn>+Field::1<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l"->field_"; 1_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.2", raw-type(Array<?,?>+CaseNumber<cn>+Field::2<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l"->field_"; 2_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.3", raw-type(Array<?,?>+CaseNumber<cn>+Field::3<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l"->field_"; 3_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.4", raw-type(Array<?,?>+CaseNumber<cn>+Field::4<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l"->field_"; 4_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.5", raw-type(Array<?,?>+CaseNumber<cn>+Field::5<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l"->field_"; 5_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.6", raw-type(Array<?,?>+CaseNumber<cn>+Field::6<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l"->field_"; 6_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.7", raw-type(Array<?,?>+CaseNumber<cn>+Field::7<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l"->field_"; 7_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.8", raw-type(Array<?,?>+CaseNumber<cn>+Field::8<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l"->field_"; 8_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-declare-binop( $"set.9", raw-type(Array<?,?>+CaseNumber<cn>+Field::9<a>), raw-type(a), raw-type(Nil), ( l"({"; x; l"->field_"; 9_l + 1000_l * (cn :: L); l"="; y; l";({});})"; ) );
-
-declare-unop( $".1", raw-type(Array<?,?>+CaseNumber<cn>+Field::1<a>+Raw), raw-type(a[]), ( l"(&"; x; l"->field_"; 1_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".2", raw-type(Array<?,?>+CaseNumber<cn>+Field::2<a>+Raw), raw-type(a[]), ( l"(&"; x; l"->field_"; 2_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".3", raw-type(Array<?,?>+CaseNumber<cn>+Field::3<a>+Raw), raw-type(a[]), ( l"(&"; x; l"->field_"; 3_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".4", raw-type(Array<?,?>+CaseNumber<cn>+Field::4<a>+Raw), raw-type(a[]), ( l"(&"; x; l"->field_"; 4_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".5", raw-type(Array<?,?>+CaseNumber<cn>+Field::5<a>+Raw), raw-type(a[]), ( l"(&"; x; l"->field_"; 5_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".6", raw-type(Array<?,?>+CaseNumber<cn>+Field::6<a>+Raw), raw-type(a[]), ( l"(&"; x; l"->field_"; 6_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".7", raw-type(Array<?,?>+CaseNumber<cn>+Field::7<a>+Raw), raw-type(a[]), ( l"(&"; x; l"->field_"; 7_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".8", raw-type(Array<?,?>+CaseNumber<cn>+Field::8<a>+Raw), raw-type(a[]), ( l"(&"; x; l"->field_"; 8_l + 1000_l * (cn :: L); l")"; ) );
-declare-unop( $".9", raw-type(Array<?,?>+CaseNumber<cn>+Field::9<a>+Raw), raw-type(a[]), ( l"(&"; x; l"->field_"; 9_l + 1000_l * (cn :: L); l")"; ) );
-

--- a/PLATFORM/C/LIB/hashtable.lsts
+++ b/PLATFORM/C/LIB/hashtable.lsts
@@ -39,7 +39,7 @@ let .has(table: HashtableEq<k,v>, key: k): U64 = (
 );
 
 let .bind(table: HashtableEq<k,v>, key: k, value: v): HashtableEq<k,v> = (
-   if is(table, (HashtableEqEOF :: HashtableEq<k,v>)) {
+   if is(table, (HashtableEqEOF : HashtableEq<k,v>)) {
       table = HashtableEq( 0_u64, 0_u64, (0_u64 as Tuple<k,v>[]) );
    };
    let occupied = (table as Tag::HashtableEq).occupied;

--- a/PLATFORM/C/LIB/list.lsts
+++ b/PLATFORM/C/LIB/list.lsts
@@ -31,7 +31,7 @@ let to-smart-string(ls: List<x>): String = (
 );
 
 let .unique(ls: List<x>): List<x> = (
-   let rs = [] :: List<x>;
+   let rs = [] : List<x>;
    for l in ls {
       if not(rs.contains(l)) {
          rs = cons(l, rs);
@@ -46,7 +46,7 @@ let .next(ls: Array<List<x>,?>): Maybe<x> = (
          ls[0_u64] = rst;
          Some(i)
       );
-      [] => (None :: Maybe<x>)();
+      [] => (None : Maybe<x>)();
    };
 );
 

--- a/PLATFORM/C/LIB/primitives.lsts
+++ b/PLATFORM/C/LIB/primitives.lsts
@@ -16,8 +16,8 @@ declare-unop( into-branch-conditional, raw-type(BranchConditional), raw-type(Bra
 declare-unop( $"cdecl::return", raw-type(Any), raw-type(Nil), (l"return "; x; l";";) );
 declare-unop( $"cdecl::return", raw-type(Nil), raw-type(Nil), (x; l";";) );
 
-declare-unop( $"primitive::field-get", raw-type(base-type), raw-type(field-type), ( l"("; x; l"."; mangle(field-name :: L); l")"; ) );
-declare-binop( $"primitive::field-set", raw-type(base-type), raw-type(field-type), raw-type(Nil), ( l"("; x; l"."; mangle(field-name :: L); l"="; y; l")"; ) );
+declare-unop( $"primitive::field-get", raw-type(base-type), raw-type(field-type), ( l"("; x; l"."; mangle(field-name : L); l")"; ) );
+declare-binop( $"primitive::field-set", raw-type(base-type), raw-type(field-type), raw-type(Nil), ( l"("; x; l"."; mangle(field-name : L); l"="; y; l")"; ) );
 
-declare-unop( $"primitive::field-get-indirect", raw-type(base-type[]), raw-type(field-type), ( l"("; x; l"->"; mangle(field-name :: L); l")"; ) );
-declare-binop( $"primitive::field-set-indirect", raw-type(base-type[]), raw-type(field-type), raw-type(Nil), ( l"("; x; l"->"; mangle(field-name :: L); l"="; y; l")"; ) );
+declare-unop( $"primitive::field-get-indirect", raw-type(base-type[]), raw-type(field-type), ( l"("; x; l"->"; mangle(field-name : L); l")"; ) );
+declare-binop( $"primitive::field-set-indirect", raw-type(base-type[]), raw-type(field-type), raw-type(Nil), ( l"("; x; l"->"; mangle(field-name : L); l"="; y; l")"; ) );

--- a/PLATFORM/C/LIB/string.lsts
+++ b/PLATFORM/C/LIB/string.lsts
@@ -68,7 +68,7 @@ let .into(s: CString, tgt: Type<String>): String = intern(s);
 let .into(s: String, tgt: Type<CString>): CString = untern(s);
 
 let .split(s: String, sep: String): List<String> = (
-   let r = [] :: List<String>;
+   let r = [] : List<String>;
    let start-index = 0_u64;
    let current-index = 0_u64;
    while current-index < s.length {

--- a/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
@@ -108,7 +108,7 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
       App{ left:Var{key:c"c::compound"}, terms=right } => (
          let original-ctx = ctx;
          let e = mk-fragment();
-         let terms-list = [] :: List<AST>;
+         let terms-list = [] : List<AST>;
          while non-zero(terms) {match terms {
             App{left=left, right=right} => (
                terms-list = cons( right, terms-list );

--- a/PLUGINS/BACKEND/C/std-c-compile-global.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-global.lsts
@@ -1,5 +1,5 @@
 
-let std-c-force-imports = {} :: HashtableEq<CString,Bool>;
+let std-c-force-imports = {} : HashtableEq<CString,Bool>;
 
 let std-c-force-import-clib(lib: CString): Nil = (
    std-c-force-imports = std-c-force-imports.bind(lib, true);

--- a/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
@@ -11,7 +11,7 @@ let std-c-compile-type-typedef(td: AST): Nil = (
    let cases = (td as Tag::Typedef2).cases;
 
    if cases.length > 0 {
-   for concrete-type in concrete-type-instances-index.lookup(lhs-type.ground-tag-and-arity, [] :: List<Type>) {
+   for concrete-type in concrete-type-instances-index.lookup(lhs-type.ground-tag-and-arity, [] : List<Type>) {
       assemble-header-section = assemble-header-section + SAtom(c"typedef struct ") + mangle-c-type(concrete-type, td)
                               + SAtom(c" ") + mangle-c-type(concrete-type, td) + SAtom(c";\n");
       let tctx = unify(lhs-type, concrete-type);

--- a/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
+++ b/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
@@ -1,5 +1,5 @@
 
-let std-c-declare-dedup-index = {} :: HashtableEq<String,Bool>;
+let std-c-declare-dedup-index = {} : HashtableEq<String,Bool>;
 
 let std-c-declare(t: CTerm): Nil = (
    match t {
@@ -35,7 +35,7 @@ let std-c-declare(t: CTerm): Nil = (
                );
             });
             CUnaryPrefix{op:c"Declarator(", arg=arg} => (
-               (let name, let body) = std-c-sig-of-declarator(return-type, arg, ta, (None :: Maybe<CTerm>)());
+               (let name, let body) = std-c-sig-of-declarator(return-type, arg, ta, (None : Maybe<CTerm>)());
                if not(std-c-declare-dedup-index.has(name.into(type(String)))) {
                   std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name.into(type(String)), true);
                   if can-unify( t2(c"C",t1(c"typedef")), return-type ) {
@@ -97,7 +97,7 @@ let std-c-declare(t: CTerm): Nil = (
 );
 
 let std-c-nametypes-of-params-list(params: List<CTerm>, is-vararg: Bool): List<(CString,Type)> = (
-   let nametypes = [] :: List<(CString,Type)>;
+   let nametypes = [] : List<(CString,Type)>;
    for p in params { match p {
       CBinaryOp{op:c"ParameterDeclaration", spec=arg1, arg2:CIdentifier{name=value}} => (
          (let return-type, let misc-types) = std-c-type-of-specifiers(spec);

--- a/PLUGINS/FRONTEND/C/c-parse.lsts
+++ b/PLUGINS/FRONTEND/C/c-parse.lsts
@@ -187,7 +187,7 @@ let std-c-parse-external-declaration(tokens: List<Token>): List<Token> = (
 let std-c-parse-attribute(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    # https://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html
    # just ignore attributes for now
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    while std-c-can-take(tokens, "__attribute__") || std-c-can-take(tokens, "__asm__") {
       if std-c-can-take(tokens, "__attribute__") {
          tokens = std-c-take-expect(tokens, "__attribute__");
@@ -215,7 +215,7 @@ let std-c-parse-attribute(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> 
 
 let std-c-parse-function-definition(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let original-tokens = tokens;
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let declaration-specifiers = std-c-parse-declaration-specifiers(tokens); tokens = declaration-specifiers.second;
    let return = if declaration-specifiers.first.is-some {
       let declarator = std-c-parse-declarator(tokens); tokens = declarator.second;
@@ -250,7 +250,7 @@ let std-c-parse-declaration(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>
 );
 
 let std-c-parse-declaration-specifiers(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let attr = std-c-parse-attribute(tokens); tokens = attr.second;
    let spec = std-c-parse-declaration-specifier(tokens); tokens = spec.second;
    if spec.first.is-some {
@@ -274,7 +274,7 @@ let std-c-parse-declaration-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,L
 );
 
 let std-c-parse-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let pointer = std-c-parse-pointer(tokens); tokens = pointer.second;
    let dd = std-c-parse-direct-declarator(tokens); tokens = dd.second;
    if pointer.first.is-some && dd.first.is-some
@@ -283,7 +283,7 @@ let std-c-parse-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>>
 );
 
 let std-c-parse-declaration-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let declaration = std-c-parse-declaration(tokens); tokens = declaration.second;
    if declaration.first.is-some {
       let decls = [declaration.first.get-or-panic];
@@ -297,9 +297,9 @@ let std-c-parse-declaration-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<T
 );
 
 let std-c-parse-compound-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "{") {
-      let stmts = [] :: List<CTerm>;
+      let stmts = [] : List<CTerm>;
       tokens = std-c-take-expect(tokens, "{");
       let declaration-or-statement = std-c-parse-declaration-or-statement(tokens); tokens = declaration-or-statement.second;
       while declaration-or-statement.first.is-some {
@@ -317,7 +317,7 @@ let std-c-parse-declaration-or-statement(tokens: List<Token>): Tuple<Maybe<CTerm
 );
 
 let std-c-parse-init-declarator-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let id = std-c-parse-init-declarator(tokens);
    if id.first.is-some {
       let ids = [id.first.get-or-panic];
@@ -345,7 +345,7 @@ let std-c-parse-init-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<To
 );
 
 let std-c-parse-static-assert-declaration(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "_Static_assert") {
       let op = head(tokens).skey;
       tokens = std-c-take-expect(tokens, "_Static_assert");
@@ -362,7 +362,7 @@ let std-c-parse-static-assert-declaration(tokens: List<Token>): Tuple<Maybe<CTer
 );
 
 let std-c-parse-storage-class-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "typedef") then (tokens = std-c-take-expect(tokens, "typedef"); Tuple(Some(CType1("typedef")), tokens) )
    else if std-c-can-take(tokens, "__extension__") then (tokens = std-c-take-expect(tokens, "__extension__"); Tuple(Some(CType1("__extension__")), tokens) )
    else if std-c-can-take(tokens, "extern") then (tokens = std-c-take-expect(tokens, "extern"); Tuple(Some(CType1("extern")), tokens) )
@@ -374,7 +374,7 @@ let std-c-parse-storage-class-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>
 );
 
 let std-c-parse-type-qualifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "const") then (let t = head(tokens).skey; tokens = std-c-take-expect(tokens, "const"); Tuple(Some(CType1(t)), tokens) )
    else if std-c-can-take(tokens, "restrict") then (let t = head(tokens).skey; tokens = std-c-take-expect(tokens, "restrict"); Tuple(Some(CType1(t)), tokens) )
    else if std-c-can-take(tokens, "__restrict") then (let t = head(tokens).skey; tokens = std-c-take-expect(tokens, "__restrict"); Tuple(Some(CType1(t)), tokens) )
@@ -385,7 +385,7 @@ let std-c-parse-type-qualifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Tok
 );
 
 let std-c-parse-function-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "inline") {
       let spec = head(tokens).skey; tokens = std-c-take-expect(tokens, "inline");
       Tuple( Some(CType1(spec)), tokens )
@@ -396,7 +396,7 @@ let std-c-parse-function-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List
 );
 
 let std-c-parse-alignment-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "_Alignas") then {
       tokens = std-c-take-expect(tokens, "_Alignas");
       tokens = std-c-take-expect(tokens, "(");
@@ -408,8 +408,8 @@ let std-c-parse-alignment-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
 );
 
 let std-c-parse-direct-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let yes = Some(CIdentifier("")) :: Maybe<CTerm>; # syntax extension: in parameter lists the identifier can be empty
-   let no = (None :: Maybe<CTerm>)();
+   let yes = Some(CIdentifier("")) : Maybe<CTerm>; # syntax extension: in parameter lists the identifier can be empty
+   let no = (None : Maybe<CTerm>)();
    let original-tokens = tokens;
    let be = if std-c-can-take(tokens, "identifier") then {
       let id = head(tokens).skey; tokens = std-c-take-expect(tokens, "identifier");
@@ -471,7 +471,7 @@ let std-c-parse-direct-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
          else {be = Tuple( no, tokens )}
       } else if std-c-can-take(tokens,"(") {
          tokens = std-c-take-expect(tokens, "(");
-         let te = (None :: Maybe<CTerm>)();
+         let te = (None : Maybe<CTerm>)();
          let ptl = std-c-parse-parameter-type-list(tokens);
          if ptl.first.is-some {
             te = ptl.first;
@@ -492,7 +492,7 @@ let std-c-parse-direct-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
 );
 
 let std-c-parse-identifier-list(tokens: List<Token>): Tuple<Maybe<List<String>>,List<Token>> = (
-   let no = (None :: Maybe<List<String>>)();
+   let no = (None : Maybe<List<String>>)();
    if std-c-can-take(tokens, "identifier") then {
       let ids = [head(tokens).skey];
       tokens = std-c-take-expect(tokens, "identifier");
@@ -508,18 +508,18 @@ let std-c-parse-identifier-list(tokens: List<Token>): Tuple<Maybe<List<String>>,
 );
 
 let std-c-parse-designative-initializer(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let designation = std-c-parse-designation(tokens); tokens = designation.second;
    let initializer = std-c-parse-initializer(tokens); tokens = initializer.second;
    if designation.first.is-some && initializer.first.is-some
    then Tuple( Some(CInitializer(close(designation.first.get-or-panic),close(initializer.first.get-or-panic))), tokens )
    else if initializer.first.is-some
-   then Tuple( Some(CInitializer(close([] :: List<CTerm>),close(initializer.first.get-or-panic))), tokens )
+   then Tuple( Some(CInitializer(close([] : List<CTerm>),close(initializer.first.get-or-panic))), tokens )
    else Tuple( no, tokens );
 );
 
 let std-c-parse-initializer-list(tokens: List<Token>): Tuple<Maybe<List<CTerm>>,List<Token>> = (
-   let no = (None :: Maybe<List<CTerm>>)();
+   let no = (None : Maybe<List<CTerm>>)();
    let di = std-c-parse-designative-initializer(tokens); tokens = di.second;
    if di.first.is-some {
       let dis = [di.first.get-or-panic];
@@ -533,7 +533,7 @@ let std-c-parse-initializer-list(tokens: List<Token>): Tuple<Maybe<List<CTerm>>,
 );
 
 let std-c-parse-initializer(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "{") {
       tokens = std-c-take-expect(tokens, "{");
       let initializer-list = std-c-parse-initializer-list(tokens); tokens = initializer-list.second;
@@ -548,7 +548,7 @@ let std-c-parse-initializer(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>
 );
 
 let std-c-parse-atomic-type-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "_Atomic") && std-c-can-take(tail(tokens), "(") then {
       let op = head(tokens).skey; tokens = std-c-take-expect(tokens, "_Atomic");
       tokens = std-c-take-expect(tokens, "(");
@@ -561,7 +561,7 @@ let std-c-parse-atomic-type-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,L
 );
 
 let std-c-parse-struct-or-union-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "struct") || std-c-can-take(tokens, "union") {
       let op = head(tokens).skey; tokens = tail(tokens);
       let attr = std-c-parse-attribute(tokens); tokens = attr.second;
@@ -583,7 +583,7 @@ let std-c-parse-struct-or-union-specifier(tokens: List<Token>): Tuple<Maybe<CTer
 );
 
 let std-c-parse-struct-declaration-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let sq = std-c-parse-struct-declaration(tokens);
    if sq.first.is-some {
       let sql = [sq.first.get-or-panic];
@@ -612,7 +612,7 @@ let std-c-parse-struct-declaration(tokens: List<Token>): Tuple<Maybe<CTerm>,List
 );
 
 let std-c-parse-enumerator-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "enum") {
       let op = head(tokens).skey; tokens = std-c-take-expect(tokens, "enum");
       let id = if std-c-can-take(tokens, "identifier") {
@@ -625,8 +625,8 @@ let std-c-parse-enumerator-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,Li
          tokens = std-c-take-expect(tokens, "}");
          if el.first.is-some
          then el.first.get-or-panic
-         else CList(close([] :: List<CTerm>));
-      } else CList(close([] :: List<CTerm>));
+         else CList(close([] : List<CTerm>));
+      } else CList(close([] : List<CTerm>));
       Tuple( Some(CBinaryOp(op, close(CIdentifier(id)), close(es) )), tokens )
    } else Tuple( no, tokens )
 );
@@ -647,10 +647,10 @@ let std-c-parse-enumerator-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<To
    e
 );
 
-let std-c-enumeration-constant-index = {} :: HashtableEq<String,Bool>;
+let std-c-enumeration-constant-index = {} : HashtableEq<String,Bool>;
 
 let std-c-parse-enumerator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "identifier") {
       let ec = head(tokens).skey; tokens = std-c-take-expect(tokens, "identifier");
       std-c-enumeration-constant-index = std-c-enumeration-constant-index.bind(ec, true);
@@ -665,7 +665,7 @@ let std-c-parse-enumerator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>>
 );
 
 let std-c-parse-type-name(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let sql = std-c-parse-specifier-qualifier-list(tokens);
    if sql.first.is-some then {
       tokens = sql.second;
@@ -675,7 +675,7 @@ let std-c-parse-type-name(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> 
 );
 
 let std-c-parse-specifier-qualifier-list(tokens: List<Token>): Tuple<Maybe<List<CTerm>>,List<Token>> = (
-   let no = (None :: Maybe<List<CTerm>>)();
+   let no = (None : Maybe<List<CTerm>>)();
    let sq = std-c-parse-specifier-qualifier(tokens);
    if sq.first.is-some {
       let sql = [sq.first.get-or-panic];
@@ -697,13 +697,13 @@ let std-c-parse-specifier-qualifier(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
    sq
 );
 
-let std-c-typedef-name-index = {} :: HashtableEq<String,Bool>;
+let std-c-typedef-name-index = {} : HashtableEq<String,Bool>;
 
 # some C things are non-standard but still just hard-coded
 std-c-typedef-name-index = std-c-typedef-name-index.bind("__builtin_va_list", true);
 
 let std-c-parse-typedef-name(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if non-zero(tokens) && std-c-typedef-name-index.has(head(tokens).skey) {
       Tuple( Some(CType1(head(tokens).skey)), tail(tokens) )
    } else Tuple( no, tokens )
@@ -729,7 +729,7 @@ let std-c-parse-type-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Tok
 );
 
 let std-c-parse-pointer(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "*") then {
       tokens = std-c-take-expect(tokens, "*");
       let type-qualifier-list = std-c-parse-type-qualifier-list(tokens); tokens = type-qualifier-list.second;
@@ -739,7 +739,7 @@ let std-c-parse-pointer(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = 
 );
 
 let std-c-parse-abstract-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let p = std-c-parse-pointer(tokens); tokens = p.second;
    let dac = std-c-parse-direct-abstract-declarator(tokens); tokens = dac.second;
    if p.first.is-some && dac.first.is-some
@@ -763,7 +763,7 @@ let std-c-parse-direct-abstract-declarator(tokens: List<Token>): Tuple<Maybe<CTe
 #                           | direct-abstract-declarator, '[', assignment-expression, ']'
 #                           | direct-abstract-declarator, '(', parameter-type-list, ')'
 #                           | direct-abstract-declarator, '(', ')';
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let original-tokens = tokens;
    if std-c-can-take(tokens, "(") then {
       let op = head(tokens).skey; tokens = std-c-take-expect(tokens, "(");
@@ -792,7 +792,7 @@ let std-c-parse-direct-abstract-declarator(tokens: List<Token>): Tuple<Maybe<CTe
 );
 
 let std-c-parse-type-qualifier-list(tokens: List<Token>): Tuple<Maybe<List<CTerm>>,List<Token>> = (
-   let no = (None :: Maybe<List<CTerm>>)();
+   let no = (None : Maybe<List<CTerm>>)();
    let tq = std-c-parse-type-qualifier(tokens);
    if tq.first.is-some {
       tokens = tq.second;
@@ -806,7 +806,7 @@ let std-c-parse-type-qualifier-list(tokens: List<Token>): Tuple<Maybe<List<CTerm
 );
 
 let std-c-parse-parameter-type-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let ptl = std-c-parse-parameter-list(tokens);
    if ptl.first.is-some {
       tokens = ptl.second;
@@ -819,7 +819,7 @@ let std-c-parse-parameter-type-list(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
 );
 
 let std-c-parse-struct-declarator-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let sq = std-c-parse-struct-declarator(tokens);
    if sq.first.is-some {
       let sql = [sq.first.get-or-panic];
@@ -837,7 +837,7 @@ let std-c-parse-struct-declarator-list(tokens: List<Token>): Tuple<Maybe<CTerm>,
 );
 
 let std-c-parse-struct-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, ":") {
       let op = head(tokens).skey; tokens = std-c-take-expect(tokens, ":");
       let ce = std-c-parse-constant-expression(tokens);
@@ -860,7 +860,7 @@ let std-c-parse-struct-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
 );
 
 let std-c-parse-assignment-operator(tokens: List<Token>): Tuple<Maybe<String>,List<Token>> = (
-   let no = (None :: Maybe<String>)();
+   let no = (None : Maybe<String>)();
    if not(non-zero(tokens)) then Tuple( no, tokens )
    else if head(tokens).skey == "=" then Tuple( Some(head(tokens).skey), tail(tokens) )
    else if head(tokens).skey == "*=" then Tuple( Some(head(tokens).skey), tail(tokens) )
@@ -877,7 +877,7 @@ let std-c-parse-assignment-operator(tokens: List<Token>): Tuple<Maybe<String>,Li
 );
 
 let std-c-parse-struct-or-union(tokens: List<Token>): Tuple<Maybe<String>,List<Token>> = (
-   let no = (None :: Maybe<String>)();
+   let no = (None : Maybe<String>)();
    if not(non-zero(tokens)) then Tuple( no, tokens )
    else if head(tokens).skey == "struct" then Tuple( Some(head(tokens).skey), tail(tokens) )
    else if head(tokens).skey == "union" then Tuple( Some(head(tokens).skey), tail(tokens) )
@@ -885,13 +885,13 @@ let std-c-parse-struct-or-union(tokens: List<Token>): Tuple<Maybe<String>,List<T
 );
 
 let std-c-parse-identifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "identifier") then Tuple( Some(CIdentifier(head(tokens).skey)), tail(tokens) )
    else Tuple( no, tokens )
 );
 
 let std-c-parse-constant(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "integer") then Tuple( Some(CInteger(head(tokens).skey)), tail(tokens) )
    else if std-c-can-take(tokens, "character") then Tuple( Some(CCharacter(head(tokens).skey)), tail(tokens) )
    else if std-c-can-take(tokens, "floating") then Tuple( Some(CFloating(head(tokens).skey)), tail(tokens) )
@@ -900,14 +900,14 @@ let std-c-parse-constant(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> =
 );
 
 let std-c-parse-string(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "string") then Tuple( Some(CString(head(tokens).skey)), tail(tokens) )
    else if std-c-can-take(tokens, "__func__") then Tuple( Some(CString(head(tokens).skey)), tail(tokens) )
    else Tuple( no, tokens )
 );
 
 let std-c-parse-primary-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let original-tokens = tokens;
    let ts = std-c-parse-generic-selection(tokens);
    if ts.first.is-none then (ts = std-c-parse-constant(tokens));
@@ -925,7 +925,7 @@ let std-c-parse-primary-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List
 );
 
 let std-c-parse-parameter-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let ptl = std-c-parse-parameter-declaration(tokens);
    if ptl.first.is-some {
       let pts = [ptl.first.get-or-panic];
@@ -940,7 +940,7 @@ let std-c-parse-parameter-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Tok
 );
 
 let std-c-parse-parameter-declaration(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let ds = std-c-parse-declaration-specifiers(tokens);
    if ds.first.is-some {
       tokens = ds.second;
@@ -1226,7 +1226,7 @@ let std-c-parse-postfix-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List
 );
 
 let std-c-parse-argument-expression-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let sq = std-c-parse-assignment-expression(tokens);
    if sq.first.is-some {
       let sql = [sq.first.get-or-panic];
@@ -1244,7 +1244,7 @@ let std-c-parse-argument-expression-list(tokens: List<Token>): Tuple<Maybe<CTerm
 );
 
 let std-c-parse-generic-selection(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "_Generic") {
       let op = head(tokens).skey; tokens = std-c-take-expect(tokens, "_Generic");
       tokens = std-c-take-expect(tokens, "(");
@@ -1259,7 +1259,7 @@ let std-c-parse-generic-selection(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
 );
 
 let std-c-parse-generic-assoc-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    let ga = std-c-parse-generic-association(tokens);
    if ga.first.is-some then {
       tokens = ga.second;
@@ -1274,7 +1274,7 @@ let std-c-parse-generic-assoc-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List
 );
 
 let std-c-parse-generic-association(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "default") {
       tokens = std-c-take-expect(tokens, "default");
       tokens = std-c-take-expect(tokens, ":");
@@ -1293,7 +1293,7 @@ let std-c-parse-generic-association(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
 );
 
 let std-c-parse-designator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "[") {
       let op = head(tokens).skey; tokens = std-c-take-expect(tokens, "[");
       let ce = std-c-parse-constant-expression(tokens); tokens = ce.second;
@@ -1309,7 +1309,7 @@ let std-c-parse-designator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>>
 );
 
 let std-c-parse-designator-list(tokens: List<Token>): Tuple<Maybe<List<CTerm>>,List<Token>> = (
-   let no = (None :: Maybe<List<CTerm>>)();
+   let no = (None : Maybe<List<CTerm>>)();
    let des = std-c-parse-designator(tokens); tokens = des.second;
    if des.first.is-some {
       let dess = [des.first.get-or-panic];
@@ -1322,7 +1322,7 @@ let std-c-parse-designator-list(tokens: List<Token>): Tuple<Maybe<List<CTerm>>,L
 );
 
 let std-c-parse-designation(tokens: List<Token>): Tuple<Maybe<List<CTerm>>,List<Token>> = (
-   let no = (None :: Maybe<List<CTerm>>)();
+   let no = (None : Maybe<List<CTerm>>)();
    let dl = std-c-parse-designator-list(tokens); tokens = dl.second;
    if dl.first.is-some { tokens = std-c-take-expect(tokens, "="); };
    if dl.first.is-some then Tuple( Some(dl.first.get-or-panic), tokens )
@@ -1351,7 +1351,7 @@ let std-c-parse-expression-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,Li
 );
 
 let std-c-parse-labeled-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "identifier") && std-c-can-take(tail(tokens), ":") {
       let lname = head(tokens).skey; tokens = std-c-take-expect(tokens, "identifier");
       let op = "c::label"; tokens = std-c-take-expect(tokens, ":");
@@ -1381,7 +1381,7 @@ let std-c-parse-labeled-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
 );
 
 let std-c-parse-selection-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "if") {
       let op = "c::if"; tokens = tail(tokens);
       tokens = std-c-take-expect(tokens, "(");
@@ -1408,7 +1408,7 @@ let std-c-parse-selection-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
 );
 
 let std-c-parse-iteration-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "while") {
       let op = "c::while"; tokens = tail(tokens);
       tokens = std-c-take-expect(tokens, "(");
@@ -1451,7 +1451,7 @@ let std-c-parse-iteration-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
 );
 
 let std-c-parse-jump-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   let no = (None :: Maybe<CTerm>)();
+   let no = (None : Maybe<CTerm>)();
    if std-c-can-take(tokens, "goto") {
       let op = intern(c"c::goto"); tokens = tail(tokens);
       let id = head(tokens).skey; tokens = std-c-take-expect(tokens, "identifier");

--- a/PLUGINS/FRONTEND/C/c-smart-tokenize.lsts
+++ b/PLUGINS/FRONTEND/C/c-smart-tokenize.lsts
@@ -6,7 +6,7 @@ let std-c-tokenize-string(file-path: CString, text: CString): List<Token> = (
 let std-c-tokenize-string(file-path: String, text: String): List<Token> = (
    smart-token-path-index = smart-token-path-index.bind( text.data as U64, file-path );
 
-   let tokens = [] :: List<String>;
+   let tokens = [] : List<String>;
    while non-zero(text) {match text {
       "\s".. rest => text = rest;
       "\t".. rest => text = rest;
@@ -103,7 +103,7 @@ let std-c-tokenize-string(file-path: String, text: String): List<Token> = (
       rest => ( fail("Unrecognized Token in File \{file-path}: \{clone-rope(rest[0_u64])}"); );
    }; };
 
-   let internal-tokens = [] :: List<Token>;
+   let internal-tokens = [] : List<Token>;
    for t in tokens {
       internal-tokens = cons( mk-token(t), internal-tokens );
    };

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -562,7 +562,12 @@ let lsts-parse-ascript(tokens: List<Token>): Tuple<AST,List<Token>> = (
    while lsts-parse-head(tokens)==c":" && non-zero(tokens) && lsts-parse-head(tail(tokens)) != c":" {
       tokens = tail(tokens);
       (let tt, tokens) = lsts-parse-type(tokens);
-      term = term.ascript(tt);
+      match term {
+         App{ constructor=left:Lit{}, right:ASTNil{} } => (
+            term = mk-app(constructor.ascript(tt), mk-nil());
+         );
+         _ => term = term.ascript(tt);
+      }
    };
    Tuple ( term, tokens )
 );

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -557,6 +557,16 @@ let lsts-parse-cmp(tokens: List<Token>): Tuple<AST,List<Token>> = (
    Tuple ( term, tokens )
 );
 
+let lsts-parse-ascript(tokens: List<Token>): Tuple<AST,List<Token>> = (
+   (let term, tokens) = lsts-parse-andor(tokens);
+   while lsts-parse-head(tokens)==c":" && non-zero(tokens) && lsts-parse-head(tail(tokens)) != c":" {
+      tokens = tail(tokens);
+      (let tt, tokens) = lsts-parse-type(tokens);
+      term = term.ascript(tt);
+   };
+   Tuple ( term, tokens )
+);
+
 let lsts-parse-andor(tokens: List<Token>): Tuple<AST,List<Token>> = (
    let term-rest = lsts-parse-cmp(tokens);
    let term = term-rest.first;
@@ -1066,7 +1076,7 @@ let lsts-parse-small-expression(tokens: List<Token>): Tuple<AST,List<Token>> = (
       );
       [Token{key:c"if"}.. rest] => (
          let loc = head(tokens).location; tokens = rest;
-         let c-rest = lsts-parse-andor(tokens);
+         let c-rest = lsts-parse-ascript(tokens);
          let c = c-rest.first;
          tokens = c-rest.second;
          if lsts-parse-head(tokens) != c"{" {
@@ -1428,7 +1438,7 @@ let lsts-parse-match2-lhs(tokens: List<Token>): Tuple<AST,List<Token>> = (
    };
    if lsts-parse-head(tokens)==c"where" {
       lsts-parse-expect(c"where", tokens); tokens = tail(tokens);
-      (let cond, tokens) = lsts-parse-andor(tokens);
+      (let cond, tokens) = lsts-parse-ascript(tokens);
       lhs = mk-app( mk-var(c"macro::lhs-guard"), mk-cons(lhs,cond) );
    };
    (lhs, tokens)
@@ -1563,7 +1573,7 @@ let lsts-parse-assign(tokens: List<Token>): Tuple<AST,List<Token>> = (
          );
       };
    } else {
-      let base-rest = lsts-parse-andor(tokens);
+      let base-rest = lsts-parse-ascript(tokens);
       base = base-rest.first;
       tokens = base-rest.second;
    };
@@ -1944,7 +1954,7 @@ let lsts-parse-atom-tail(base: AST, tokens: List<Token>): Tuple<AST,List<Token>>
             let term1 = if lsts-parse-head(tokens)==c":" {
                Lit( c"0_i64", with-location(mk-token("0_i64"),loc) )
             } else {
-               let term1-rest = lsts-parse-small-expression(tokens);
+               let term1-rest = lsts-parse-andor(tokens);
                tokens = term1-rest.second;
                term1-rest.first;
             };
@@ -1954,7 +1964,7 @@ let lsts-parse-atom-tail(base: AST, tokens: List<Token>): Tuple<AST,List<Token>>
                term2 = if lsts-parse-head(tokens)==c"]" {
                   Var( c"minimum-I64", with-location(mk-token("minimum-I64"),loc) )
                } else {
-                  let term2-rest = lsts-parse-small-expression(tokens);
+                  let term2-rest = lsts-parse-andor(tokens);
                   tokens = term2-rest.second;
                   term2-rest.first;
                };

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -64,7 +64,7 @@ let lsts-parse-doc-wordf(tokens: List<Token>, begin: CString, end: CString): Tup
 );
 
 let lsts-parse-doc-expr(tokens: List<Token>): Tuple<AST, List<(CString, AST)>, List<Token>> = (
-   let tags = [] :: List<(CString, AST)>;
+   let tags = [] : List<(CString, AST)>;
    let val = match lsts-parse-head(tokens) {
       c"__" => (
          (let s, tokens) = lsts-parse-doc-wordf(tokens, c"__", c"__");
@@ -109,7 +109,7 @@ let lsts-parse-doc(tokens: List<Token>): Tuple<AST, List<Token>> = (
    let ast = mk-eof();
    let para = mk-eof();
 
-   let tags = [] :: List<(CString, AST)>;
+   let tags = [] : List<(CString, AST)>;
 
    while lsts-parse-head(tokens) == c"##" {
       tokens = tail(tokens);
@@ -153,17 +153,17 @@ let lsts-has-assign(tokens: List<Token>): U64 = (
       [Token{key:c"]"} .. rest] => (depth = depth - 1_i64; tokens = rest;);
       [Token{key:c"}"} .. rest] => (depth = depth - 1_i64; tokens = rest;);
       [Token{key:c")"} .. rest] => (depth = depth - 1_i64; tokens = rest;);
-      [Token{key:c";"} .. rest] => (if depth <= 0_i64 {tokens = [] :: List<Token>} else {tokens = rest;});
-      [Token{key:c","} .. rest] => (if depth <= 0_i64 {tokens = [] :: List<Token>} else {tokens = rest;});
-      [Token{key:c"."}.. Token{key:c"."} .. rest] => (if depth == 0_i64 {tokens = [] :: List<Token>;} else {tokens = rest;});
-      [Token{key:c"="}.. Token{key:c">"} .. rest] => (if depth == 0_i64 {tokens = [] :: List<Token>;} else {tokens = rest;});
-      [Token{key:c"="} .. rest] => (if depth == 0_i64 {has-assign = 1; tokens = [] :: List<Token>;} else {tokens = rest;});
-      [Token{key:c"if"} .. rest] => (if depth == 0_i64 {tokens = [] :: List<Token>;} else {tokens = rest;});
-      [Token{key:c"then"} .. rest] => (if depth == 0_i64 {tokens = [] :: List<Token>;} else {tokens = rest;});
-      [Token{key:c"else"} .. rest] => (if depth == 0_i64 {tokens = [] :: List<Token>;} else {tokens = rest;});
-      [Token{key:c"fn"} .. rest] => (if depth == 0_i64 {tokens = [] :: List<Token>;} else {tokens = rest;});
+      [Token{key:c";"} .. rest] => (if depth <= 0_i64 {tokens = [] : List<Token>} else {tokens = rest;});
+      [Token{key:c","} .. rest] => (if depth <= 0_i64 {tokens = [] : List<Token>} else {tokens = rest;});
+      [Token{key:c"."}.. Token{key:c"."} .. rest] => (if depth == 0_i64 {tokens = [] : List<Token>;} else {tokens = rest;});
+      [Token{key:c"="}.. Token{key:c">"} .. rest] => (if depth == 0_i64 {tokens = [] : List<Token>;} else {tokens = rest;});
+      [Token{key:c"="} .. rest] => (if depth == 0_i64 {has-assign = 1; tokens = [] : List<Token>;} else {tokens = rest;});
+      [Token{key:c"if"} .. rest] => (if depth == 0_i64 {tokens = [] : List<Token>;} else {tokens = rest;});
+      [Token{key:c"then"} .. rest] => (if depth == 0_i64 {tokens = [] : List<Token>;} else {tokens = rest;});
+      [Token{key:c"else"} .. rest] => (if depth == 0_i64 {tokens = [] : List<Token>;} else {tokens = rest;});
+      [Token{key:c"fn"} .. rest] => (if depth == 0_i64 {tokens = [] : List<Token>;} else {tokens = rest;});
       [_ .. rest] => tokens = rest;
-   }; if depth < 0_i64 { tokens = [] :: List<Token>; }; };
+   }; if depth < 0_i64 { tokens = [] : List<Token>; }; };
    has-assign
 );
 
@@ -320,7 +320,7 @@ let lsts-parse-type-conjugate(tokens: List<Token>): Tuple<Type,List<Token>> = (
          base = base + c"::" + lsts-substitute-type-aliases(lsts-parse-head(tokens));
          tokens = tail(tokens);
       };
-      let args = [] :: List<Type>;
+      let args = [] : List<Type>;
       if lsts-parse-head(tokens) == c"<" {
          lsts-parse-expect(c"<", tokens); tokens = tail(tokens);
          let targs-rest = lsts-parse-type(tokens);
@@ -612,7 +612,7 @@ let lsts-parse-map(tokens: List<Token>): Tuple<AST,List<Token>> = (
    } else {
       if lsts-parse-head(tokens) != c"}" {
          while non-zero(tokens) && lsts-parse-head(tokens)!=c"}" {
-            let item-rest = lsts-parse-expression(tokens);
+            let item-rest = lsts-parse-andor(tokens);
             let item = item-rest.first;
             tokens = item-rest.second;
             let mapped = if non-zero(tokens) && lsts-parse-head(tokens)==c":" {
@@ -661,7 +661,7 @@ let lsts-parse-list(tokens: List<Token>): Tuple<AST,List<Token>> = (
       fail("TODO List Comprehension at \{loc}")
    } else {
       if lsts-parse-head(tokens)!=c"]" {
-         let add-items = [] :: List<AST>;
+         let add-items = [] : List<AST>;
          while non-zero(tokens) && lsts-parse-head(tokens)!=c"]" {
             let item-rest = lsts-parse-expression(tokens);
             tokens = item-rest.second;
@@ -714,7 +714,7 @@ let lsts-parse-interface(tokens: List<Token>): List<Token> = (
       let args-list = sig.first.args-list;
       let return-type = sig.first.return-type;
 
-      let shapes = interface-shape-index.lookup(interface-type.ground-tag-and-arity,[] :: List<(CString,Type,Type)>);
+      let shapes = interface-shape-index.lookup(interface-type.ground-tag-and-arity,[] : List<(CString,Type,Type)>);
       shapes = cons( (name, args-type, return-type), shapes );
       interface-shape-index = interface-shape-index.bind(interface-type.ground-tag-and-arity, shapes);
 
@@ -754,7 +754,7 @@ let lsts-parse-typedef2(tokens: List<Token>): (AST, List<Token>) = (
    let typename = lsts-parse-head(tokens); tokens = tail(tokens);
    if typename.has-suffix(c"_ss") then typename = typename.remove-suffix(c"_ss");
    let lhs-type = if lsts-parse-head(tokens)==c"<" {
-      let pars = [] :: List<Type>;
+      let pars = [] : List<Type>;
       lsts-parse-expect(c"<", tokens); tokens = tail(tokens);
       let pt = ta;
       if lsts-is-enum-head(lsts-parse-head(tokens)) || lsts-parse-head(tokens).has-suffix(c"_ss") {
@@ -1258,7 +1258,7 @@ let lsts-parse-match2-lhs-one(tokens: List<Token>): Tuple<AST,List<Token>> = (
       let loc = head(tokens).location;
       lsts-parse-expect(c"[", tokens); tokens = tail(tokens);
       expr = mk-app(mk-var(c"macro::lhs-tail").with-location(loc), mk-nil());
-      let seq = [] :: List<AST>;
+      let seq = [] : List<AST>;
       while non-zero(tokens) && lsts-parse-head(tokens)!=c"]" {
          (let head, tokens) = lsts-parse-match2-lhs-one-bind(tokens);
          if lsts-parse-head(tokens)==c"." && lsts-parse-head(tail(tokens))==c"." {
@@ -1460,7 +1460,7 @@ let lsts-parse-match2(tokens: List<Token>): Tuple<AST,List<Token>> = (
       mk-app(mk-var(c"macro::location"),mk-var(c"here").with-location(loc))
    ));
    lsts-parse-expect(c"{", tokens); tokens = tail(tokens);
-   let cases = [] :: List<(AST,AST)>;
+   let cases = [] : List<(AST,AST)>;
    while non-zero(tokens) && lsts-parse-head(tokens)!=c"}" {
       (let lhs, tokens) = lsts-parse-match2-lhs(tokens);
       lsts-parse-expect(c"=", tokens); tokens = tail(tokens);
@@ -1491,7 +1491,7 @@ let lsts-parse-assign(tokens: List<Token>): Tuple<AST,List<Token>> = (
       if lsts-parse-head(tokens) == c"(" {
          lsts-parse-expect(c"(", tokens); tokens = tail(tokens);
 
-         let lefts = [] :: List<ASTOrIdent>;
+         let lefts = [] : List<ASTOrIdent>;
 
          let loop = true;
          while loop {
@@ -1899,29 +1899,9 @@ let lsts-parse-atom-tail(base: AST, tokens: List<Token>): Tuple<AST,List<Token>>
    while lsts-parse-head(tokens) == c"[" ||
          lsts-parse-head(tokens) == c"(" ||
          lsts-parse-head(tokens) == c"." ||
-         lsts-parse-head(tokens) == c"as" ||
-         (lsts-parse-head(tokens) == c":" && non-zero(tokens) && lsts-parse-head(tail(tokens)) == c":") {
+         lsts-parse-head(tokens) == c"as" {
       let loc = head(tokens).location;
       match tokens {
-         [Token{key:c":"}.. Token{key:c":"}.. rest] => (
-            tokens = rest;
-            let type-rest = lsts-parse-type(tokens);
-            tokens = type-rest.second;
-            match base {
-               App{ constructor=left:Lit{}, right:ASTNil{} } => (
-                  base = mk-app(mk-app(
-                     Lit( c":", with-location(mk-token(":"),loc) ),
-                     mk-cons(constructor, mk-atype(type-rest.first))
-                  ), mk-nil());
-               );
-               _ => (
-                  base = mk-app(
-                     Lit( c":", with-location(mk-token(":"),loc) ),
-                     mk-cons(base, mk-atype(type-rest.first))
-                  );
-               );
-            };
-         );
          [Token{key:"."}.. rest] => (
             tokens = rest;
             lsts-parse-expect( c"[Identifier]", lsts-is-ident-head(lsts-parse-head(tokens)), tokens );

--- a/PLUGINS/FRONTEND/LSTS/lsts-smart-tokenize.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-smart-tokenize.lsts
@@ -7,7 +7,7 @@ let lsts-tokenize-string(file-path: String, text: String): List<Token> = (
    smart-token-path-index = smart-token-path-index.bind( text.data as U64, file-path );
 
    let push-newline = 0;
-   let tokens = [] :: List<String>;
+   let tokens = [] : List<String>;
    while non-zero(text) {match text {
       "\s".. rest => text = rest;
       "\t".. rest => text = rest;
@@ -99,7 +99,7 @@ let lsts-tokenize-string(file-path: String, text: String): List<Token> = (
       rest => ( fail("Unrecognized Token in File \{file-path}: \{clone-rope(rest[0_u64])}"); );
    }; };
 
-   let internal-tokens = [] :: List<Token>;
+   let internal-tokens = [] : List<Token>;
    for t in tokens {
       internal-tokens = cons( mk-lsts-token(t), internal-tokens );
    };

--- a/SRC/actx-bind.lsts
+++ b/SRC/actx-bind.lsts
@@ -1,4 +1,4 @@
 
 let .bind(ctx: Maybe<AContext>, key: CString, val: AST): Maybe<AContext> = (
-   Some( cons( Tuple(key,val), ctx.get-or([] :: AContext) ) )
+   Some( cons( Tuple(key,val), ctx.get-or([] : AContext) ) )
 );

--- a/SRC/assert-no-infinite-types.lsts
+++ b/SRC/assert-no-infinite-types.lsts
@@ -1,6 +1,6 @@
 
 let assert-no-infinite-types(): Nil = (
-   let fields-of-type = {} :: HashtableEq<(CString,U64),Vector<(Type,Type)>>;
+   let fields-of-type = {} : HashtableEq<(CString,U64),Vector<(Type,Type)>>;
    for vector td in ast-parsed-program.unroll-seq { match td {
       Typedef2{} => (
          let lhs-type = (td as Tag::Typedef2).lhs-type;

--- a/SRC/ctx-union.lsts
+++ b/SRC/ctx-union.lsts
@@ -1,7 +1,7 @@
 
 let union(ctx: FContext, tctx: Maybe<TypeContext>): FContext = (
    let r = ctx;
-   for Tuple{ k=first, vt=second } in tctx.get-or([] :: TypeContext) {
+   for Tuple{ k=first, vt=second } in tctx.get-or([] : TypeContext) {
       r = r.bind( k, ta, mk-fragment() );
    };
    r

--- a/SRC/decorate-var-to-def.lsts
+++ b/SRC/decorate-var-to-def.lsts
@@ -1,5 +1,5 @@
 
-let decorate-var-to-def-todo = mk-vector(type((Maybe<TypeContext>,CString,Type,AST))) :: Vector<(Maybe<TypeContext>,CString,Type,AST)>;
+let decorate-var-to-def-todo = mk-vector(type((Maybe<TypeContext>,CString,Type,AST))) : Vector<(Maybe<TypeContext>,CString,Type,AST)>;
 
 let mark-var-to-def-todo(tctx: Maybe<TypeContext>, k: CString, tt: Type, t: AST): Nil = (
    decorate-var-to-def-todo = decorate-var-to-def-todo.push( (tctx, k, tt, t) );

--- a/SRC/extract-uuids.lsts
+++ b/SRC/extract-uuids.lsts
@@ -7,13 +7,13 @@ let extract-uuids(term: AST): AContext = (
       );
       App{left=left, right=right} => extract-uuids(left) + extract-uuids(right);
       Seq{seq=seq} => (
-         let ret = [] :: AContext;
+         let ret = [] : AContext;
          for vector s in seq { ret = ret + extract-uuids(s) };
          ret
       );
       Abs{lhs=lhs, rhs=rhs} => extract-uuids(lhs) + extract-uuids(rhs);
       Glb{val=val} => extract-uuids(val);
-      _ => [] :: AContext;
+      _ => [] : AContext;
    }
 );
 

--- a/SRC/find-global-callable.lsts
+++ b/SRC/find-global-callable.lsts
@@ -2,7 +2,7 @@
 let find-global-callable(fname: CString, arg-types: Type, blame: AST): AST = (
    arg-types = denormalize-strong(arg-types);
    let match-set = mk-vector(type((Type,AST)), 16);
-   for Tuple{kt=second, t=third} in global-type-context.lookup(fname, [] :: List<Tuple<Type,Type,AST>>) {
+   for Tuple{kt=second, t=third} in global-type-context.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
       if can-apply(kt, arg-types) {
          match-set = match-set.push( (kt, t) );
       }
@@ -30,14 +30,14 @@ let find-global-callable(fname: CString, arg-types: Type, blame: AST): AST = (
 let find-global-constructor(fname: CString, hint: Type, arg-types: Type, blame: AST): AST = (
    hint = hint.rewrite-type-alias;
    let result = ASTEOF();
-   for Tuple{ot=first, kt=second, t=third} in global-type-context.lookup(fname, [] :: List<Tuple<Type,Type,AST>>) {
+   for Tuple{ot=first, kt=second, t=third} in global-type-context.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
       if not(ot.is-open) && (not(non-zero(hint)) || can-receive(ot, hint)) && can-apply(ot, arg-types) {
          if non-zero(result) then fail("Duplicate global constructor: \{fname} :: \{hint} (\{arg-types})At: \{blame.location}\n1: \{result}\n2: \{t}\n");
          result = t;
       }
    };
    if not(non-zero(result)) then {
-      for Tuple{ot=first, kt=second, t=third} in global-type-context.lookup(fname, [] :: List<Tuple<Type,Type,AST>>) {
+      for Tuple{ot=first, kt=second, t=third} in global-type-context.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
          print("Candidate \{fname} : \{kt}\n");
       };
       fail("Unable to find appropriate global constructor: \{fname} :: \{hint} (\{arg-types})At: \{blame.location}\n");
@@ -50,7 +50,7 @@ let apply-global-constructor(fname: CString, hint: Type, arg-types: Type, blame:
    let result = ta;
    let simple = ta;
    if non-zero(hint) && hint.is-type {
-      for Tuple{ot=first, kt=second, t=third} in global-type-context.lookup(fname, [] :: List<Tuple<Type,Type,AST>>) {
+      for Tuple{ot=first, kt=second, t=third} in global-type-context.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
          if (not(non-zero(hint)) || can-receive(ot, hint)) && (not(non-zero(arg-types)) || can-apply(ot, arg-types)) {
             let next = if non-zero(hint)
             then substitute(unify(ot.range,hint),kt)
@@ -60,7 +60,7 @@ let apply-global-constructor(fname: CString, hint: Type, arg-types: Type, blame:
          }
       };
    } else {
-      for Tuple{ot=first, kt=second, t=third} in global-type-context.lookup(fname, [] :: List<Tuple<Type,Type,AST>>) {
+      for Tuple{ot=first, kt=second, t=third} in global-type-context.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
          if not(non-zero(arg-types)) || can-apply(ot, arg-types) {
             let next = if non-zero(hint)
             then hint
@@ -89,7 +89,7 @@ let maybe-apply-global-callable(fname: CString, arg-types: Type, blame: AST): Ty
 let apply-global-callable(fname: CString, arg-types: Type, blame: AST, can-fail: Bool): Type = (
    arg-types = denormalize-strong(arg-types);
    let match-set = mk-vector(type((Type,Type,AST)), 16);
-   for Tuple{ot=first, kt=second, t=third} in global-type-context.lookup(fname, [] :: List<Tuple<Type,Type,AST>>) {
+   for Tuple{ot=first, kt=second, t=third} in global-type-context.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
       if can-apply(kt, arg-types) {
          match-set = match-set.push( (ot, kt, t) );
       }

--- a/SRC/global-type-context.lsts
+++ b/SRC/global-type-context.lsts
@@ -1,2 +1,2 @@
 
-let global-type-context = {} :: HashtableEq<CString,List<Tuple<Type,Type,AST>>>;
+let global-type-context = {} : HashtableEq<CString,List<Tuple<Type,Type,AST>>>;

--- a/SRC/infer-global-terms.lsts
+++ b/SRC/infer-global-terms.lsts
@@ -10,7 +10,7 @@ let infer-global-terms(term: AST): AST = (
       );
       Glb{val:Abs{}} => ();
       Glb{k=key, rhs=val} => (
-         (_, let new-rhs) = std-infer-expr((None :: TypeContext?)(), rhs, false, Used(), ta);
+         (_, let new-rhs) = std-infer-expr((None : TypeContext?)(), rhs, false, Used(), ta);
          if not(is(rhs,new-rhs)) then {
             let new-term = mk-glb(k, new-rhs);
             mark-var-to-def(new-term, term);

--- a/SRC/infer-type-definition.lsts
+++ b/SRC/infer-type-definition.lsts
@@ -3,7 +3,7 @@ let type-ast-inserts = mk-vector(type(AST));
 
 let visit-field-template(field-name: CString, base-type: Type, field-type: Type, blame: AST, field-ordinal: U64, case-number: U64): Nil = (
    let mangled-field-name = to-string(case-number) + c"_" + field-name;
-   let ctx = (None :: Maybe<TypeContext>)();
+   let ctx = (None : Maybe<TypeContext>)();
    ctx = ctx.bind( c"base-type", base-type, mk-eof() );
    ctx = ctx.bind( c"field-type", field-type, mk-eof() );
    ctx = ctx.bind( c"field-name", ta, mk-lit(mangled-field-name) );
@@ -16,7 +16,7 @@ let visit-field-template(field-name: CString, base-type: Type, field-type: Type,
    let field-get-indirect = substitute(ctx, find-global-callable(c"primitive::field-get-indirect", t3(c"Array",base-type,ta), blame));
    let field-set-indirect = substitute(ctx, find-global-callable(c"primitive::field-set-indirect", t3(c"Cons", t3(c"Array",base-type,ta), field-type), blame));
 
-   ctx = (None :: Maybe<TypeContext>)();
+   ctx = (None : Maybe<TypeContext>)();
    ctx = ctx.bind( c"base-type", base-type, mk-eof() );
    ctx = ctx.bind( c"field-type", field-type, mk-eof() );
    ctx = ctx.bind( c"field-name", ta, mk-lit(mangled-field-name) );
@@ -31,7 +31,7 @@ let visit-field-template(field-name: CString, base-type: Type, field-type: Type,
    ()
 );
 
-let type-base-type-index = {} :: HashtableEq<(CString,U64),U64>;
+let type-base-type-index = {} : HashtableEq<(CString,U64),U64>;
 
 let .is-type(tt: Type): U64 = (
    let gta = normalize(tt).ground-tag-and-arity;
@@ -72,7 +72,7 @@ let infer-type-definition(term: AST): Nil = (
       };
       if case-tag!=c"" then case-number = case-number + 1;
    };
-   let common-fields = [] :: List<(CString,Type)>;
+   let common-fields = [] : List<(CString,Type)>;
    let has-tag-case = false;
    let has-any-case = false;
    for vector Tuple{ case-tag=first, case-fields=second } in cases {
@@ -110,7 +110,7 @@ let infer-type-definition(term: AST): Nil = (
    };
 );
 
-let type-constructor-tag-ordinal-index = {} :: HashtableEq<(CString,U64,CString),U64>;
+let type-constructor-tag-ordinal-index = {} : HashtableEq<(CString,U64,CString),U64>;
 
 let infer-type-yield-constructor(base-type: Type, case-tag: CString, case-number: U64, case-fields: List<(CString,Type)>, blame: AST, has-tag-case: U64): Nil = (
    (let base-tag, let base-arity) = base-type.ground-tag-and-arity;

--- a/SRC/interface-index.lsts
+++ b/SRC/interface-index.lsts
@@ -1,20 +1,20 @@
 
-let interface-index = {} :: HashtableEq<(CString,U64),U64>;
+let interface-index = {} : HashtableEq<(CString,U64),U64>;
 
 # TODO: remove this lookup
 # ((CString,U64),U64) needed to be reified, but the compiler should infer that
 interface-index.lookup((c"",0_u64),0_u64);
 
-let interface-shape-index = {} :: HashtableEq<(CString,U64),List<(CString,Type,Type)>>;
+let interface-shape-index = {} : HashtableEq<(CString,U64),List<(CString,Type,Type)>>;
 
 # TODO: remove this lookup
 # ((CString,Type),Type) needed to be reified, but the compiler should infer that
-interface-shape-index.lookup((c"",0_u64),[] :: List<(CString,Type,Type)>);
+interface-shape-index.lookup((c"",0_u64),[] : List<(CString,Type,Type)>);
 
-let interface-self-index = {} :: HashtableEq<(CString,U64),(Type,Type)>;
+let interface-self-index = {} : HashtableEq<(CString,U64),(Type,Type)>;
 
 # TODO: remove this lookup
 # (Type,Type) needed to be reified, but the compiler should infer that
 interface-self-index.lookup((c"",0_u64),(ta, ta));
 
-let interface-implementors = [] :: List<(Type,Type,AST)>;
+let interface-implementors = [] : List<(Type,Type,AST)>;

--- a/SRC/is-lone-tag.lsts
+++ b/SRC/is-lone-tag.lsts
@@ -1,5 +1,5 @@
 
-let lone-index = {} :: HashtableEq<CString,U64>;
+let lone-index = {} : HashtableEq<CString,U64>;
 
 let index-lone-tag(tag: CString): Nil = lone-index = lone-index.bind(tag,true);
 let is-lone-tag(tag: CString): U64 = lone-index.lookup(tag,false);

--- a/SRC/macro-table.lsts
+++ b/SRC/macro-table.lsts
@@ -1,21 +1,21 @@
 
-let index-macro-table = {} :: HashtableEq<CString,List<(Type,Type,AST)>>;
-index-macro-table = index-macro-table.bind(c"macro::concat", [] :: List<(Type,Type,AST)>);
-index-macro-table = index-macro-table.bind(c"macro::location", [] :: List<(Type,Type,AST)>);
-index-macro-table = index-macro-table.bind(c"macro::variable", [] :: List<(Type,Type,AST)>);
-index-macro-table = index-macro-table.bind(c"macro::underscore", [] :: List<(Type,Type,AST)>);
-index-macro-table = index-macro-table.bind(c"macro::constant", [] :: List<(Type,Type,AST)>);
-index-macro-table = index-macro-table.bind(c"macro::tag", [] :: List<(Type,Type,AST)>);
+let index-macro-table = {} : HashtableEq<CString,List<(Type,Type,AST)>>;
+index-macro-table = index-macro-table.bind(c"macro::concat", [] : List<(Type,Type,AST)>);
+index-macro-table = index-macro-table.bind(c"macro::location", [] : List<(Type,Type,AST)>);
+index-macro-table = index-macro-table.bind(c"macro::variable", [] : List<(Type,Type,AST)>);
+index-macro-table = index-macro-table.bind(c"macro::underscore", [] : List<(Type,Type,AST)>);
+index-macro-table = index-macro-table.bind(c"macro::constant", [] : List<(Type,Type,AST)>);
+index-macro-table = index-macro-table.bind(c"macro::tag", [] : List<(Type,Type,AST)>);
 
 # Meta variables can be used to match syntax patterns
-let index-macro-meta = {} :: HashtableEq<CString,List<(Type,Type,AST)>>;
-index-macro-meta = index-macro-meta.bind(c"macro::variable", [] :: List<(Type,Type,AST)>);
-index-macro-meta = index-macro-meta.bind(c"macro::underscore", [] :: List<(Type,Type,AST)>);
-index-macro-meta = index-macro-meta.bind(c"macro::constant", [] :: List<(Type,Type,AST)>);
-index-macro-meta = index-macro-meta.bind(c"macro::tag", [] :: List<(Type,Type,AST)>);
+let index-macro-meta = {} : HashtableEq<CString,List<(Type,Type,AST)>>;
+index-macro-meta = index-macro-meta.bind(c"macro::variable", [] : List<(Type,Type,AST)>);
+index-macro-meta = index-macro-meta.bind(c"macro::underscore", [] : List<(Type,Type,AST)>);
+index-macro-meta = index-macro-meta.bind(c"macro::constant", [] : List<(Type,Type,AST)>);
+index-macro-meta = index-macro-meta.bind(c"macro::tag", [] : List<(Type,Type,AST)>);
 
 let bind-new-macro(mname: CString, mterm: AST): Nil = (
-   let row = index-macro-table.lookup(mname, [] :: List<(Type,Type,AST)>);
+   let row = index-macro-table.lookup(mname, [] : List<(Type,Type,AST)>);
    let mtype = param-types-of-macro(mterm);
    row = cons( (denormalize(mtype), macro-type-peep-holes(mtype), mterm), row);
    index-macro-table = index-macro-table.bind(mname, row);

--- a/SRC/main.lsts
+++ b/SRC/main.lsts
@@ -1,7 +1,7 @@
 
 let main(argc: C_int, argv: CString[]): Nil = (
    let argi = 1_u64;
-   let input = [] :: List<CString>;
+   let input = [] : List<CString>;
    while argi < (argc as U64) {
       match argv[argi] {
          c"--typecheck" => config-mode = ModeTypecheck();

--- a/SRC/mk-fragment.lsts
+++ b/SRC/mk-fragment.lsts
@@ -1,8 +1,8 @@
 
 let mk-fragment(): Fragment = (
    Fragment (
-      mk-eof(), close([] :: List<Tuple<CString,S>>),
-      ta, close(mk-fctx()), ([] :: List<Fragment[]>)
+      mk-eof(), close([] : List<Tuple<CString,S>>),
+      ta, close(mk-fctx()), ([] : List<Fragment[]>)
    )
 );
 

--- a/SRC/plugins-backends.lsts
+++ b/SRC/plugins-backends.lsts
@@ -1,5 +1,5 @@
 
-let plugins-backends-index = {} :: HashtableEq<CString,(Nil -> Nil)[]>;
+let plugins-backends-index = {} : HashtableEq<CString,(Nil -> Nil)[]>;
 
 let plugin-null-backend(): Nil = (
    print("Cannot Compile: No Backend Was Specified\n");

--- a/SRC/plugins-frontends.lsts
+++ b/SRC/plugins-frontends.lsts
@@ -1,5 +1,5 @@
 
-let plugins-frontends-index = {} :: HashtableEq<CString,CString -> Nil>;
+let plugins-frontends-index = {} : HashtableEq<CString,CString -> Nil>;
 
 let plugin-null-frontend(fp: CString): Nil = (
    print("Unable to find a suitable frontend: \{fp}\n");

--- a/SRC/quick-prop.lsts
+++ b/SRC/quick-prop.lsts
@@ -1,9 +1,9 @@
 
-let quick-prop = {} :: HashtableEq<(CString,U64),List<(Type,Type)>>;
+let quick-prop = {} : HashtableEq<(CString,U64),List<(Type,Type)>>;
 
 let add-quick-prop(pre: Type, pat: Type, post: Type): Nil = (
    let key = pre.ground-tag-and-arity;
-   let val = quick-prop.lookup(key, ([] :: List<(Type,Type)>));
+   let val = quick-prop.lookup(key, ([] : List<(Type,Type)>));
    val = cons( (pat,post), val );
    quick-prop = quick-prop.bind( key, val );
 );
@@ -19,7 +19,7 @@ let enrich-quick-prop(base: Type, pre: Type): Type = (
    let original-pre = pre;
    match pre {
       TGround {} => (
-         for Tuple { lt=first, rt=second } in quick-prop.lookup( pre.ground-tag-and-arity, ([] :: List<(Type,Type)>) ) {
+         for Tuple { lt=first, rt=second } in quick-prop.lookup( pre.ground-tag-and-arity, ([] : List<(Type,Type)>) ) {
             if can-unify(lt, base) then (
                let tctx = unify(lt, base);
                let post = substitute(tctx, rt);
@@ -47,7 +47,7 @@ let enrich-quick-prop(base: Type, pre: Type): Type = (
    pre
 );
 
-let weaken-quick-prop-index = {} :: HashtableEq<(CString,U64),List<(Type,Type)>>;
+let weaken-quick-prop-index = {} : HashtableEq<(CString,U64),List<(Type,Type)>>;
 
 # core implicit weakening rules
 add-weaken-quick-prop( t2(c"Phi",ta), t2(c"Phi",ta), t2(c"Phi",ta) );
@@ -56,7 +56,7 @@ add-weaken-quick-prop( t2(c"CaseNumber",ta), t2(c"CaseNumber",ta), t2(c"CaseNumb
 
 let add-weaken-quick-prop(pre: Type, pat: Type, post: Type): Nil = (
    let key = pre.ground-tag-and-arity;
-   let val = weaken-quick-prop-index.lookup(key, ([] :: List<(Type,Type)>));
+   let val = weaken-quick-prop-index.lookup(key, ([] : List<(Type,Type)>));
    val = cons( (pat,post), val );
    weaken-quick-prop-index = weaken-quick-prop-index.bind( key, val );
 );
@@ -69,7 +69,7 @@ let weaken-quick-prop(base: Type): Type = (
 let weaken-quick-prop(original-base: Type, base: Type, pre: Type): Type = (
    match pre {
       TGround {} => (
-         for Tuple { lt=first, rt=second } in weaken-quick-prop-index.lookup( pre.ground-tag-and-arity, ([] :: List<(Type,Type)>) ) {
+         for Tuple { lt=first, rt=second } in weaken-quick-prop-index.lookup( pre.ground-tag-and-arity, ([] : List<(Type,Type)>) ) {
             if can-unify(lt, original-base) then (
                base = remove-info(base, rt);
             );

--- a/SRC/reduce-plural.lsts
+++ b/SRC/reduce-plural.lsts
@@ -1,8 +1,8 @@
 
 let reduce-plural(dpts: List<Type>): List<Type> = (
-   let pts = [] :: List<Tuple<Type,Type>>;
+   let pts = [] : List<Tuple<Type,Type>>;
    for pt in dpts { pts = cons(Tuple(denormalize-arrow(pt),pt),pts); };
-   let return = [] :: List<Type>;
+   let return = [] : List<Type>;
    for Tuple{try-denormal=first, try=second} in pts {
       for Tuple{tst-denormal=first, tst=second} in pts {
          if not(is(try-denormal,tst-denormal)) && can-unify(try-denormal.domain, tst-denormal.domain) {

--- a/SRC/smart-token-location.lsts
+++ b/SRC/smart-token-location.lsts
@@ -1,5 +1,5 @@
 
-let smart-token-path-index = {} :: HashtableEq<U64,String>;
+let smart-token-path-index = {} : HashtableEq<U64,String>;
 
 let .location(t: String): SourceLocation = (
    let file-path = smart-token-path-index.lookup( t.data as U64, "[Unknown File]" );

--- a/SRC/std-apply-macro-candidates.lsts
+++ b/SRC/std-apply-macro-candidates.lsts
@@ -18,7 +18,7 @@ let std-apply-macro-candidates(tctx: TypeContext?, mname: CString, margs: AST, c
 );
 
 let std-try-destructure-macro(tctx: TypeContext?, margs: AST, mtype: Type, mcandidate: AST): (TypeContext?, AContext?) = (
-   let no = (None :: AContext?)();
+   let no = (None : AContext?)();
    if let Abs{lhs=lhs, rhs=rhs} = mcandidate then std-try-destructure-macro(tctx, margs, mtype, lhs)
    else {
       match mtype {

--- a/SRC/std-apply-macro.lsts
+++ b/SRC/std-apply-macro.lsts
@@ -65,7 +65,7 @@ let std-apply-macro(tctx: Maybe<TypeContext>, mname: CString, margs: AST, used: 
    else if mname==c"macro::constant" then (tctx, result) = std-apply-macro-constant(tctx, mname, margs)
    else if mname==c"macro::tag" then (tctx, result) = std-apply-macro-tag(tctx, mname, margs)
    else {
-      let row = index-macro-table.lookup(mname, [] :: List<(Type,Type,AST)>);
+      let row = index-macro-table.lookup(mname, [] : List<(Type,Type,AST)>);
       let peep-holes = ta;
       let peeped = ta;
       for Tuple{mtype=first, peep=second, mterm=third} in row {
@@ -78,13 +78,13 @@ let std-apply-macro(tctx: Maybe<TypeContext>, mname: CString, margs: AST, used: 
       };
       (let peeped-type, margs) = std-infer-peeped-arguments(tctx, margs, peep-holes);
 
-      let matched = [] :: List<(Type,AST)>;
+      let matched = [] : List<(Type,AST)>;
       for Tuple{mtype=first, mterm=third} in row {
          if can-unify(mtype, peeped-type) then matched = cons( (mtype,mterm), matched );
       }; 
 
       let dominant-type = ta;
-      let candidates = [] :: List<(Type,AST)>;
+      let candidates = [] : List<(Type,AST)>;
       for Tuple{mtype=first, mterm=second} in matched {
          if non-zero(dominant-type) {
             if can-unify(mtype,dominant-type) && can-unify(dominant-type,mtype) {

--- a/SRC/std-destructure-macro.lsts
+++ b/SRC/std-destructure-macro.lsts
@@ -1,6 +1,6 @@
 
 let std-destructure-macro(lhs: AST, rhs: AST): AContext? = (
-   let no = (None :: AContext?)();
+   let no = (None : AContext?)();
    match (lhs, rhs) {
       _ => fail("Unexpected std-destructure-macro\nLeft: \{lhs}\nRight: \{rhs}\n");
    };

--- a/SRC/std-direct-destructure-macro.lsts
+++ b/SRC/std-direct-destructure-macro.lsts
@@ -1,6 +1,6 @@
 
 let std-direct-destructure-macro(margs: AST, mstruct: AST): AContext? = (
-   let no = (None :: AContext?)();
+   let no = (None : AContext?)();
    match (margs, mstruct) {
       Tuple{ val=first, second:Var{key=key} } => Some([(key,val)]);
       Tuple{ first:App{lrest=left, val=right}, second:App{rrest=left, right:Var{key=key}} } => (

--- a/SRC/t.lsts
+++ b/SRC/t.lsts
@@ -1,6 +1,6 @@
 
 let ts(tag: CString, ps: List<Type>): Type = TGround( tag, close(ps) );
-let t1(tag: CString): Type = TGround( tag, close([] :: List<Type>) );
+let t1(tag: CString): Type = TGround( tag, close([] : List<Type>) );
 let t2(tag: CString, p1: Type): Type = TGround( tag, close([p1]) );
 let t3(tag: CString, p1: Type, p2: Type): Type = TGround( tag, close([p2, p1]) );
 let tv(v: CString): Type = TVar( v );

--- a/SRC/tctx-bind.lsts
+++ b/SRC/tctx-bind.lsts
@@ -1,11 +1,11 @@
 
 let .bind(tctx: HashtableEq<CString,List<Tuple<Type,Type,AST>>>, k: CString, kt: Type, kv: AST): HashtableEq<CString,List<Tuple<Type,Type,AST>>> = (
    let ktd = denormalize-strong(kt);
-   let row = tctx.lookup(k, [] :: List<(Type,Type,AST)>);
+   let row = tctx.lookup(k, [] : List<(Type,Type,AST)>);
    row = cons((kt, ktd, kv), row);
    tctx.bind(k, row);
 );
 
 let .bind(tctx: TypeContext?, k: CString, kt: Type, kv: AST): TypeContext? = (
-   Some( cons(Tuple(k, kt, kv), tctx.get-or([] :: TypeContext)) );
+   Some( cons(Tuple(k, kt, kv), tctx.get-or([] : TypeContext)) );
 );

--- a/SRC/tctx-substitute.lsts
+++ b/SRC/tctx-substitute.lsts
@@ -23,7 +23,7 @@ let substitute(tctx: Maybe<TypeContext>, tt: Type): Type = (
       );
       TGround{tag=tag,parameters=parameters} => TGround(tag,close(substitute(tctx,parameters)));
       TVar{name=name} => (
-         let ta = tctx.get-or([] :: List<Tuple<CString,Type,AST>>).lookup(name,Tuple(ta,mk-eof()));
+         let ta = tctx.get-or([] : List<Tuple<CString,Type,AST>>).lookup(name,Tuple(ta,mk-eof()));
          if non-zero(ta.first) then ta.first else tt;
       );
       _ => tt;

--- a/SRC/tctx-to-string.lsts
+++ b/SRC/tctx-to-string.lsts
@@ -1,7 +1,7 @@
 
 let .into(tctx: Maybe<TypeContext>, tt: Type<String>): String = (
    let result = "";
-   for Tuple{first=first,second=second} in tctx.get-or([] :: TypeContext) {
+   for Tuple{first=first,second=second} in tctx.get-or([] : TypeContext) {
       result = result + "\{first} : \{second}\n";
    };
    result
@@ -11,7 +11,7 @@ let to-smart-string(tctx: Maybe<TypeContext>): String = tctx.into(type(String));
 
 let .into(ctx: Maybe<AContext>, tt: Type<String>): String = (
    let result = "";
-   for Tuple{first=first,second=second} in ctx.get-or([] :: AContext) {
+   for Tuple{first=first,second=second} in ctx.get-or([] : AContext) {
       result = result + "\{first} : \{second}\n";
    };
    result

--- a/SRC/tctx-union.lsts
+++ b/SRC/tctx-union.lsts
@@ -1,5 +1,5 @@
 
 let union(lctx: Maybe<TypeContext>, rctx: Maybe<TypeContext>): Maybe<TypeContext> = (
-   Some( rctx.get-or([] :: TypeContext) +
-         lctx.get-or([] :: TypeContext) )
+   Some( rctx.get-or([] : TypeContext) +
+         lctx.get-or([] : TypeContext) )
 );

--- a/SRC/type-alias-index.lsts
+++ b/SRC/type-alias-index.lsts
@@ -1,5 +1,5 @@
 
-let type-alias-index = {} :: HashtableEq<Tuple<CString,U64>,Tuple<Type,Type>>;
+let type-alias-index = {} : HashtableEq<Tuple<CString,U64>,Tuple<Type,Type>>;
 
 let add-type-alias(lt: Type, rt: Type): Nil = (
    type-alias-index = type-alias-index.bind( lt.ground-tag-and-arity, Tuple( lt, rt ) );
@@ -39,7 +39,7 @@ let .rewrite-type-alias(lt: List<Type>): List<Type> = (
    }
 );
 
-let opaque-type-alias-index = {} :: HashtableEq<Tuple<CString,U64>,Tuple<Type,Type>>;
+let opaque-type-alias-index = {} : HashtableEq<Tuple<CString,U64>,Tuple<Type,Type>>;
 
 let add-opaque-type-alias(lt: Type, rt: Type): Nil = (
    opaque-type-alias-index = opaque-type-alias-index.bind( lt.ground-tag-and-arity, Tuple( lt, rt ) );

--- a/SRC/typeof-tag.lsts
+++ b/SRC/typeof-tag.lsts
@@ -1,4 +1,4 @@
 
 let typeof-tag(tag: CString): Type = (
-   typeof-var-raw(mk-eof(), (None :: Maybe<TypeContext>)(), tag)
+   typeof-var-raw(mk-eof(), (None : Maybe<TypeContext>)(), tag)
 );

--- a/SRC/unify.lsts
+++ b/SRC/unify.lsts
@@ -1,6 +1,6 @@
 
 let unify(fpt: Type, pt: Type): Maybe<TypeContext> = (
-   let ctx = (None :: Maybe<TypeContext>)();
+   let ctx = (None : Maybe<TypeContext>)();
    if can-unify(fpt, pt) {
       ctx = unify-inner(fpt, pt);
    };
@@ -8,9 +8,9 @@ let unify(fpt: Type, pt: Type): Maybe<TypeContext> = (
 );
 
 let unify-inner(fpt: Type, pt: Type): Maybe<TypeContext> = (
-   let ctx = (None :: Maybe<TypeContext>)();
-   let yes = Some([] :: TypeContext);
-   let no = (None :: Maybe<TypeContext>)();
+   let ctx = (None : Maybe<TypeContext>)();
+   let yes = Some([] : TypeContext);
+   let no = (None : Maybe<TypeContext>)();
    match (Tuple(fpt, pt)) {
       Tuple{ first:TAny{} } => ctx = yes;
       Tuple{ first:TGround{tag:c"Any"} } => ctx = yes;
@@ -133,8 +133,8 @@ let unify-inner(fpt: Type, pt: Type): Maybe<TypeContext> = (
 );
 
 let unify(fpt: List<Type>, pt: List<Type>): Maybe<TypeContext> = (
-   let ctx = (None :: Maybe<TypeContext>)();
-   let yes = Some([] :: TypeContext);
+   let ctx = (None : Maybe<TypeContext>)();
+   let yes = Some([] : TypeContext);
    match Tuple( fpt, pt ) {
       Tuple{ first:[lp1..lps], second:[rp1..rps] } => (
          ctx = unify-inner(lp1,rp1);

--- a/SRC/union.lsts
+++ b/SRC/union.lsts
@@ -2,5 +2,5 @@
 let union(l: Maybe<AContext>, r: Maybe<AContext>): Maybe<AContext> = (
    if l.is-some && r.is-some then (
       Some ( l.get-or-panic + r.get-or-panic )
-   ) else (None :: Maybe<AContext>)()
+   ) else (None : Maybe<AContext>)()
 );

--- a/SRC/validate-interfaces.lsts
+++ b/SRC/validate-interfaces.lsts
@@ -4,10 +4,10 @@ let validate-interfaces(): Nil = (
       (let self-type, let interface-type) = interface-self-index.lookup(reified-interface-type.ground-tag-and-arity, (ta, ta));
       let tctx = union( unify(self-type, base-type), unify(interface-type, reified-interface-type) );
       for Tuple{ symbol-name=first, args-type=second, return-type=third } in
-          interface-shape-index.lookup(interface-type.ground-tag-and-arity, [] :: List<(CString,Type,Type)>) {
+          interface-shape-index.lookup(interface-type.ground-tag-and-arity, [] : List<(CString,Type,Type)>) {
          args-type = denormalize(substitute(tctx, args-type).reify-type-variables);
          return-type = substitute(tctx, return-type).reify-type-variables;
-         let function-type = typeof-var-raw( blame, (None :: Maybe<TypeContext>)(), symbol-name );
+         let function-type = typeof-var-raw( blame, (None : Maybe<TypeContext>)(), symbol-name );
          let apply-return-type = apply-global-callable(symbol-name, args-type, blame);
          if not(can-unify(return-type, denormalize(apply-return-type))) {
             fail("Function Application Yielded Unexpected Return Value\n"

--- a/tests/c/c-parse.lsts
+++ b/tests/c/c-parse.lsts
@@ -27,7 +27,7 @@ if true then {
 # assignment operators
 if true then { 
    let abc = std-c-tokenize-string("ab", "ab");
-   assert( std-c-parse-assignment-operator(abc).first == None :: Maybe<String> );
+   assert( std-c-parse-assignment-operator(abc).first == None : Maybe<String> );
    if true then {
       let tokens = std-c-tokenize-string("[=]", "=");
       assert( std-c-parse-assignment-operator(tokens).first == Some{"="} );
@@ -76,7 +76,7 @@ if true then {
 
 if true then { 
    let abc = std-c-tokenize-string("ab", "ab");
-   assert( std-c-parse-unary-operator(abc).first == None :: Maybe<String> );
+   assert( std-c-parse-unary-operator(abc).first == None : Maybe<String> );
    if true then {
       let tokens = std-c-tokenize-string("[&]", "&");
       assert( std-c-parse-unary-operator(tokens).first == Some{"&"} );
@@ -105,7 +105,7 @@ if true then {
 
 if true then { 
    let abc = std-c-tokenize-string("ab", "ab");
-   assert( std-c-parse-struct-or-union(abc).first == None :: Maybe<String> );
+   assert( std-c-parse-struct-or-union(abc).first == None : Maybe<String> );
    if true then {
       let tokens = std-c-tokenize-string("[struct]", "struct");
       assert( std-c-parse-struct-or-union(tokens).first == Some{"struct"} );
@@ -131,13 +131,13 @@ if true then {
    };
    if true then {
       let tokens = std-c-tokenize-string("[int]", "int");
-      assert( std-c-parse-identifier(tokens).first == None :: Maybe<CTerm> );
+      assert( std-c-parse-identifier(tokens).first == None : Maybe<CTerm> );
    };
 };
 
 if true then { 
    let abc = std-c-tokenize-string("ab", "ab");
-   assert( std-c-parse-constant(abc).first == None :: Maybe<CTerm> );
+   assert( std-c-parse-constant(abc).first == None : Maybe<CTerm> );
    if true then {
       let tokens = std-c-tokenize-string("[0123456789]", "0123456789");
       assert( std-c-parse-constant(tokens).first == Some{CInteger{"0123456789"}} );
@@ -808,7 +808,7 @@ if true then {
    assert( std-c-parse-type-specifier(std-c-tokenize-string("_Complex", "_Complex")).first == Some{CType1{"_Complex"}} );
    assert( std-c-parse-type-specifier(std-c-tokenize-string("_Imaginary", "_Imaginary")).first == Some{CType1{"_Imaginary"}} );
    assert( std-c-parse-type-specifier(std-c-tokenize-string("td1", "td1")).first == Some{CType1{"td1"}} );
-   assert( std-c-parse-type-specifier(std-c-tokenize-string("td2", "td2")).first == (None :: Maybe<CTerm>) );
+   assert( std-c-parse-type-specifier(std-c-tokenize-string("td2", "td2")).first == (None : Maybe<CTerm>) );
 };
 
 if true then {
@@ -820,7 +820,7 @@ if true then {
 };
 
 if true then {
-   assert( std-c-parse-specifier-qualifier-list(std-c-tokenize-string("td2", "td2")).first == (None :: Maybe<List<CTerm>>) );
+   assert( std-c-parse-specifier-qualifier-list(std-c-tokenize-string("td2", "td2")).first == (None : Maybe<List<CTerm>>) );
    assert( std-c-parse-specifier-qualifier-list(std-c-tokenize-string("void", "void")).first == Some{[CType1{"void"}]} );
    assert( std-c-parse-specifier-qualifier-list(std-c-tokenize-string("void void", "void void")).first == Some{[CType1{"void"},CType1{"void"}]} );
 };
@@ -859,7 +859,7 @@ if true then {
 };
 
 if true then {
-   assert( std-c-parse-statement(std-c-tokenize-string("{}", "{}")).first == Some{CCompound{close([] :: List<CTerm>)}} );
+   assert( std-c-parse-statement(std-c-tokenize-string("{}", "{}")).first == Some{CCompound{close([] : List<CTerm>)}} );
    assert( std-c-parse-statement(std-c-tokenize-string("{a;}", "{a;}")).first == Some{CCompound{close([CIdentifier{"a"}])}} );
    assert( std-c-parse-statement(std-c-tokenize-string("{a; b;}", "{a; b;}")).first == Some{CCompound{close([CIdentifier{"a"},CIdentifier{"b"}])}} );
 };
@@ -867,8 +867,8 @@ if true then {
 if true then {
    assert( std-c-parse-initializer(std-c-tokenize-string("{a,b}", "{a,b}")).first ==
       Some{CInitializerList{close([
-         CInitializer{ close([] :: List<CTerm>), close(CIdentifier{"a"}) },
-         CInitializer{ close([] :: List<CTerm>), close(CIdentifier{"b"}) }
+         CInitializer{ close([] : List<CTerm>), close(CIdentifier{"a"}) },
+         CInitializer{ close([] : List<CTerm>), close(CIdentifier{"b"}) }
       ])}}
    );
    assert( std-c-parse-initializer(std-c-tokenize-string("{.a[b]=c}", "{.a[b]=c}")).first ==
@@ -883,14 +883,14 @@ if true then {
 
 if true then {
    assert( std-c-parse-pointer(std-c-tokenize-string("*", "*")).first ==
-      Some{CPointer{ close(None :: Maybe<List<CTerm>>), close(None :: Maybe<CTerm>) }}
+      Some{CPointer{ close(None : Maybe<List<CTerm>>), close(None : Maybe<CTerm>) }}
    );
    assert( std-c-parse-pointer(std-c-tokenize-string("*const", "*const")).first ==
-      Some{CPointer{ close(Some{[ CType1("const") ]}), close(None :: Maybe<CTerm>) }}
+      Some{CPointer{ close(Some{[ CType1("const") ]}), close(None : Maybe<CTerm>) }}
    );
    assert( std-c-parse-pointer(std-c-tokenize-string("*const*", "*const*")).first ==
       Some{CPointer{ close(Some{[ CType1("const") ]}), close(
-         Some{CPointer{ close(None :: Maybe<List<CTerm>>), close(None :: Maybe<CTerm>) }}
+         Some{CPointer{ close(None : Maybe<List<CTerm>>), close(None : Maybe<CTerm>) }}
       )}}
    );
 };
@@ -902,7 +902,7 @@ if true then {
    }} );
    assert( std-c-parse-abstract-declarator(std-c-tokenize-string("*()", "*()")).first == Some{CBinaryOp{
       "AbstractDeclarator",
-      close(CPointer{ close(None :: Maybe<List<CTerm>>), close(None :: Maybe<CTerm>) }),
+      close(CPointer{ close(None : Maybe<List<CTerm>>), close(None : Maybe<CTerm>) }),
       close(CUnaryPrefix{"AbstractDeclarator", close(CZOp{"("}) })
    }} );
    assert( std-c-parse-abstract-declarator(std-c-tokenize-string("[]", "[]")).first == Some{CUnaryPrefix{
@@ -920,7 +920,7 @@ if true then {
    assert( std-c-parse-type-name(std-c-tokenize-string("short int", "short int")).first == Some{CBinaryOp{
       "TypeName",
       close(CList{close([ CType1{"short"}, CType1{"int"} ])}),
-      close(CMaybe{close( None :: Maybe<CTerm> )})
+      close(CMaybe{close( None : Maybe<CTerm> )})
    }} );
 };
 
@@ -933,11 +933,11 @@ if true then {
             close(CBinaryOp{
                "TypeName",
                close(CList{close([ CType1{"short"}, CType1{"int"} ])}),
-               close(CMaybe{close( None :: Maybe<CTerm> )})
+               close(CMaybe{close( None : Maybe<CTerm> )})
             })
          }
       ])}),
-      close(CMaybe{close( None :: Maybe<CTerm> )})
+      close(CMaybe{close( None : Maybe<CTerm> )})
    }});
 };
 
@@ -951,7 +951,7 @@ if true then {
       close(CBinaryOp{
          "TypeName",
          close(CList{close([ CType1{"short"}, CType1{"int"} ])}),
-         close(CMaybe{close( None :: Maybe<CTerm> )})
+         close(CMaybe{close( None : Maybe<CTerm> )})
       }),
       close(CIdentifier{"a"})
    }} );
@@ -967,7 +967,7 @@ if true then {
       close(CBinaryOp{
          "TypeName",
          close(CList{close([ CType1{"short"}, CType1{"int"} ])}),
-         close(CMaybe{close( None :: Maybe<CTerm> )})
+         close(CMaybe{close( None : Maybe<CTerm> )})
       }),
       close(CIdentifier{"a"})
    }} );
@@ -993,7 +993,7 @@ if true then {
             close(CBinaryOp{
                "TypeName",
                close(CList{close([ CType1{"short"}, CType1{"int"} ])}),
-               close(CMaybe{close( None :: Maybe<CTerm> )})
+               close(CMaybe{close( None : Maybe<CTerm> )})
             }),
             close(CIdentifier{"a"})
          },
@@ -1021,6 +1021,6 @@ if true then {
    assert( std-c-parse-enumerator(std-c-tokenize-string("abc", "abc")).first == Some{CBinaryOp{
       "Enumerator",
       close(CIdentifier{"abc"}),
-      close(CMaybe{close( None :: Maybe<CTerm> )})
+      close(CMaybe{close( None : Maybe<CTerm> )})
    }} );
 };

--- a/tests/unit/ast-macros.lsts
+++ b/tests/unit/ast-macros.lsts
@@ -43,7 +43,7 @@ match2 "def" { d..ef="ef" => print("\{d}\{ef}"); };
 
 match2 [1,2,3] { [x=1.. y.. z] => print("\{x}\{y}\{z}"); };
 match2 [4,5,6] { [xyz] => print("\{xyz}"); };
-match2 [] :: List<U64> { [] => print("[]"); };
+match2 [] : List<U64> { [] => print("[]"); };
 
 match2 (A(123)) {
    _{} => print("_");


### PR DESCRIPTION
## Describe your changes
Features:
* ascript is always just one colon
* `t : T`
* if it is confusing for me, it will be confusing for everyone else

## Issue ticket number and link

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
