### PR TITLE
Retain more fmpsfsp

### DIFF
--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -167,6 +167,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          );
          mark-var-to-def-todo(tctx, key, ta, term);
          if not(hint.is-t(c"MustNotRetain",0)) {
+            if typeof-term(term).is-t(c"MustRetain",0) then print("Retain Var \{key} : \{hint}\n");
             (tctx, term) = maybe-retain(tctx, term);
          }
       );

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -167,7 +167,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          );
          mark-var-to-def-todo(tctx, key, ta, term);
          if not(hint.is-t(c"MustNotRetain",0)) {
-            if typeof-term(term).is-t(c"MustRetain",0) then print("Retain Var \{key} : \{hint}\n");
             (tctx, term) = maybe-retain(tctx, term);
          }
       );

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -80,7 +80,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
       App{asc=left:Var{key:c"as"}, right:App{t=left,right:AType{tt=tt}}} => (
          tt = tt.rewrite-type-alias;
          add-concrete-type-instance(tt, term);
-         (tctx, let new-t) = std-infer-expr(tctx, t, false, used, ta);
+         (tctx, let new-t) = std-infer-expr(tctx, t, false, used, tt);
          if not(is(t,new-t)) then { t = new-t; term = mk-app(asc, mk-app(t, mk-atype(tt))); };
          let inner-tt = normalize(typeof-term(t));
          if tt.tag.has-prefix(c"Tag::") then tt = tt && inner-tt
@@ -162,7 +162,9 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             ascript(term, vt);
          );
          mark-var-to-def-todo(tctx, key, ta, term);
-         (tctx, term) = maybe-retain(tctx, term);
+         if not(hint.is-t(c"MustNotRetain",0)) {
+            (tctx, term) = maybe-retain(tctx, term);
+         }
       );
       Lit{key=key, token=token} => (
          if hint.is-t(c"Literal",0) {
@@ -253,7 +255,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                ascript(term, rt);
                if not(rt.is-t(c"Cons",2)) {
                   let function-type = typeof-term(find-global-callable(var-name-if-var-or-lit(l), typeof-term(r), term));
-                  if function-type.is-t(c"MustRetainOnCall",0) {
+                  if function-type.is-t(c"MustRetainOnCall",0) && not(hint.is-t(c"MustNotRetain",0)) {
                      (tctx, term) = maybe-retain(tctx, term);
                   }
                }

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -162,6 +162,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             ascript(term, vt);
          );
          mark-var-to-def-todo(tctx, key, ta, term);
+         (tctx, term) = maybe-retain(tctx, term);
       );
       Lit{key=key, token=token} => (
          if hint.is-t(c"Literal",0) {

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -1,9 +1,11 @@
 
-let std-bind-term(tctx: Maybe<TypeContext>, key: CString, rhs: AST, def: AST, blame: AST): (TypeContext?, Type) = (
+let std-bind-term(tctx: Maybe<TypeContext>, key: CString, rhs: AST, def: AST, blame: AST, hint: Type): (TypeContext?, Type) = (
    let rhs-tt = phi-state(tctx,typeof-term(rhs),blame);
    let tt = rhs-tt && t1(c"LocalVariable");
    (tctx, tt) = phi-fresh(tctx, tt, blame);
-   tctx = phi-move(tctx, rhs-tt, blame);
+   if not(hint.is-t(c"MustNotMove",0)) {
+      tctx = phi-move(tctx, rhs-tt, blame);
+   };
    tctx = tctx.bind(key, ta, tt, def);
    (tctx, tt)
 );
@@ -15,7 +17,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          then exit-error("Variable Name Is Already Bound In Outer Scope \{lname}", term);
          (tctx, let new-rhs) = std-infer-expr(tctx, rhs, false, Tail(), ta);
          if not(is(rhs,new-rhs)) then { rhs = new-rhs; term = mk-app(mk-abs(def,mk-nil(),misc-tt),rhs); };
-         (tctx, let tt) = std-bind-term(tctx, lname, rhs, def, term);
+         (tctx, let tt) = std-bind-term(tctx, lname, rhs, def, term, hint);
          ascript(def, tt);
          ascript(term, t1(c"Nil"));
       );
@@ -51,7 +53,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
       App{szof=left:Var{key:c"scope"}, r=right} => (
          let before-tctx = tctx;
          (let inner-tctx, let new-r) = std-infer-expr(tctx, r, true, Tail(), ta);
-         (inner-tctx, new-r) = del-locals(before-tctx, inner-tctx, new-r);
+         (inner-tctx, new-r) = del-locals(before-tctx, inner-tctx, new-r, hint);
          if not(is(r,new-r)) then { r = new-r; term = mk-app(szof, r); };
          ascript(term, typeof-term(r));
          tctx = tctx.with-pctx(inner-tctx.get-or(mk-tctx()).pctx);
@@ -140,7 +142,9 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                      if not(can-unify(rhs-tt, typeof-term(rhs)))
                      then exit-error("Return value does not match declared type:\nExpected \{rhs-tt}\nFound \{typeof-term(rhs)}\n", term);
                   };
-                  inner-tctx = phi-move(inner-tctx, typeof-term(rhs), term);
+                  if not(rhs-tt.is-t(c"MustNotMove",0)) {
+                     inner-tctx = phi-move(inner-tctx, typeof-term(rhs), term);
+                  };
                   if not(tlt.is-t(c"Blob",0) || tlt.is-t(c"C-FFI",0) || tlt.is-t(c"FFI",0) || tlt.is-t(c"Phi::Source",0) ) {
                      validate-pctx-del(inner-tctx);
                   }
@@ -184,7 +188,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          tctx = infer-ctx(tctx, lhs);
          let before-tctx = tctx;
          (tctx, let new-inner-rhs) = std-infer-expr(tctx, inner-rhs, false, Tail(), return-type);
-         (tctx, new-inner-rhs) = del-locals(before-tctx, tctx, new-inner-rhs);
+         (tctx, new-inner-rhs) = del-locals(before-tctx, tctx, new-inner-rhs, misc-tt);
          if not(is(inner-rhs,new-inner-rhs))
          then {
             inner-rhs = new-inner-rhs;
@@ -249,7 +253,9 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                   let from-tt = typeof-term(r).slot(c"Cons",2).l1;
                   let to-tt = typeof-term(r).slot(c"Cons",2).l2;
                   tctx = phi-override(tctx, from-tt, to-tt, term);
-                  tctx = phi-move(tctx, from-tt, term);
+                  if not(hint.is-t(c"MustNotMove",0)) {
+                     tctx = phi-move(tctx, from-tt, term);
+                  }
                };
                rt = phi-state(tctx, rt, term);
                ascript(term, rt);
@@ -285,7 +291,7 @@ let wrap-call(tctx: TypeContext?, fname: CString, term: AST): (TypeContext?, AST
    (tctx, result)
 );
 
-let del-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AST): (TypeContext?, AST) = (
+let del-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AST, hint: Type): (TypeContext?, AST) = (
    let tctx-before-tctx = tctx-before.get-or(mk-tctx()).tctx;
    let tctx-after-tctx = tctx-after.get-or(mk-tctx()).tctx;
    let needs-delete = [] : List<TypeContextRow>;
@@ -303,7 +309,7 @@ let del-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AST): 
       let def = mk-var(return-id);
       if not(return-type.is-t(c"Nil",0)) {
          term = mk-app( mk-abs(def, mk-nil(), ta), term ); ascript(term, t1(c"Nil"));
-         (tctx-after, let tt) = std-bind-term(tctx-after, return-id, rhs, def, term);
+         (tctx-after, let tt) = std-bind-term(tctx-after, return-id, rhs, def, term, hint);
          ascript(def, tt);
       };
       for nd in needs-delete {

--- a/SRC/without-tag.lsts
+++ b/SRC/without-tag.lsts
@@ -29,6 +29,8 @@ let .without-tag(tt: Type): Type = (
       TGround { tag:c"Phi::Transition" } => ta;
       TGround { tag:c"Phi::Initialize" } => ta;
       TGround { tag:c"Phi::State" } => ta;
+      TGround { tag:c"MustNotRetain" } => ta;
+      TGround { tag:c"MustNotMove" } => ta;
       TGround { tag:tag } => if tag.has-prefix(c"Tag::") then ta
                         else if tag.has-prefix(c"Field::") then ta
                         else tt;

--- a/lib2/core/string.lsts
+++ b/lib2/core/string.lsts
@@ -8,7 +8,7 @@ let :Phi::Source del(x: String+(MustDelete::ToDelete<'a> ~> MustDelete::Deleted)
 
 let .retain(x: String): String = (
    print(c"implicit retain\n");
-   x.data.retain; x
+   (x as MustNotRetain).data.retain; x
 );
 
 let :Phi::Source .length(s: String): USize = s.end-offset - s.start-offset;

--- a/lib2/core/string.lsts
+++ b/lib2/core/string.lsts
@@ -1,45 +1,45 @@
 
-type String suffix _ss implied phi MustDelete::ToDelete<'a> implies MustRetain
-          = { start-offset:USize, end-offset:USize, data:OwnedData<U8>[] };
+#type String suffix _ss implied phi MustDelete::ToDelete<'a> implies MustRetain
+#          = { start-offset:USize, end-offset:USize, data:OwnedData<U8>[] };
 
-let :Phi::Source del(x: String+(MustDelete::ToDelete<'a> ~> MustDelete::Deleted)): Nil = (
-   x.data.release
-);
+#let :Phi::Source del(x: String+(MustDelete::ToDelete<'a> ~> MustDelete::Deleted)): Nil = (
+#   x.data.release
+#);
 
-let .retain(x: String): String = (
-   (x as MustNotRetain+MustNotMove).data.retain; x
-);
+#let .retain(x: String): String = (
+#   (x as MustNotRetain+MustNotMove).data.retain; x
+#);
 
-let :Phi::Source .length(s: String): USize = s.end-offset - s.start-offset;
+#let .length(s: String): USize = s.end-offset - s.start-offset;
 
-let :Phi::Source cmp(l: String+(MustDelete::ToDelete<'a> ~> MustDelete::ToDelete<'a>), r: String+(MustDelete::ToDelete<'a> ~> MustDelete::ToDelete<'a>)): Ord = (
-   let l_size = l.end-offset - l.start-offset;
-   let r_size = r.end-offset - r.start-offset;
-   let c = memcmp(
-      (l.data.data + l.start-offset) as C<"void">[],
-      (r.data.data + r.start-offset) as C<"void">[],
-      min(l_size, r_size)
-   ) as I64;
-   if c < 0 then LessThan
-   else if c > 0 then GreaterThan
-   else if l_size < r_size then LessThan
-   else if l_size > r_size then GreaterThan
-   else Equal
-);
+#let cmp(l: String, r: String): Ord = (
+#   let l_size = l.end-offset - l.start-offset;
+#   let r_size = r.end-offset - r.start-offset;
+#   let c = memcmp(
+#      (l.data.data + l.start-offset) as C<"void">[],
+#      (r.data.data + r.start-offset) as C<"void">[],
+#      min(l_size, r_size)
+#   ) as I64;
+#   if c < 0 then LessThan
+#   else if c > 0 then GreaterThan
+#   else if l_size < r_size then LessThan
+#   else if l_size > r_size then GreaterThan
+#   else Equal
+#);
 
-let intern(cs: CString): String = cs.into(type(String));
-let .into(s: String, tt: Type<String>): String = s;
-let .into(cs: CString, tt: Type<String>): String = (
-   let cs_length = cs.length;
-   let od = mk-owned-data(type(U8), cs_length);
-   od.retain;
-   let csi = 0_sz;
-   while csi < cs_length {
-      od.push(cs[csi] as U8);
-      csi = csi + 1;
-   };
-   String(0 as USize, cs_length, od)
-);
+#let intern(cs: CString): String = cs.into(type(String));
+#let .into(s: String, tt: Type<String>): String = s;
+#let .into(cs: CString, tt: Type<String>): String = (
+#   let cs_length = cs.length;
+#   let od = mk-owned-data(type(U8), cs_length);
+#   od.retain;
+#   let csi = 0_sz;
+#   while csi < cs_length {
+#      od.push(cs[csi] as U8);
+#      csi = csi + 1;
+#   };
+#   String(0 as USize, cs_length, od)
+#);
 
 #let $"[:]"(s: String, begin: I64, end: I64): String = (
 #   let s_length = s.length as I64;
@@ -54,24 +54,24 @@ let .into(cs: CString, tt: Type<String>): String = (
 #   rs
 #);
 
-let :Phi::Source print(s: String+(MustDelete::ToDelete<'a> ~> MustDelete::ToDelete<'a>)): Nil = (
-   fwrite((s.data.data + s.start-offset) as C<"void">[], sizeof(U8) as USize, s.length as USize, stdout);
-   ()
-);
+#let :Phi::Source print(s: String+(MustDelete::ToDelete<'a> ~> MustDelete::ToDelete<'a>)): Nil = (
+#   fwrite((s.data.data + s.start-offset) as C<"void">[], sizeof(U8) as USize, s.length as USize, stdout);
+#   ()
+#);
 
-let :Phi::Source eprint(s: String+(MustDelete::ToDelete<'a> ~> MustDelete::ToDelete<'a>)): Nil = (
-   fwrite((s.data.data + s.start-offset) as C<"void">[], sizeof(U8) as USize, s.length as USize, stderr);
-   ()
-);
+#let :Phi::Source eprint(s: String+(MustDelete::ToDelete<'a> ~> MustDelete::ToDelete<'a>)): Nil = (
+#   fwrite((s.data.data + s.start-offset) as C<"void">[], sizeof(U8) as USize, s.length as USize, stderr);
+#   ()
+#);
 
-let :Phi::Source $"+"(l: String+(MustDelete::ToDelete<'a> ~> MustDelete::ToDelete<'a>), r: String+(MustDelete::ToDelete<'a> ~> MustDelete::ToDelete<'a>)): String = (
-   let l_length = l.length;
-   let r_length = r.length;
-   let cs_length = l_length + r_length;
-   let od = mk-owned-data(type(U8), cs_length);
-   od.retain;
-   memcpy(od.data as C<"void">[], l.data.data as C<"void">[], l_length as USize);
-   memcpy((od.data + l_length) as C<"void">[], r.data.data as C<"void">[], r_length as USize);
-   String(0 as USize, cs_length, od) 
-);
+#let :Phi::Source $"+"(l: String+(MustDelete::ToDelete<'a> ~> MustDelete::ToDelete<'a>), r: String+(MustDelete::ToDelete<'a> ~> MustDelete::ToDelete<'a>)): String = (
+#   let l_length = l.length;
+#   let r_length = r.length;
+#   let cs_length = l_length + r_length;
+#   let od = mk-owned-data(type(U8), cs_length);
+#   od.retain;
+#   memcpy(od.data as C<"void">[], l.data.data as C<"void">[], l_length as USize);
+#   memcpy((od.data + l_length) as C<"void">[], r.data.data as C<"void">[], r_length as USize);
+#   String(0 as USize, cs_length, od) 
+#);
 

--- a/lib2/core/string.lsts
+++ b/lib2/core/string.lsts
@@ -7,8 +7,7 @@ let :Phi::Source del(x: String+(MustDelete::ToDelete<'a> ~> MustDelete::Deleted)
 );
 
 let .retain(x: String): String = (
-   print(c"implicit retain\n");
-   (x as MustNotRetain).data.retain; x
+   (x as MustNotRetain+MustNotMove).data.retain; x
 );
 
 let :Phi::Source .length(s: String): USize = s.end-offset - s.start-offset;

--- a/lib2/core/u64.lsts
+++ b/lib2/core/u64.lsts
@@ -32,26 +32,26 @@ let cmp(l: U64, r: U64): Ord = (
    else Equal
 );
 
-let .into(i: U64, tt: Type<String>): String = (
-   let od = mk-owned-data(type(U8), 20_sz);
-   let cs_length = 0_sz;
-   if i == 0_u64 {
-      od.push(48);
-      cs_length = cs_length + 1;
-   };
-   while i != 0_u64 {
-      od.push(48 + ((i % 10) as U8));
-      cs_length = cs_length + 1;
-      i = i / 10;
-   };
-   let start_i = 0_sz;
-   let end_i = cs_length - 1_sz;
-   while start_i < end_i {
-      let tmpc = od.data[start_i];
-      od.data[start_i] = od.data[end_i];
-      od.data[end_i] = tmpc;
-      start_i = start_i + 1_sz;
-      end_i = end_i - 1_sz;
-   };
-   String(0 as USize, cs_length, od)
-);
+#let .into(i: U64, tt: Type<String>): String = (
+#   let od = mk-owned-data(type(U8), 20_sz);
+#   let cs_length = 0_sz;
+#   if i == 0_u64 {
+#      od.push(48);
+#      cs_length = cs_length + 1;
+#   };
+#   while i != 0_u64 {
+#      od.push(48 + ((i % 10) as U8));
+#      cs_length = cs_length + 1;
+#      i = i / 10;
+#   };
+#   let start_i = 0_sz;
+#   let end_i = cs_length - 1_sz;
+#   while start_i < end_i {
+#      let tmpc = od.data[start_i];
+#      od.data[start_i] = od.data[end_i];
+#      od.data[end_i] = tmpc;
+#      start_i = start_i + 1_sz;
+#      end_i = end_i - 1_sz;
+#   };
+#   String(0 as USize, cs_length, od)
+#);

--- a/lib2/core/usize.lsts
+++ b/lib2/core/usize.lsts
@@ -1,6 +1,6 @@
 
 type opaque alias USize suffix _sz
-     implies I64, U64, C<"size_t">
+     implies U64, C<"size_t">
      = C<"size_t">;
 
 declare-binop( $"!=", raw-type(USize), raw-type(USize), raw-type(Bool), ( l"("; x; l"!="; y; l")"; ) );

--- a/tests/promises/retain/constructor.lsts
+++ b/tests/promises/retain/constructor.lsts
@@ -5,10 +5,11 @@ type A implies MustRetain = {};
 
 let .retain(x: A): A = (
    print(c"retain\n");
-   x
+   x as MustNotRetain
 );
 
 A();
+A() as MustNotRetain;
 
 # Retains happen when
 # 1) The type is MustRetain

--- a/tests/promises/retain/local.lsts
+++ b/tests/promises/retain/local.lsts
@@ -9,7 +9,7 @@ let .retain(x: A): A = (
 );
 
 if true {
-   let a = A();
+   let a = A() as MustNotRetain;
    let b = a;
    let c = a as MustNotRetain;
 };

--- a/tests/promises/retain/local.lsts
+++ b/tests/promises/retain/local.lsts
@@ -5,13 +5,14 @@ type A implies MustRetain = {};
 
 let .retain(x: A): A = (
    print(c"retain\n");
-   x
+   x as MustNotRetain
 );
 
 if true {
    let a = A();
-   let b = a;
+   let b = a as MustNotRetain;
 };
+
 # Retains happen when
 # 1) The type is MustRetain
 # 2) The reference count might go up

--- a/tests/promises/retain/local.lsts
+++ b/tests/promises/retain/local.lsts
@@ -10,7 +10,8 @@ let .retain(x: A): A = (
 
 if true {
    let a = A();
-   let b = a as MustNotRetain;
+   let b = a;
+   let c = a as MustNotRetain;
 };
 
 # Retains happen when

--- a/tests/promises/retain/local.lsts.out
+++ b/tests/promises/retain/local.lsts.out
@@ -1,2 +1,1 @@
 retain
-retain

--- a/tests/promises/retain/local.lsts.out
+++ b/tests/promises/retain/local.lsts.out
@@ -1,1 +1,2 @@
 retain
+retain

--- a/tests/promises/retain/variable.lsts
+++ b/tests/promises/retain/variable.lsts
@@ -1,0 +1,21 @@
+
+import lib2/core/bedrock.lsts;
+
+type A implies MustRetain = {};
+
+let .retain(x: A): A = (
+   print(c"retain\n");
+   x
+);
+
+if true {
+   let a = A();
+   let b = a;
+};
+# Retains happen when
+# 1) The type is MustRetain
+# 2) The reference count might go up
+
+# Retains might be a noop
+# However, they always result in a nominal call to a .retain
+# For example, linear types can be used to "remove" unnecessary retain calls

--- a/tests/promises/retain/variable.lsts.out
+++ b/tests/promises/retain/variable.lsts.out
@@ -1,0 +1,2 @@
+retain
+retain


### PR DESCRIPTION
## Describe your changes
Features:
* retain variable references
* moves and retains can always be manually overridden with `MustNotMove` and `MustNotRetain`
* this is a somewhat temporary feature as we learn patterns of where these features can be implied
* the goal is to be 100% correct, not overzealous, or under-specified
* this way we can close the gap from both directions, eventually making almost all interactions implicit

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1540

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
