### PR TITLE
Phi mov override fewfmfm

### DIFF
--- a/SRC/phi-override.lsts
+++ b/SRC/phi-override.lsts
@@ -1,0 +1,26 @@
+
+let phi-override(tctx: TypeContext?, current-tt: Type, new-tt: Type): TypeContext? = (
+   match current-tt {
+      TAnd{conjugate=conjugate} => (
+         for c in conjugate {
+            tctx = phi-override(tctx, c, new-tt);
+         }
+      );
+      TGround{tag:c"Phi::Id",parameters:[TGround{phi-id=tag}..]} => (
+         let new-phi-type = ta;
+         match new-tt {
+            TAnd{conjugate=conjugate} => (
+               for c in conjugate { match c {
+                  TGround{tag:c"Phi::State",parameters:[phi-state..]} => new-phi-type = new-phi-type && phi-state;
+                  _ => ();
+               }}
+            );
+            TGround{tag:c"Phi::State",parameters:[phi-state..]} => new-phi-type = new-phi-type && phi-state;
+            _ => ();
+         };
+         tctx = tctx.bind-phi(phi-id, new-phi-type);
+      );
+      _ => ();
+   };
+   tctx
+);

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -197,6 +197,11 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                (tctx, rt) = phi-initialize(tctx, rt);
                rt = phi-state(tctx, rt);
                ascript(term, rt);
+               if var-name-if-var-or-lit(l)==c"mov" && typeof-term(r).is-t(c"Cons",2) {
+                  let new-tt = typeof-term(r).slot(c"Cons",2).l1;
+                  let current-tt = typeof-term(r).slot(c"Cons",2).l2;
+                  tctx = phi-override(tctx, current-tt, new-tt);
+               };
             };
          };
 

--- a/SRC/unit-orphans.lsts
+++ b/SRC/unit-orphans.lsts
@@ -22,6 +22,7 @@ import SRC/phi-initialize.lsts;
 import SRC/phi-state.lsts;
 import SRC/phi-merge.lsts;
 import SRC/without-phi.lsts;
+import SRC/phi-override.lsts;
 
 let .unroll-seq(t: AST): Vector<AST> = (
    match t {

--- a/tests/regress/phi2-initializers.lsts
+++ b/tests/regress/phi2-initializers.lsts
@@ -41,5 +41,4 @@ assert( typeof(x) <: type(U64+Phi::State<ABCDEF::F>) );
 no-phi(x);
 
 x = f();
-print("typeof(x) = \{typeof(x)}\n");
 assert( typeof(x) <: type(U64+Phi::State<ABCDEF::A>) );

--- a/tests/regress/phi2-initializers.lsts
+++ b/tests/regress/phi2-initializers.lsts
@@ -39,3 +39,7 @@ if true then j(x) else j(x);
 assert( typeof(x) <: type(U64+Phi::State<ABCDEF::F>) );
 
 no-phi(x);
+
+x = f();
+print("typeof(x) = \{typeof(x)}\n");
+assert( typeof(x) <: type(U64+Phi::State<ABCDEF::A>) );


### PR DESCRIPTION
## Describe your changes
* phi variables are override during assignment
* `mov` is hard-coded interpreted as an assignment for this purpose
* we can come back to this later when the compiler gets un-hard-coded
* I think this relation can be coded as a corollary, but that feature doesn't exist to this level of features yet

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1556

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
