### PR TITLE
fixed global variable return position count

### DIFF
--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -166,7 +166,8 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             ascript(term, vt);
          );
          mark-var-to-def-todo(tctx, key, ta, term);
-         if not(hint.is-t(c"TailPosition",0))
+         # TailPosition LocalVariables don't need to be retained because +1/-1 retain/release cancels itself out
+         if not(hint.is-t(c"TailPosition",0) && typeof-term(term).is-t(c"LocalVariable",0))
          && not(hint.is-t(c"MustNotRetain",0))
          && not(tctx.get-or(mk-tctx()).is-blob) {
             (tctx, term) = maybe-retain(tctx, term);


### PR DESCRIPTION
## Describe your changes
Features:
* fixed a count of return position global variables
* they still need to be retained on reference,
* unlike local variables that can just be returned instead of retain/release'ing them

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1540

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
