### PR TITLE
Linear move on return

### DIFF
--- a/SRC/can-apply.lsts
+++ b/SRC/can-apply.lsts
@@ -1,3 +1,7 @@
 
-let can-apply(ft: Type, pt: Type): U64 = can-unify(ft.domain, pt);
+let can-apply(ft: Type, pt: Type): U64 = (
+   let r = can-unify(ft.domain, pt);
+   print("Can Apply \{ft}\nWith Argument \{pt}\nAccept \{r}\n");
+   r
+);
 let can-receive(ft: Type, pt: Type): U64 = can-unify(ft.range, pt);

--- a/SRC/can-apply.lsts
+++ b/SRC/can-apply.lsts
@@ -1,7 +1,3 @@
 
-let can-apply(ft: Type, pt: Type): U64 = (
-   let r = can-unify(ft.domain, pt);
-   print("Can Apply \{ft}\nWith Argument \{pt}\nAccept \{r}\n");
-   r
-);
+let can-apply(ft: Type, pt: Type): U64 = can-unify(ft.domain, pt);
 let can-receive(ft: Type, pt: Type): U64 = can-unify(ft.range, pt);

--- a/SRC/can-unify.lsts
+++ b/SRC/can-unify.lsts
@@ -25,7 +25,14 @@ let can-unify(fpt: Type, pt: Type): U64 = (
          for lc in lconjugate {
             if result then (match lc {
                TGround{tag:c"Any"} => ();
-               TGround{tag:c"Phi::Initialize"} => ();
+               TGround{tag:c"Phi::Initialize",parameters:[phi-expect..]} => (
+                  let pt-phi-state = ta;
+                  for rct in rconjugate { match rct {
+                     TGround{tag:c"Phi::State",parameters:[rct-phi-state..]} => pt-phi-state = rct-phi-state;
+                     _ => ();
+                  }};
+                  result = result && can-unify(phi-expect, pt-phi-state);
+               );
                TGround{tag:c"Phi::Transition", parameters:[phi-to..phi-from..]} => (
                   let scan-states = true;
                   let skip-state-check = false;

--- a/SRC/can-unify.lsts
+++ b/SRC/can-unify.lsts
@@ -34,6 +34,10 @@ let can-unify(fpt: Type, pt: Type): U64 = (
                         phi-state-in = phi-state-in && new-phi-state;
                         ri = ri + 1;
                      );
+                     TGround{tag:c"Phi::Transition",parameters:[new-phi-to..new-phi-from..]} => (
+                        result = result && can-unify(phi-to, new-phi-to) && can-unify(phi-from, new-phi-from);
+                        ri = ri + 1;
+                     );
                      TGround{tag=tag} => (
                         if tag < c"Phi::Transition"
                         then ri = ri + 1

--- a/SRC/can-unify.lsts
+++ b/SRC/can-unify.lsts
@@ -28,6 +28,7 @@ let can-unify(fpt: Type, pt: Type): U64 = (
                TGround{tag:c"Phi::Initialize"} => ();
                TGround{tag:c"Phi::Transition", parameters:[phi-to..phi-from..]} => (
                   let scan-states = true;
+                  let skip-state-check = false;
                   while scan-states && ri < rconjugate.length { match rconjugate[ri] {
                      TGround{tag:c"Phi::Id",parameters:[TGround{new-phi-id=tag}..]} => ri = ri + 1;
                      TGround{tag:c"Phi::State",parameters:[new-phi-state..]} => (
@@ -37,6 +38,7 @@ let can-unify(fpt: Type, pt: Type): U64 = (
                      TGround{tag:c"Phi::Transition",parameters:[new-phi-to..new-phi-from..]} => (
                         result = result && can-unify(phi-to, new-phi-to) && can-unify(phi-from, new-phi-from);
                         ri = ri + 1;
+                        skip-state-check = true;
                      );
                      TGround{tag=tag} => (
                         if tag < c"Phi::Transition"
@@ -45,7 +47,7 @@ let can-unify(fpt: Type, pt: Type): U64 = (
                      );
                      _ => scan-states = false;
                   }};
-                  result = can-unify(phi-from, phi-state-in)
+                  if not(skip-state-check) then result = result && can-unify(phi-from, phi-state-in);
                );
                TGround{ltag=tag} => (
                   let this-result-ok = false as U64;

--- a/SRC/find-global-callable.lsts
+++ b/SRC/find-global-callable.lsts
@@ -17,7 +17,7 @@ let find-global-callable(fname: CString, arg-types: Type, blame: AST): AST = (
       if all-accept { result = t1 };
    }};
    if not(non-zero(result)) && match-set.length > 0 {
-      eprint("Unable to find unambiguous global callable: \{fname} \{arg-types}\n");
+      eprint("Unable to find unambiguous global callable: \{fname} \{arg-types}\nAt: \{blame.location}\n");
       for Tuple{kt=first, t=second} in match-set {
          eprint("\{kt}\n");
       };

--- a/SRC/find-global-callable.lsts
+++ b/SRC/find-global-callable.lsts
@@ -34,7 +34,7 @@ let find-global-callable(fname: CString, arg-types: Type, blame: AST): AST = (
 );
 
 let find-global-constructor(fname: CString, hint: Type, arg-types: Type, blame: AST): AST = (
-   hint = hint.rewrite-type-alias;
+   hint = hint.rewrite-type-alias.without-phi;
    let result = ASTEOF();
    for Tuple{ot=first, kt=second, t=third} in global-type-context-denormal.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
       if not(ot.is-open) && (not(non-zero(hint)) || can-receive(ot, hint)) && can-apply(ot, arg-types) {

--- a/SRC/most-special.lsts
+++ b/SRC/most-special.lsts
@@ -10,11 +10,9 @@
 
 let most-special(t1: Type, t2: Type): Type = (
    if t1.is-arrow && t2.is-arrow {
-      let rt = if can-unify(t1.domain, t2.domain) then t2
+      if can-unify(t1.domain, t2.domain) then t2
       else if can-unify(t2.domain, t1.domain) then t1
-      else ta;
-      if not(non-zero(rt)) then print("Not Most Special\n\{t1}\n\{t2}\n");
-      rt
+      else ta
    } else if can-unify(t1, t2) then t2
      else if can-unify(t2, t1) then t1
      else ta

--- a/SRC/most-special.lsts
+++ b/SRC/most-special.lsts
@@ -10,9 +10,11 @@
 
 let most-special(t1: Type, t2: Type): Type = (
    if t1.is-arrow && t2.is-arrow {
-      if can-unify(t1.domain, t2.domain) then t2
+      let rt = if can-unify(t1.domain, t2.domain) then t2
       else if can-unify(t2.domain, t1.domain) then t1
-      else ta
+      else ta;
+      if not(non-zero(rt)) then print("Not Most Special\n\{t1}\n\{t2}\n");
+      rt
    } else if can-unify(t1, t2) then t2
      else if can-unify(t2, t1) then t1
      else ta

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -113,8 +113,11 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             (let inner-tctx, let new-val) = std-infer-expr(tctx, val, is-scoped, Used(), ta);
             match new-val {
                Abs{rhs:App{ left:Lit{key:c":"}, right:App{ rhs=left, right:AType{rhs-tt=tt} } }, tlt=tt} => (
-                  if not(tlt.is-t(c"Blob",0) || tlt.is-t(c"C-FFI",0) || tlt.is-t(c"FFI",0)) && not(can-unify(rhs-tt, typeof-term(rhs)))
-                  then exit-error("Return value does not match declared type:\nExpected \{rhs-tt}\nFound \{typeof-term(rhs)}\n", term);
+                  if not(tlt.is-t(c"Blob",0) || tlt.is-t(c"C-FFI",0) || tlt.is-t(c"FFI",0)) {
+                     print("Check Return Value\nExpected \{rhs-tt}\nFound \{typeof-term(rhs)}\n");
+                     if not(can-unify(rhs-tt, typeof-term(rhs)))
+                     then exit-error("Return value does not match declared type:\nExpected \{rhs-tt}\nFound \{typeof-term(rhs)}\n", term);
+                  };
                   inner-tctx = phi-move(inner-tctx, typeof-term(rhs), term);
                );
                _ => ();

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -111,6 +111,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          let rough-tt = typeof-term-plain(term);
          if rough-tt.is-arrow && not(rough-tt.is-open) && not(rough-tt.is-t(c"TypedMacro",0)) {
             (let inner-tctx, let new-val) = std-infer-expr(tctx, val, is-scoped, Used(), ta);
+            inner-tctx = phi-move(inner-tctx, typeof-term(new-val), term);
             validate-pctx-del(inner-tctx);
             if not(is(val,new-val)) then {
                let new-term = mk-glb(key,new-val);

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -114,6 +114,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             match new-val {
                Abs{rhs:App{ left:Lit{key:c":"}, right:App{ rhs=left, right:AType{rhs-tt=tt} } }, tlt=tt} => (
                   if not(tlt.is-t(c"Blob",0) || tlt.is-t(c"C-FFI",0) || tlt.is-t(c"FFI",0) || tlt.is-t(c"Phi::Source",0) ) {
+                     rhs-tt = rhs-tt.rewrite-type-alias;
                      if not(can-unify(rhs-tt, typeof-term(rhs)))
                      then exit-error("Return value does not match declared type:\nExpected \{rhs-tt}\nFound \{typeof-term(rhs)}\n", term);
                   };

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -113,8 +113,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             (let inner-tctx, let new-val) = std-infer-expr(tctx, val, is-scoped, Used(), ta);
             match new-val {
                Abs{rhs:App{ left:Lit{key:c":"}, right:App{ rhs=left, right:AType{rhs-tt=tt} } }, tlt=tt} => (
-                  if not(tlt.is-t(c"Blob",0) || tlt.is-t(c"C-FFI",0) || tlt.is-t(c"FFI",0)) {
-                     print("Check Return Value\nExpected \{rhs-tt}\nFound \{typeof-term(rhs)}\n");
+                  if not(tlt.is-t(c"Blob",0) || tlt.is-t(c"C-FFI",0) || tlt.is-t(c"FFI",0) || tlt.is-t(c"Phi::Source",0) ) {
                      if not(can-unify(rhs-tt, typeof-term(rhs)))
                      then exit-error("Return value does not match declared type:\nExpected \{rhs-tt}\nFound \{typeof-term(rhs)}\n", term);
                   };

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -111,7 +111,12 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          let rough-tt = typeof-term-plain(term);
          if rough-tt.is-arrow && not(rough-tt.is-open) && not(rough-tt.is-t(c"TypedMacro",0)) {
             (let inner-tctx, let new-val) = std-infer-expr(tctx, val, is-scoped, Used(), ta);
-            inner-tctx = phi-move(inner-tctx, typeof-term(new-val), term);
+            match new-val {
+               Abs{rhs:App{ left:Lit{key:c":"}, right:App{ rhs=left, right:AType{rhs-tt=tt} } }} => (
+                  inner-tctx = phi-move(inner-tctx, typeof-term(rhs), term);
+               );
+               _ => ();
+            };
             validate-pctx-del(inner-tctx);
             if not(is(val,new-val)) then {
                let new-term = mk-glb(key,new-val);

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -112,7 +112,9 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          if rough-tt.is-arrow && not(rough-tt.is-open) && not(rough-tt.is-t(c"TypedMacro",0)) {
             (let inner-tctx, let new-val) = std-infer-expr(tctx, val, is-scoped, Used(), ta);
             match new-val {
-               Abs{rhs:App{ left:Lit{key:c":"}, right:App{ rhs=left, right:AType{rhs-tt=tt} } }} => (
+               Abs{rhs:App{ left:Lit{key:c":"}, right:App{ rhs=left, right:AType{rhs-tt=tt} } }, tlt=tt} => (
+                  if not(tlt.is-t(c"Blob",0) || tlt.is-t(c"C-FFI",0) || tlt.is-t(c"FFI",0)) && not(can-unify(rhs-tt, typeof-term(rhs)))
+                  then exit-error("Return value does not match declared type:\nExpected \{rhs-tt}\nFound \{typeof-term(rhs)}\n", term);
                   inner-tctx = phi-move(inner-tctx, typeof-term(rhs), term);
                );
                _ => ();

--- a/SRC/tctx-substitute.lsts
+++ b/SRC/tctx-substitute.lsts
@@ -21,6 +21,7 @@ let substitute(tctx: Maybe<TypeContext>, tt: Type): Type = (
          else if result.length==1 then result[0]
          else tand(result)
       );
+      TGround{tag:c"Linear",parameters:[TVar{}..]} => tt;
       TGround{tag=tag,parameters=parameters} => TGround(tag,close(substitute(tctx,parameters)));
       TVar{name=name} => (
          let tn = tctx.get-or(mk-tctx()).tctx.lookup(name,TypeContextRow(c"",ta,ta,mk-eof())).normalized-type;

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -47,3 +47,5 @@ let f(x: A): A = (
 );
 
 chomp(f(A(1)));
+
+let wrong-chomp(x: U64+MustChomp::ToChomp<'s>): U64+MustChomp::Chomped = x;

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -22,11 +22,9 @@ if true {
 if true {
    let x = $"if" (true) (
       let inner = to-chomp(1);
-      print("typeof(inner) = \{typeof(inner)}\n");
       inner
    ) (
       let outer = to-chomp(2);
-      print("typeof(outer) = \{typeof(outer)}\n");
       outer
    );
    chomp(x);

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -47,5 +47,3 @@ let f(x: A): A = (
 );
 
 chomp(f(A(1)));
-
-let wrong-chomp(x: U64+MustChomp::ToChomp<'s>): U64+MustChomp::Chomped = x;

--- a/tests/regress/linear.lsts
+++ b/tests/regress/linear.lsts
@@ -3,7 +3,7 @@ import lib/std/default.lsts;
 
 type phi MustChomp = ToChomp { x: 'a } | Chomped;
 
-let to-chomp(x: U64): U64+MustChomp::ToChomp<'a> = x;
+let :Phi::Source to-chomp(x: U64): U64+MustChomp::ToChomp<'a> = x;
 
 let chomp(x: x+(MustChomp::ToChomp<'a> ~> MustChomp::Chomped)): Nil = ();
 let send-chomp(x: U64+MustChomp::ToChomp<'s>): Nil = (

--- a/tests/regress/phi2-initializers.lsts
+++ b/tests/regress/phi2-initializers.lsts
@@ -3,7 +3,7 @@ import lib/std/default.lsts;
 
 type phi ABCDEF = A | B | C | D | E | F;
 
-let f(): U64+ABCDEF::A = 123;
+let :Phi::Source f(): U64+ABCDEF::A = 123;
 let g(x: U64+(ABCDEF::A ~> ABCDEF::B)): U64 = 123;
 let h(x: U64+(ABCDEF::B ~> ABCDEF::C)): U64 = 123;
 let i(x: U64+(ABCDEF::B ~> ABCDEF::D)): U64 = 123;


### PR DESCRIPTION
## Describe your changes
Features:
* mark linear variables as moved when they are returned from a function
* check that return values are valid for functions (including phi States unless marked as Phi::Source)

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1675

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
