### PR TITLE
Phi sanitation fewpfcmp

### DIFF
--- a/SRC/unify.lsts
+++ b/SRC/unify.lsts
@@ -17,9 +17,13 @@ let unify-inner(fpt: Type, pt: Type): Maybe<TypeContext> = (
       Tuple{ first:TGround{tag:c"Phi::Initialize"} } => ctx = yes;
       Tuple{ first:TVar{}, second:TGround{tag:c"Cons"} } => no;
       Tuple{ first:TVar{name=name}, second:TGround{tag=tag} } => (
+         pt = pt.without-phi;
          ctx = ctx.bind(name, normalize(pt), pt, Lit(tag, mk-token(tag)));
       );
-      Tuple{ first:TVar{name=name} } => ctx = ctx.bind(name, normalize(pt), pt, mk-eof());
+      Tuple{ first:TVar{name=name} } => (
+         pt = pt.without-phi;
+         ctx = ctx.bind(name, normalize(pt), pt, mk-eof());
+      );
       Tuple{ first:TAnd{ lconjugate=conjugate }, second:TAnd{ rconjugate=conjugate } } => (
          let result = yes;
          let ri = 0_u64;

--- a/SRC/unit-orphans.lsts
+++ b/SRC/unit-orphans.lsts
@@ -21,6 +21,7 @@ import SRC/assert-no-infinite-types.lsts;
 import SRC/phi-initialize.lsts;
 import SRC/phi-state.lsts;
 import SRC/phi-merge.lsts;
+import SRC/without-phi.lsts;
 
 let .unroll-seq(t: AST): Vector<AST> = (
    match t {

--- a/SRC/without-phi.lsts
+++ b/SRC/without-phi.lsts
@@ -12,9 +12,10 @@ let .without-phi(tt: Type): Type = (
          else tand(result)
       );
       TGround { tag:c"Arrow", parameters:[_.._..] } => tt;
-      TGround { tag:c"Phi::Transition" } => ta;
-      TGround { tag:c"Phi::Initialize" } => ta;
-      TGround { tag:c"Phi::State" } => ta;
+      TGround { tag:c"Phi::Id", parameters:[_..] } => ta;
+      TGround { tag:c"Phi::Transition", parameters:[_.._..] } => ta;
+      TGround { tag:c"Phi::Initialize", parameters:[_..] } => ta;
+      TGround { tag:c"Phi::State", parameters:[_..] } => ta;
       TGround { tag=tag, parameters=parameters } => ts(tag, parameters.without-phi);
       _ => tt;
    }
@@ -22,7 +23,7 @@ let .without-phi(tt: Type): Type = (
 
 let .without-phi(tt: List<Type>): List<Type> = (
    match tt {
-      [hd..tl] => cons( hd.without-tag, tl.without-tag );
+      [hd..tl] => cons( hd.without-phi, tl.without-phi );
       tl => tl;
    }
 );

--- a/SRC/without-phi.lsts
+++ b/SRC/without-phi.lsts
@@ -1,0 +1,28 @@
+
+let .without-phi(tt: Type): Type = (
+   match tt {
+      TAnd { conjugate=conjugate } => (
+         let result = mk-vector(type(Type), 0_u64);
+         for c in conjugate {
+            c = c.without-phi;
+            if non-zero(c) then result = result.push(c);
+         };
+         if result.length==0 then ta
+         else if result.length==1 then result[0]
+         else tand(result)
+      );
+      TGround { tag:c"Arrow", parameters:[_.._..] } => tt;
+      TGround { tag:c"Phi::Transition" } => ta;
+      TGround { tag:c"Phi::Initialize" } => ta;
+      TGround { tag:c"Phi::State" } => ta;
+      TGround { tag=tag, parameters=parameters } => ts(tag, parameters.without-phi);
+      _ => tt;
+   }
+);
+
+let .without-phi(tt: List<Type>): List<Type> = (
+   match tt {
+      [hd..tl] => cons( hd.without-tag, tl.without-tag );
+      tl => tl;
+   }
+);

--- a/lib/core/common-macros.lsts
+++ b/lib/core/common-macros.lsts
@@ -297,7 +297,7 @@ deprecated macro ( rl"for-each"(item(rl"in")(iterable))(loop) ) ((
 
 deprecated macro ( rl"assert"(c) ) (
    $"if"( not(c) )
-        ( print(c"Assertion Failed At"); print(p(rl":Location:") : Constant+Literal+CString); exit(1_u64); )
+        ( print(c"Assertion Failed At "); print(p(rl":Location:") : Constant+Literal+CString); exit(1_u64); )
         ()
 );
 

--- a/lib/std/primitives.lsts
+++ b/lib/std/primitives.lsts
@@ -25,11 +25,11 @@ declare-binop( $"primitive::field-set-indirect", raw-type(base-type[]), raw-type
 # needs to be declared to prevent a special case during inference
 # this only needs to be declared if you want to support casting type information into String literals
 # EXAMPLE: print(typeof(x))
-declare-binop( $".into", type(x), type(String), raw-type(String), () );
+declare-binop( $".into", type(Any), type(String), raw-type(String), () );
 
 # this operator is hard-coded in the compiler for now
 # but this definition being in the library is simplest for inference
-declare-binop( $"<:", type(x), type(y), raw-type(Bool), () );
+declare-binop( $"<:", type(Any), type(Any), raw-type(Bool), () );
 
 let :Blob $"primitive::while"(body: Any, cond: BranchConditional): Nil = (
    $":frame"( $":frame"(body); $":frame"(cond) );

--- a/tests/regress/phi2-initializers.lsts
+++ b/tests/regress/phi2-initializers.lsts
@@ -11,7 +11,6 @@ let j(x: U64+Phi::Transition<E,F>): U64 = 123;
 let phi(l: C, r: D): E;
 
 let no-phi(phi-x: x): Nil = (
-   print("\{typeof(phi-x)}");
    assert(not( typeof(phi-x) <: type(Phi::State<Any>) ));
 );
 

--- a/tests/regress/phi2-initializers.lsts
+++ b/tests/regress/phi2-initializers.lsts
@@ -10,6 +10,10 @@ let i(x: U64+Phi::Transition<B,D>): U64 = 123;
 let j(x: U64+Phi::Transition<E,F>): U64 = 123;
 let phi(l: C, r: D): E;
 
+let no-phi(x: x): Nil = (
+   assert(not( typeof(x) <: type(Phi::State<Any>) ));
+);
+
 let x = f();
 assert( typeof(x) <: type(U64+Phi::State<A>) );
 
@@ -23,3 +27,5 @@ if true {
 };
 if true then j(x) else j(x);
 assert( typeof(x) <: type(U64+Phi::State<F>) );
+
+no-phi(x);

--- a/tests/regress/phi2-initializers.lsts
+++ b/tests/regress/phi2-initializers.lsts
@@ -10,8 +10,9 @@ let i(x: U64+Phi::Transition<B,D>): U64 = 123;
 let j(x: U64+Phi::Transition<E,F>): U64 = 123;
 let phi(l: C, r: D): E;
 
-let no-phi(x: x): Nil = (
-   assert(not( typeof(x) <: type(Phi::State<Any>) ));
+let no-phi(phi-x: x): Nil = (
+   print("\{typeof(phi-x)}");
+   assert(not( typeof(phi-x) <: type(Phi::State<Any>) ));
 );
 
 let x = f();


### PR DESCRIPTION
## Describe your changes
Features:
* remove Phi types during unification
* there is a logical boundary between external function application and internal function definition
* phi types do not cross this boundary unless they are explicitly part of the function type signature
* even then phi ids are kept unique across this boundary

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1556

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
