### PR TITLE
use standard memcmp for is implementation

### DIFF
--- a/lib2/core/sized.lsts
+++ b/lib2/core/sized.lsts
@@ -1,12 +1,4 @@
 
 let is(l: t, r: t): Bool = (
-   let i = 0_sz;
-   let return = true;
-   while i < sizeof(t) {
-      let li = (&l as U8[])[i];
-      let ri = (&r as U8[])[i];
-      if li != ri then return = false;
-      i = i + 1;
-   };
-   return
+   memcmp(&l as C<"void">[], &r as C<"void">[], sizeof(t) as USize) as U8 == 0
 );


### PR DESCRIPTION
## Describe your changes
Features:
* use `memcmp` to implement `is(Sized,Sized)` instead of custom implementation

## Issue ticket number and link

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
