### PR TITLE
Linear middle part fjepwpwp

### DIFF
--- a/SRC/apply-and-specialize.lsts
+++ b/SRC/apply-and-specialize.lsts
@@ -1,10 +1,11 @@
 
 let apply-and-specialize(tctx: TypeContext?, fname: CString, ft: Type, ft-denormal: Type, at: Type, blame: AST): (TypeContext?, Type) = (
-   if not(can-apply(ft-denormal, at)) then fail("Unable to apply and specialize: \{fname}\nFunction: \{ft}\nArguments: \{at}\nAt \{blame.location}\n");
+   if not(can-apply(ft-denormal, at)) then exit-error("Unable to apply and specialize: \{fname}\nFunction: \{ft}\nArguments: \{at}", blame);
    let inner-tctx = unify(ft-denormal.domain, at, blame);
-   if inner-tctx.is-none then fail("Unable to apply and specialize (unify): \{fname}\nFunction: \{ft}\nArguments: \{at}\nAt \{blame.location}\n");
+   if inner-tctx.has-moved then exit-error("Linear Value Used After Move", blame);
+   if inner-tctx.is-none then exit-error("Unable to apply and specialize (unify): \{fname}\nFunction: \{ft}\nArguments: \{at}", blame);
    let closed-type = substitute(inner-tctx, ft);
-   if closed-type.is-open then fail("Error: Unification Did Not Close Before Specialization\nfunction: \{fname} \{ft}\nargs: \{at}\nAt \{blame.location}\n");
+   if closed-type.is-open then exit-error("Unification Did Not Close Before Specialization\nfunction: \{fname} \{ft}\nargs: \{at}", blame);
    if ft.is-open then try-specialize(fname, ft, inner-tctx, closed-type);
    let r = substitute(inner-tctx, ft.range);
    if ft.is-t(c"Prop",0) then r = r && cons-root(at);

--- a/SRC/ast-definitions.lsts
+++ b/SRC/ast-definitions.lsts
@@ -46,6 +46,7 @@ let .lookup(trs: List<PhiContextRow>, key: CString, default: Type): Type = (
    }};
    default
 );
+let .into(tr: TypeContextRow, tt: Type<String>): String = "TypeContextRow{ key: \"\{tr.key}\", dt: \"\{tr.dt}\" }";
 
 type alias AContext = List<(CString,AST)>;
 

--- a/SRC/has-moved.lsts
+++ b/SRC/has-moved.lsts
@@ -1,0 +1,29 @@
+
+let .has-moved(tctx: TypeContext?): U64 = (
+   let moved = false;
+   for TypeContextRow{dt=dt} in tctx.get-or(mk-tctx()).tctx {
+      moved = moved || dt.has-moved;
+   };
+   moved
+);
+
+let .has-moved(tt: Type): U64 = (
+   match tt {
+      TAnd{conjugate=conjugate} => (
+         let moved = false;
+         for c in conjugate {
+            moved = moved || c.has-moved;
+         };
+         moved
+      );
+      TGround{tag:c"Linear",parameters:[TGround{tag:c"Phi::Moved",parameters:[]}..]} => true;
+      TGround{tag=tag,parameters=parameters} => (
+         let moved = false;
+         for c in parameters {
+            moved = moved || c.has-moved;
+         };
+         moved
+      );
+      _ => false;
+   }
+);

--- a/SRC/has-moved.lsts
+++ b/SRC/has-moved.lsts
@@ -16,7 +16,7 @@ let .has-moved(tt: Type): U64 = (
          };
          moved
       );
-      TGround{tag:c"Linear",parameters:[TGround{tag:c"Phi::Moved",parameters:[]}..]} => true;
+      TGround{tag:c"Phi::Moved",parameters:[]} => true;
       TGround{tag=tag,parameters=parameters} => (
          let moved = false;
          for c in parameters {

--- a/SRC/is-linear.lsts
+++ b/SRC/is-linear.lsts
@@ -6,6 +6,7 @@ let .is-linear(tt: Type): U64 = (
          for c in conjugate { return = return || c.is-linear };
          return
       );
+      TGround{tag:c"Linear",parameters:[TGround{tag:c"Phi::Moved",parameters:[]}..]} => false;
       TGround{tag:c"Linear",parameters:[_..]} => true;
       TGround{parameters=parameters} => (
          let return = false;

--- a/SRC/least-upper-bound.lsts
+++ b/SRC/least-upper-bound.lsts
@@ -48,8 +48,8 @@ let least-upper-bound(tctx: TypeContext?, left: Type, right: Type, blame: AST): 
             if not(non-zero(left-phi-id)) || not(non-zero(right-phi-id)) || not(non-zero(left-phi-state)) || not(non-zero(right-phi-state)) {
                exit-error("Unable to Merge Phi States: \{left-phi-state} x \{right-phi-state}", blame);
             };
-            tctx = tctx.bind-phi(left-phi-id, t1(c"Phi::Moved"), blame);
-            tctx = tctx.bind-phi(right-phi-id, t1(c"Phi::Moved"), blame);
+            tctx = tctx.bind-phi(left-phi-id, phi-linear-moved(left-phi-state), blame);
+            tctx = tctx.bind-phi(right-phi-id, phi-linear-moved(right-phi-state), blame);
             let new-phi-id = uuid();
             let new-phi-state = phi-merge(tctx,left-phi-state,right-phi-state,blame);
             result = result.push(t2(c"Phi::Id",t1(new-phi-id)));

--- a/SRC/phi-linear-moved.lsts
+++ b/SRC/phi-linear-moved.lsts
@@ -1,0 +1,21 @@
+
+let phi-linear-moved(tt: Type): Type = (
+   match tt {
+      TAnd{conjugate=conjugate} => (
+         let new-conjugate = mk-vector(type(Type));
+         for c in conjugate {
+            new-conjugate = new-conjugate.push(phi-linear-moved(c));
+         };
+         TAnd(new-conjugate)
+      );
+      TGround{tag:c"Linear", parameters:[_..]} => t2(c"Linear",t1(c"Phi::Moved"));
+      TGround{tag=tag, parameters=parameters} => (
+         let new-parameters = [] : List<Type>;
+         for p in parameters.reverse {
+            new-parameters = cons( phi-linear-moved(p), new-parameters );
+         };
+         ts(tag,new-parameters);
+      );
+      _ => tt;
+   }
+);

--- a/SRC/unify.lsts
+++ b/SRC/unify.lsts
@@ -53,7 +53,10 @@ let unify-inner(fpt: Type, pt: Type, blame: AST): Maybe<TypeContext> = (
                      _ => scan-states = false;
                   }};
                   if can-unify(phi-from, phi-state-in)
-                  then phi-state-out = phi-state-out && phi-to;
+                  then (
+                     result = result && unify(phi-from, phi-state-in, blame);
+                     phi-state-out = phi-state-out && phi-to;
+                  );
                );
                TGround{ltag=tag} => (
                   let this-result-ok = no;

--- a/SRC/unit-orphans.lsts
+++ b/SRC/unit-orphans.lsts
@@ -29,6 +29,7 @@ import SRC/validate-type.lsts;
 import SRC/validate-pctx-del.lsts;
 import SRC/is-linear.lsts;
 import SRC/least-upper-bound.lsts;
+import SRC/phi-linear-moved.lsts;
 
 let .unroll-seq(t: AST): Vector<AST> = (
    match t {

--- a/SRC/unit-orphans.lsts
+++ b/SRC/unit-orphans.lsts
@@ -30,6 +30,7 @@ import SRC/validate-pctx-del.lsts;
 import SRC/is-linear.lsts;
 import SRC/least-upper-bound.lsts;
 import SRC/phi-linear-moved.lsts;
+import SRC/has-moved.lsts;
 
 let .unroll-seq(t: AST): Vector<AST> = (
    match t {

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -27,6 +27,7 @@ if true {
    );
    print("typeof(x) = \{typeof(x)}\n");  
    print("typeof(inner) = \{typeof(inner)}\n");  
+   chomp(x);
    chomp(inner);
 };
 

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -16,7 +16,7 @@ if true {
 
 # merge case: open two linear types and merge them
 if true {
-   let x = $"if"(true) (
+   let x = $"if" (true) (
       let inner = to-chomp(1);
       print("typeof(inner) = \{typeof(inner)}\n");
       inner

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -28,7 +28,6 @@ if true {
    print("typeof(x) = \{typeof(x)}\n");  
    print("typeof(inner) = \{typeof(inner)}\n");  
    chomp(x);
-   chomp(inner);
 };
 
 

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -27,7 +27,7 @@ if true {
    );
    print("typeof(x) = \{typeof(x)}\n");  
    print("typeof(inner) = \{typeof(inner)}\n");  
-   chomp(x);
+   chomp(inner);
 };
 
 


### PR DESCRIPTION
## Describe your changes
Features:
* `Phi::Moved` only overwrites the linear variable, not the whole phi type
* check for `Phi::Moved` to validate use after move

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1661

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
