### PR TITLE
Retain flsdfcmpq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/retain/constructor.lsts
+	lm tests/promises/retain/field-access.lsts
 	cc tmp.c
 	./a.out
 

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -1255,47 +1255,6 @@ let lsts-parse-small-expression(tokens: List<Token>): Tuple<AST,List<Token>> = (
             )
          );         
       );
-      [Token{key:c"match2"}.. rest] => (
-         (base, tokens) = lsts-parse-match2(tokens);
-      );
-      [Token{key:c"match"}.. rest] => (
-         let loc = head(tokens).location; tokens = rest;
-         
-         let raw = if lsts-parse-head(tokens)==c"raw" {
-            tokens = tail(tokens); true;
-         } else false;
-         let e-rest = lsts-parse-small-expression(tokens);
-         tokens = e-rest.second;
-         if raw {
-            e-rest.first = mk-app(
-               Var( c"macro::bind-raw", with-location(mk-token("macro::bind-raw"),loc) ),
-               e-rest.first
-            );
-         };
-         let pats = mk-nil();
-         lsts-parse-expect(c"{", tokens); tokens = tail(tokens);
-         while non-zero(tokens) && lsts-parse-head(tokens)!=c"}" {
-            let lhs-rest = lsts-parse-lhs(tokens);
-            tokens = lhs-rest.second;
-            lsts-parse-expect(c"=", tokens); tokens = tail(tokens);
-            lsts-parse-expect(c">", tokens); tokens = tail(tokens);
-            if lsts-parse-head(tokens) == c"{" {
-               fail("Please wrap map literals in match cases in parenthesis. At \{tokens.formatted-location}\n");
-            };
-            let rhs-rest = lsts-parse-small-expression(tokens);
-            tokens = rhs-rest.second;
-            lsts-parse-expect(c";", tokens); tokens = tail(tokens);
-            pats = mk-cons(pats, mk-cons(lhs-rest.first, rhs-rest.first));
-         };
-         lsts-parse-expect(c"}", tokens); tokens = tail(tokens);
-         base = mk-app(
-            mk-app(
-               Var( c"match", with-location(mk-token("match"),loc) ),
-               e-rest.first
-            ),
-            pats
-         );
-      );
       _ => (
          let assign-rest = lsts-parse-assign(tokens);
          base = assign-rest.first;
@@ -1855,6 +1814,44 @@ let lsts-parse-atom-without-tail(tokens: List<Token>): Tuple<AST,List<Token>> = 
       tokens = term-rest.second;
       lsts-parse-expect(c")", tokens); tokens = tail(tokens);
       term = AType( term-rest.first );
+   } else if lsts-parse-head(tokens)==c"match2" {
+      (term, tokens) = lsts-parse-match2(tokens);
+   } else if lsts-parse-head(tokens)==c"match" {
+      let loc = head(tokens).location; tokens = tail(tokens);
+      let raw = if lsts-parse-head(tokens)==c"raw" {
+         tokens = tail(tokens); true;
+      } else false;
+      let e-rest = lsts-parse-small-expression(tokens);
+      tokens = e-rest.second;
+      if raw {
+         e-rest.first = mk-app(
+            Var( c"macro::bind-raw", with-location(mk-token("macro::bind-raw"),loc) ),
+            e-rest.first
+         );
+      };
+      let pats = mk-nil();
+      lsts-parse-expect(c"{", tokens); tokens = tail(tokens);
+      while non-zero(tokens) && lsts-parse-head(tokens)!=c"}" {
+         let lhs-rest = lsts-parse-lhs(tokens);
+         tokens = lhs-rest.second;
+         lsts-parse-expect(c"=", tokens); tokens = tail(tokens);
+         lsts-parse-expect(c">", tokens); tokens = tail(tokens);
+         if lsts-parse-head(tokens) == c"{" {
+            fail("Please wrap map literals in match cases in parenthesis. At \{tokens.formatted-location}\n");
+         };
+         let rhs-rest = lsts-parse-small-expression(tokens);
+         tokens = rhs-rest.second;
+         lsts-parse-expect(c";", tokens); tokens = tail(tokens);
+         pats = mk-cons(pats, mk-cons(lhs-rest.first, rhs-rest.first));
+      };
+      lsts-parse-expect(c"}", tokens); tokens = tail(tokens);
+      term = mk-app(
+         mk-app(
+            Var( c"match", with-location(mk-token("match"),loc) ),
+            e-rest.first
+         ),
+         pats
+      );
    } else if lsts-parse-head(tokens).has-suffix(c"_ss") {
       (term, tokens) = lsts-parse-lit(tokens);
    } else if lsts-parse-head(tokens).has-suffix(c"_rl") {

--- a/SRC/can-unify.lsts
+++ b/SRC/can-unify.lsts
@@ -14,6 +14,7 @@ let can-unify(fpt: Type, pt: Type): U64 = (
    match (Tuple(fpt, pt)) {
       Tuple{ first:TAny{} } => true;
       Tuple{ first:TGround{tag:c"Any"} } => true;
+      Tuple{ first:TGround{tag:c"MustNotRetain"} } => true;
       Tuple{ first:TGround{tag:c"Phi::Initialize"} } => true;
       Tuple{ first:TGround{tag:c"Linear",parameters:[_..]}, second:TGround{tag:c"Linear",parameters:[_..]} } => true;
       Tuple{ first:TVar{}, second:TGround{tag:c"Cons"} } => false;
@@ -25,6 +26,7 @@ let can-unify(fpt: Type, pt: Type): U64 = (
          for lc in lconjugate {
             if result then (match lc {
                TGround{tag:c"Any"} => ();
+               TGround{tag:c"MustNotRetain"} => ();
                TGround{tag:c"Phi::Initialize",parameters:[phi-expect..]} => (
                   let pt-phi-state = ta;
                   for rct in rconjugate { match rct {

--- a/SRC/maybe-not-retain-args.lsts
+++ b/SRC/maybe-not-retain-args.lsts
@@ -1,0 +1,26 @@
+
+let maybe-not-retain-args(tctx: TypeContext?, function-type: Type, term: AST): (TypeContext?, AST) = (
+   match term {
+      App{left=left, right=right} => (
+         (tctx, let new-right) = maybe-not-retain-args-each(tctx, function-type.domain, right);
+         if not(is(right,new-right)) then term = mk-app(left, new-right);
+         (tctx, term)
+      );
+   }
+);
+
+let maybe-not-retain-args-each(tctx: TypeContext?, args-type: Type, args: AST): (TypeContext?, AST) = (
+   if args-type.is-t(c"Cons",2) then (match args {
+      App{left=left,right=right} => (
+         (tctx, let new-left) = maybe-not-retain-args-each(tctx, args-type.slot(c"Cons",2).l1, left);
+         (tctx, let new-right) = maybe-not-retain-args-one(tctx, args-type.slot(c"Cons",1).l2, right);
+         if not(is(left,new-left)) || not(is(right,new-right)) then args = mk-cons(new-left,new-right);
+         (tctx, args)
+      );
+   }) else maybe-not-retain-args-one(tctx, args-type, args)
+);
+
+let maybe-not-retain-args-one(tctx: TypeContext?, args-type: Type, args: AST): (TypeContext?, AST) = (
+   if args-type.is-t(c"MustNotRetain",0) then print("MustNotRetain \{args-type} \{args}\n");
+   (tctx, args)
+);

--- a/SRC/maybe-not-retain-args.lsts
+++ b/SRC/maybe-not-retain-args.lsts
@@ -3,7 +3,11 @@ let maybe-not-retain-args(tctx: TypeContext?, function-type: Type, term: AST): (
    match term {
       App{left=left, right=right} => (
          (tctx, let new-right) = maybe-not-retain-args-each(tctx, function-type.domain, right);
-         if not(is(right,new-right)) then term = mk-app(left, new-right);
+         if not(is(right,new-right)) {
+            let new-term = mk-app(left, new-right);
+            ascript(new-term, typeof-term(term));
+            term = new-term;
+         };
          (tctx, term)
       );
    }
@@ -14,13 +18,22 @@ let maybe-not-retain-args-each(tctx: TypeContext?, args-type: Type, args: AST): 
       App{left=left,right=right} => (
          (tctx, let new-left) = maybe-not-retain-args-each(tctx, args-type.slot(c"Cons",2).l1, left);
          (tctx, let new-right) = maybe-not-retain-args-one(tctx, args-type.slot(c"Cons",1).l2, right);
-         if not(is(left,new-left)) || not(is(right,new-right)) then args = mk-cons(new-left,new-right);
+         if not(is(left,new-left)) || not(is(right,new-right)) {
+            let new-args = mk-cons(new-left,new-right);
+            ascript(new-args, t3(c"Cons",typeof-term(new-left),typeof-term(new-right)));
+            args = new-args;
+         };
          (tctx, args)
       );
    } else maybe-not-retain-args-one(tctx, args-type, args)
 );
 
 let maybe-not-retain-args-one(tctx: TypeContext?, args-type: Type, args: AST): (TypeContext?, AST) = (
-   if args-type.is-t(c"MustNotRetain",0) then print("MustNotRetain \{args-type} \{args}\n");
+   if args-type.is-t(c"MustNotRetain",0) then match args {
+      App{left:Var{key:c".retain"},right=right} => args = right;
+      _ => (
+         if typeof-term(args).is-t(c"MustRetain",0) then exit-error("TODO: MustNotRetain arg cannot be structurally unretained",args);
+      );
+   };
    (tctx, args)
 );

--- a/SRC/maybe-not-retain-args.lsts
+++ b/SRC/maybe-not-retain-args.lsts
@@ -10,14 +10,14 @@ let maybe-not-retain-args(tctx: TypeContext?, function-type: Type, term: AST): (
 );
 
 let maybe-not-retain-args-each(tctx: TypeContext?, args-type: Type, args: AST): (TypeContext?, AST) = (
-   if args-type.is-t(c"Cons",2) then (match args {
+   if args-type.is-t(c"Cons",2) then match args {
       App{left=left,right=right} => (
          (tctx, let new-left) = maybe-not-retain-args-each(tctx, args-type.slot(c"Cons",2).l1, left);
          (tctx, let new-right) = maybe-not-retain-args-one(tctx, args-type.slot(c"Cons",1).l2, right);
          if not(is(left,new-left)) || not(is(right,new-right)) then args = mk-cons(new-left,new-right);
          (tctx, args)
       );
-   }) else maybe-not-retain-args-one(tctx, args-type, args)
+   } else maybe-not-retain-args-one(tctx, args-type, args)
 );
 
 let maybe-not-retain-args-one(tctx: TypeContext?, args-type: Type, args: AST): (TypeContext?, AST) = (

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -261,6 +261,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                ascript(term, rt);
                if not(rt.is-t(c"Cons",2)) {
                   let function-type = typeof-term(find-global-callable(var-name-if-var-or-lit(l), typeof-term(r), term));
+                  (tctx, term) = maybe-not-retain-args(tctx, function-type, term);
                   if function-type.is-t(c"MustRetainOnCall",0) && not(hint.is-t(c"MustNotRetain",0)) {
                      (tctx, term) = maybe-retain(tctx, term);
                   }

--- a/SRC/unify.lsts
+++ b/SRC/unify.lsts
@@ -14,6 +14,7 @@ let unify-inner(fpt: Type, pt: Type, blame: AST): Maybe<TypeContext> = (
    match (Tuple(fpt, pt)) {
       Tuple{ first:TAny{} } => ctx = yes;
       Tuple{ first:TGround{tag:c"Any"} } => ctx = yes;
+      Tuple{ first:TGround{tag:c"MustNotRetain"} } => ctx = yes;
       Tuple{ first:TGround{tag:c"Phi::Initialize"} } => ctx = yes;
       Tuple{ first:TVar{}, second:TGround{tag:c"Cons"} } => no;
       Tuple{ first:TVar{name=name}, second:TGround{tag=tag} } => (
@@ -31,6 +32,7 @@ let unify-inner(fpt: Type, pt: Type, blame: AST): Maybe<TypeContext> = (
          for lc in lconjugate {
             if result.is-some then (match lc {
                TGround{tag:c"Any"} => ();
+               TGround{tag:c"MustNotRetain"} => ();
                TGround{tag:c"Phi::Initialize"} => ();
                TGround{tag:c"Phi::Transition", parameters:[phi-to..phi-from..]} => (
                   let scan-states = true;

--- a/SRC/unit-orphans.lsts
+++ b/SRC/unit-orphans.lsts
@@ -37,6 +37,7 @@ import SRC/expand-implied-phi.lsts;
 import SRC/phi-specialize.lsts;
 import SRC/with-only-phi.lsts;
 import SRC/maybe-retain.lsts;
+import SRC/maybe-not-retain-args.lsts;
 
 let .unroll-seq(t: AST): Vector<AST> = (
    match t {

--- a/lib2/core/platform-macros.lsts
+++ b/lib2/core/platform-macros.lsts
@@ -5,6 +5,12 @@ deprecated macro (rl"declare-unop"(op-alias, x-type, r-type, op-expr)) (
       $":frame"($":frame"(x));
    );
 );
+deprecated macro (rl"declare-unop-retain"(op-alias, x-type, r-type, op-expr)) (
+   let :Blob+MustRetainOnCall op-alias(x: x-type): r-type = (
+      $":expression"(op-expr);
+      $":frame"($":frame"(x));
+   );
+);
 
 deprecated macro (rl"declare-binop"(op-alias, x-type, y-type, r-type, op-expr)) (
    let :Blob op-alias(x: x-type, y: y-type): r-type = (

--- a/lib2/core/primitives.lsts
+++ b/lib2/core/primitives.lsts
@@ -35,10 +35,10 @@ let :Blob $"primitive::call"(ictx: ImplicitContext, args: Any): Nil = (
 );
 
 declare-unop( $".discriminator-case-tag", raw-type(LM2Struct+CaseNumber<cn>), raw-type(USize), ( l"("; cn : L; l")"; ) );
-declare-unop( $".discriminator-case-tag", raw-type(LM2Struct), raw-type(USize), ( l"("; x; l".discriminator_case_tag)"; ) );
+declare-unop( $".discriminator-case-tag", raw-type(LM2Struct+MustNotRetain), raw-type(USize), ( l"("; x; l".discriminator_case_tag)"; ) );
 
-declare-unop( $"primitive::field-get", raw-type(base-type), raw-type(field-type), ( l"("; x; l"."; mangle(field-name : L); l")"; ) );
-declare-binop( $"primitive::field-set", raw-type(base-type), raw-type(field-type), raw-type(Nil), ( l"("; x; l"."; mangle(field-name : L); l"="; y; l")"; ) );
+declare-unop( $"primitive::field-get", raw-type(base-type+MustNotRetain), raw-type(field-type), ( l"("; x; l"."; mangle(field-name : L); l")"; ) );
+declare-binop( $"primitive::field-set", raw-type(base-type+MustNotRetain), raw-type(field-type), raw-type(Nil), ( l"("; x; l"."; mangle(field-name : L); l"="; y; l")"; ) );
 
 declare-unop( $"primitive::field-get-indirect", raw-type(base-type[]), raw-type(field-type), ( l"("; x; l"->"; mangle(field-name : L); l")"; ) );
 declare-binop( $"primitive::field-set-indirect", raw-type(base-type[]), raw-type(field-type), raw-type(Nil), ( l"("; x; l"->"; mangle(field-name : L); l"="; y; l")"; ) );

--- a/lib2/core/primitives.lsts
+++ b/lib2/core/primitives.lsts
@@ -37,8 +37,8 @@ let :Blob $"primitive::call"(ictx: ImplicitContext, args: Any): Nil = (
 declare-unop( $".discriminator-case-tag", raw-type(LM2Struct+CaseNumber<cn>), raw-type(USize), ( l"("; cn : L; l")"; ) );
 declare-unop( $".discriminator-case-tag", raw-type(LM2Struct+MustNotRetain), raw-type(USize), ( l"("; x; l".discriminator_case_tag)"; ) );
 
-declare-unop( $"primitive::field-get", raw-type(base-type+MustNotRetain), raw-type(field-type), ( l"("; x; l"."; mangle(field-name : L); l")"; ) );
+declare-unop-retain( $"primitive::field-get", raw-type(base-type+MustNotRetain), raw-type(field-type), ( l"("; x; l"."; mangle(field-name : L); l")"; ) );
 declare-binop( $"primitive::field-set", raw-type(base-type+MustNotRetain), raw-type(field-type), raw-type(Nil), ( l"("; x; l"."; mangle(field-name : L); l"="; y; l")"; ) );
 
-declare-unop( $"primitive::field-get-indirect", raw-type(base-type[]), raw-type(field-type), ( l"("; x; l"->"; mangle(field-name : L); l")"; ) );
+declare-unop-retain( $"primitive::field-get-indirect", raw-type(base-type[]), raw-type(field-type), ( l"("; x; l"->"; mangle(field-name : L); l")"; ) );
 declare-binop( $"primitive::field-set-indirect", raw-type(base-type[]), raw-type(field-type), raw-type(Nil), ( l"("; x; l"->"; mangle(field-name : L); l"="; y; l")"; ) );

--- a/tests/promises/retain/complex-constructor.lsts
+++ b/tests/promises/retain/complex-constructor.lsts
@@ -1,0 +1,13 @@
+
+import lib2/core/bedrock.lsts;
+
+type A implies MustRetain = {};
+type B implies MustRetain = { a: A };
+
+let .retain(x: x): x = (
+   print(c"retain\n");
+   x as MustNotRetain
+);
+
+let a = A() as MustNotRetain;
+let b = B(a);

--- a/tests/promises/retain/complex-constructor.lsts
+++ b/tests/promises/retain/complex-constructor.lsts
@@ -4,8 +4,12 @@ import lib2/core/bedrock.lsts;
 type A implies MustRetain = {};
 type B implies MustRetain = { a: A };
 
-let .retain(x: x): x = (
-   print(c"retain\n");
+let .retain(x: A): A = (
+   print(c"retain A\n");
+   x as MustNotRetain
+);
+let .retain(x: B): B = (
+   print(c"retain B\n");
    x as MustNotRetain
 );
 

--- a/tests/promises/retain/complex-constructor.lsts.out
+++ b/tests/promises/retain/complex-constructor.lsts.out
@@ -1,2 +1,2 @@
-retain
-retain
+retain A
+retain B

--- a/tests/promises/retain/complex-constructor.lsts.out
+++ b/tests/promises/retain/complex-constructor.lsts.out
@@ -1,0 +1,2 @@
+retain
+retain

--- a/tests/promises/retain/field-access.lsts
+++ b/tests/promises/retain/field-access.lsts
@@ -1,0 +1,8 @@
+
+import lib2/core/default.lsts;
+
+type A implies MustRetain = {};
+type B implies MustRetain = { a: A };
+
+let a = A() as MustNotRetain;
+let b = B(a as MustNotRetain) as MustNotRetain;

--- a/tests/promises/retain/field-access.lsts
+++ b/tests/promises/retain/field-access.lsts
@@ -1,8 +1,18 @@
 
-import lib2/core/default.lsts;
+import lib2/core/bedrock.lsts;
 
 type A implies MustRetain = {};
 type B implies MustRetain = { a: A };
 
+let .retain(x: A): A = (
+   print(c"retain A\n");
+   x as MustNotRetain
+);
+let .retain(x: B): B = (
+   print(c"retain B\n");
+   x as MustNotRetain
+);
+
 let a = A() as MustNotRetain;
 let b = B(a as MustNotRetain) as MustNotRetain;
+b.a;

--- a/tests/promises/retain/field-access.lsts.out
+++ b/tests/promises/retain/field-access.lsts.out
@@ -1,0 +1,1 @@
+retain A


### PR DESCRIPTION
## Describe your changes
Features:
* `match` is now an atom, so it can be used basically anywhere
* arguments can be marked as MustNotRetain to avoid automatic retains / or to automatically discard
* fields are retained correctly now

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1540

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
