### PR TITLE
Linear must del fqmpqpq

### DIFF
--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -986,7 +986,7 @@ let lsts-parse-function-signature(fname: CString, tokens: List<Token>, loc: Sour
        lsts-parse-expect(c":", tokens); tokens = tail(tokens);
        let rtype-rest = lsts-parse-type(tokens);
        out.return-type = rtype-rest.first;
-       if fname!=c"phi" then out.return-type = phi-as-initialize(out.return-type).expand-implied-phi;
+       if fname!=c"phi" then out.return-type = out.return-type.expand-implied-phi.phi-as-initialize;
        tokens = rtype-rest.second;
    };
 

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -586,7 +586,7 @@ let lsts-parse-ascript(tokens: List<Token>): Tuple<AST,List<Token>> = (
    while lsts-parse-head(tokens)==c":" && non-zero(tokens) && lsts-parse-head(tail(tokens)) != c":" {
       tokens = tail(tokens);
       (let tt, tokens) = lsts-parse-type(tokens);
-      tt = phi-as-state(tt);
+      tt = phi-as-state(tt).expand-implied-phi;
       match term {
          App{ constructor=left:Lit{}, right:ASTNil{} } => (
             term = mk-app(constructor.ascript(tt), mk-nil());
@@ -829,6 +829,7 @@ let lsts-parse-typedef2(tokens: List<Token>): (AST, List<Token>) = (
          lsts-parse-expect(c"phi", tokens); tokens = tail(tokens);
          (let mt, tokens) = lsts-parse-type(tokens);
          implied-phi = implied-phi && mt;
+         implied-phi-index = implied-phi-index.bind(lhs-type.ground-tag-and-arity, mt);
       };
       if lsts-parse-head(tokens)==c":" {
          lsts-parse-expect(c":", tokens); tokens = tail(tokens);
@@ -964,7 +965,7 @@ let lsts-parse-function-signature(fname: CString, tokens: List<Token>, loc: Sour
          had-type = true;
          lsts-parse-expect(c":", tokens); tokens = tail(tokens);
          (arg-type, tokens) = lsts-parse-type(tokens);
-         if fname!=c"phi" then arg-type = phi-as-state(arg-type);
+         if fname!=c"phi" then arg-type = phi-as-state(arg-type).expand-implied-phi;
       };
       if lsts-parse-head(tokens)==c"," { tokens = tail(tokens); } else { lsts-parse-expect(c")", tokens); };
       let arg-binding = if had-type then mk-cons(
@@ -1971,7 +1972,7 @@ let lsts-parse-atom-tail(base: AST, tokens: List<Token>): Tuple<AST,List<Token>>
             tokens = type-rest.second;
             base = mk-app(
                Var( c"as", with-location(mk-token("as"),loc) ),
-               mk-cons(base, mk-atype(phi-as-state(type-rest.first)))
+               mk-cons(base, mk-atype(phi-as-state(type-rest.first).expand-implied-phi))
             );
          );
          [Token{key:"["}.. rest] => (

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -986,7 +986,7 @@ let lsts-parse-function-signature(fname: CString, tokens: List<Token>, loc: Sour
        lsts-parse-expect(c":", tokens); tokens = tail(tokens);
        let rtype-rest = lsts-parse-type(tokens);
        out.return-type = rtype-rest.first;
-       if fname!=c"phi" then out.return-type = phi-as-initialize(out.return-type);
+       if fname!=c"phi" then out.return-type = phi-as-initialize(out.return-type).expand-implied-phi;
        tokens = rtype-rest.second;
    };
 

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -819,9 +819,17 @@ let lsts-parse-typedef2(tokens: List<Token>): (AST, List<Token>) = (
    let infers = mk-vector(type(Type));
    let impls = mk-vector(type(Type));
    let size = ta;
+   let implied-phi = ta;
    while lsts-parse-head(tokens)==c":" || lsts-parse-head(tokens)==c"implies"
       || lsts-parse-head(tokens)==c"implements" || lsts-parse-head(tokens)==c"size"
-      || lsts-parse-head(tokens)==c"suffix" || lsts-parse-head(tokens)==c"zero" {
+      || lsts-parse-head(tokens)==c"suffix" || lsts-parse-head(tokens)==c"zero"
+      || (lsts-parse-head(tokens)==c"implied" && lsts-parse-head(tail(tokens))==c"phi") {
+      if (lsts-parse-head(tokens)==c"implied" && lsts-parse-head(tail(tokens))==c"phi") {
+         lsts-parse-expect(c"implied", tokens); tokens = tail(tokens);
+         lsts-parse-expect(c"phi", tokens); tokens = tail(tokens);
+         (let mt, tokens) = lsts-parse-type(tokens);
+         implied-phi = implied-phi && mt;
+      };
       if lsts-parse-head(tokens)==c":" {
          lsts-parse-expect(c":", tokens); tokens = tail(tokens);
          (let mt, tokens) = lsts-parse-type(tokens);
@@ -912,7 +920,7 @@ let lsts-parse-typedef2(tokens: List<Token>): (AST, List<Token>) = (
    };
    let td = mk-typedef2(loc, lhs-type).with-implies(infers).with-implements(impls)
             .with-size(size).with-alias(alias).with-opaque-alias(opaque-alias)
-            .with-cases(cases).with-misc(misc-type);
+            .with-cases(cases).with-misc(misc-type).with-implied-phi(implied-phi);
    lsts-parse-expect(c";", tokens); tokens = tail(tokens);
    if misc-type.is-t(c"Phi",0) then infer-type-definition(td);
    (td, tokens);

--- a/SRC/ast-definitions.lsts
+++ b/SRC/ast-definitions.lsts
@@ -15,7 +15,7 @@ type AST zero ASTEOF implements DefaultFormattable
          | Glb { key: Token , val: AST[] }
          | Typedef2 { location: SourceLocation, lhs-type: Type, implies: Vector<Type>, implements: Vector<Type>,
                       size: Type, alias: Type, opaque-alias: Type, cases: Vector<(CString,Vector<(CString,Type)>)>,
-                      misc-type: Type };
+                      misc-type: Type, implied-phi: Type };
 
 # constructor with a default argument
 let $"App"(left: AST[], right: AST[]): AST = App ( false, left, right );

--- a/SRC/expand-implied-phi.lsts
+++ b/SRC/expand-implied-phi.lsts
@@ -24,6 +24,5 @@ let .expand-implied-phi(tt: Type): Type = (
       );
       _ => ();
    };
-   if not(is(original-tt, tt)) then print("Expanded \{original-tt} => \{tt}\n");
    tt
 );

--- a/SRC/expand-implied-phi.lsts
+++ b/SRC/expand-implied-phi.lsts
@@ -2,6 +2,7 @@
 let implied-phi-index = {} : HashtableEq<(CString,U64),Type>;
 
 let .expand-implied-phi(tt: Type): Type = (
+   let original-tt = tt;
    match tt {
       TAnd{conjugate=conjugate} => (
          for c in conjugate {
@@ -23,5 +24,6 @@ let .expand-implied-phi(tt: Type): Type = (
       );
       _ => ();
    };
+   if not(is(original-tt, tt)) then print("Expanded \{original-tt} => \{tt}\n");
    tt
 );

--- a/SRC/expand-implied-phi.lsts
+++ b/SRC/expand-implied-phi.lsts
@@ -1,0 +1,27 @@
+
+let implied-phi-index = {} : HashtableEq<(CString,U64),Type>;
+
+let .expand-implied-phi(tt: Type): Type = (
+   match tt {
+      TAnd{conjugate=conjugate} => (
+         for c in conjugate {
+            let ga = c.ground-tag-and-arity;
+            let ip = implied-phi-index.lookup(ga,ta);
+            let ps = t2(c"Phi::State",ip);
+            if non-zero(ip) && not(can-unify(ps, tt)) {
+               tt = tt && ps
+            }
+         }
+      );
+      TGround{} => (
+         let ga = tt.ground-tag-and-arity;
+         let ip = implied-phi-index.lookup(ga,ta);
+         let ps = t2(c"Phi::State",ip);
+         if non-zero(ip) && not(can-unify(ps, tt)) {
+            tt = tt && ps
+         }
+      );
+      _ => ();
+   };
+   tt
+);

--- a/SRC/infer-type-definition.lsts
+++ b/SRC/infer-type-definition.lsts
@@ -207,7 +207,9 @@ let infer-type-yield-constructor(base-type: Type, case-tag: CString, case-number
    body = mk-cons(body, mk-lit(return-id).ascript(t1(c"L")));
    body = mk-cons(body, mk-lit(c";})").ascript(t1(c"L")));
 
-   let constructor = mk-glb( mk-token(case-tag).with-location(blame.location), mk-abs(args, body.ascript(base-type), t1(c"Blob")) );
+   let constructor = mk-glb( mk-token(case-tag).with-location(blame.location), mk-abs(args, body.ascript(base-type.expand-implied-phi.phi-as-initialize), t1(c"Blob")) );
+   print("Constructor \{constructor}\n");
+
    type-ast-inserts = type-ast-inserts.push(constructor); ()
 );
 

--- a/SRC/infer-type-definition.lsts
+++ b/SRC/infer-type-definition.lsts
@@ -208,7 +208,6 @@ let infer-type-yield-constructor(base-type: Type, case-tag: CString, case-number
    body = mk-cons(body, mk-lit(c";})").ascript(t1(c"L")));
 
    let constructor = mk-glb( mk-token(case-tag).with-location(blame.location), mk-abs(args, body.ascript(base-type.expand-implied-phi.phi-as-initialize), t1(c"Blob")) );
-   print("Constructor \{constructor}\n");
 
    type-ast-inserts = type-ast-inserts.push(constructor); ()
 );

--- a/SRC/mk-app.lsts
+++ b/SRC/mk-app.lsts
@@ -21,7 +21,7 @@ let mk-seq(): AST = (
 
 let mk-typedef2(loc: SourceLocation, lhs-type: Type): AST = (
    Typedef2( loc, lhs-type, mk-vector(type(Type)), mk-vector(type(Type)),
-             ta, ta, ta, mk-vector(type((CString,Vector<(CString,Type)>))), ta )
+             ta, ta, ta, mk-vector(type((CString,Vector<(CString,Type)>))), ta, ta )
 );
 
 let .with-implies(term: AST, implies: Vector<Type>): AST = (
@@ -35,7 +35,8 @@ let .with-implies(term: AST, implies: Vector<Type>): AST = (
          let opaque-alias = (term as Tag::Typedef2).opaque-alias;
          let cases = (term as Tag::Typedef2).cases;
          let misc-type = (term as Tag::Typedef2).misc-type;
-         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type );
+         let implied-phi = (term as Tag::Typedef2).implied-phi;
+         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type, implied-phi );
       );
       _ => term;
    }
@@ -51,7 +52,8 @@ let .with-implements(term: AST, implements: Vector<Type>): AST = (
          let opaque-alias = (term as Tag::Typedef2).opaque-alias;
          let cases = (term as Tag::Typedef2).cases;
          let misc-type = (term as Tag::Typedef2).misc-type;
-         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type );
+         let implied-phi = (term as Tag::Typedef2).implied-phi;
+         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type, implied-phi );
       );
       _ => term;
    }
@@ -67,7 +69,8 @@ let .with-size(term: AST, size: Type): AST = (
          let opaque-alias = (term as Tag::Typedef2).opaque-alias;
          let cases = (term as Tag::Typedef2).cases;
          let misc-type = (term as Tag::Typedef2).misc-type;
-         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type );
+         let implied-phi = (term as Tag::Typedef2).implied-phi;
+         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type, implied-phi );
       );
       _ => term;
    }
@@ -83,7 +86,8 @@ let .with-alias(term: AST, alias: Type): AST = (
          let opaque-alias = (term as Tag::Typedef2).opaque-alias;
          let cases = (term as Tag::Typedef2).cases;
          let misc-type = (term as Tag::Typedef2).misc-type;
-         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type );
+         let implied-phi = (term as Tag::Typedef2).implied-phi;
+         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type, implied-phi );
       );
       _ => term;
    }
@@ -99,7 +103,8 @@ let .with-opaque-alias(term: AST, opaque-alias: Type): AST = (
          let alias = (term as Tag::Typedef2).alias;
          let cases = (term as Tag::Typedef2).cases;
          let misc-type = (term as Tag::Typedef2).misc-type;
-         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type );
+         let implied-phi = (term as Tag::Typedef2).implied-phi;
+         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type, implied-phi );
       );
       _ => term;
    }
@@ -115,7 +120,8 @@ let .with-cases(term: AST, cases: Vector<(CString,Vector<(CString,Type)>)>): AST
          let alias = (term as Tag::Typedef2).alias;
          let opaque-alias = (term as Tag::Typedef2).opaque-alias;
          let misc-type = (term as Tag::Typedef2).misc-type;
-         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type );
+         let implied-phi = (term as Tag::Typedef2).implied-phi;
+         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type, implied-phi );
       );
       _ => term;
    }
@@ -131,7 +137,25 @@ let .with-misc(term: AST, misc-type: Type): AST = (
          let alias = (term as Tag::Typedef2).alias;
          let opaque-alias = (term as Tag::Typedef2).opaque-alias;
          let cases = (term as Tag::Typedef2).cases;
-         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type );
+         let implied-phi = (term as Tag::Typedef2).implied-phi;
+         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type, implied-phi );
+      );
+      _ => term;
+   }
+);
+let .with-implied-phi(term: AST, implied-phi: Type): AST = (
+   match term {
+      Typedef2{} => (
+         let location = (term as Tag::Typedef2).location;
+         let lhs-type = (term as Tag::Typedef2).lhs-type;
+         let implies = (term as Tag::Typedef2).implies;
+         let implements = (term as Tag::Typedef2).implements;
+         let size = (term as Tag::Typedef2).size;
+         let alias = (term as Tag::Typedef2).alias;
+         let opaque-alias = (term as Tag::Typedef2).opaque-alias;
+         let cases = (term as Tag::Typedef2).cases;
+         let misc-type = (term as Tag::Typedef2).misc-type;
+         Typedef2( location, lhs-type, implies, implements, size, alias, opaque-alias, cases, misc-type, implied-phi );
       );
       _ => term;
    }

--- a/SRC/phi-as-initialize.lsts
+++ b/SRC/phi-as-initialize.lsts
@@ -1,10 +1,10 @@
 
-let phi-as-initialize(tt: Type): Type = (
+let .phi-as-initialize(tt: Type): Type = (
    match tt {
       TAnd{conjugate=conjugate} => (
          let new-conjugate = mk-vector(type(Type));
          for c in conjugate {
-            new-conjugate = new-conjugate.push(phi-as-initialize(c));
+            new-conjugate = new-conjugate.push(c.phi-as-initialize);
          };
          TAnd(new-conjugate);
       );

--- a/SRC/unit-orphans.lsts
+++ b/SRC/unit-orphans.lsts
@@ -33,6 +33,7 @@ import SRC/phi-linear-moved.lsts;
 import SRC/phi-move.lsts;
 import SRC/phi-fresh.lsts;
 import SRC/has-moved.lsts;
+import SRC/expand-implied-phi.lsts;
 
 let .unroll-seq(t: AST): Vector<AST> = (
    match t {

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -42,6 +42,8 @@ if true {
    chomp(y);
 };
 
-let f(x: A): A = x;
+let f(x: A): A = (
+   x
+);
 
 chomp(f(A(1)));

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -10,7 +10,7 @@ let send-chomp(x: U64+MustChomp::ToChomp<'s>): Nil = (
    chomp(x);
 );
 
-type A implicit phi MustChomp::ToChomp<'a> = { a: U64 };
+type A implies associated MustChomp::ToChomp<'a> = { a: U64 };
 
 # simple case: open linear type and close it
 if true {

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -5,10 +5,12 @@ type phi MustChomp = ToChomp { x: 'a } | Chomped;
 
 let to-chomp(x: U64): U64+MustChomp::ToChomp<'a> = x;
 
-let chomp(x: U64+(MustChomp::ToChomp<'a> ~> MustChomp::Chomped)): Nil = ();
+let chomp(x: x+(MustChomp::ToChomp<'a> ~> MustChomp::Chomped)): Nil = ();
 let send-chomp(x: U64+MustChomp::ToChomp<'s>): Nil = (
    chomp(x);
 );
+
+type A implicit phi MustChomp::ToChomp<'a> = { a: U64 };
 
 # simple case: open linear type and close it
 if true {
@@ -39,3 +41,7 @@ if true {
    y = x;
    chomp(y);
 };
+
+let f(x: A): A = x;
+
+chomp(f(A(1)));

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -10,7 +10,7 @@ let send-chomp(x: U64+MustChomp::ToChomp<'s>): Nil = (
    chomp(x);
 );
 
-type A implies associated MustChomp::ToChomp<'a> = { a: U64 };
+type A implied phi MustChomp::ToChomp<'a> = { a: U64 };
 
 # simple case: open linear type and close it
 if true {


### PR DESCRIPTION
## Describe your changes
Features:
* types can be marked with implicit phi states
* this helps avoid so much typing long conjugates

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1675

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
