### PR TITLE
All bedrock String functions working with GC enabled

### DIFF
--- a/lib2/core/string.lsts
+++ b/lib2/core/string.lsts
@@ -53,28 +53,27 @@ let .into(cs: CString, tt: Type<String>): String = (
    String(0 as USize, cs_length, od)
 );
 
-#let $"[:]"(s: String, begin: I64, end: I64): String = (
-#   let s_length = s.length as I64;
-#   if end == minimum-I64 then end = s_length;
-#   if begin < 0_i64 then begin = s_length + begin;
-#   if end < 0_i64 then end = s_length + end;
-#   if begin < 0_i64 or begin > s_length then fail(c"String [:] Slice Start Index Out of Bounds");
-#   if end < 0_i64 or end > s_length then fail(c"String [:] Slice End Index Out of Bounds");
-#   let start_offset = ((s.start-offset as I64) + begin) as USize;
-#   let end_offset = ((s.start-offset as I64) + end) as USize;
-#   let rs = String(start_offset, end_offset, s.data);
-#   rs
-#);
+let $"[:]"(s: String, begin: I64, end: I64): String = (
+   let s_length = s.length as I64;
+   if end == minimum-I64 then end = s_length;
+   if begin < 0_i64 then begin = s_length + begin;
+   if end < 0_i64 then end = s_length + end;
+   if begin < 0_i64 or begin > s_length then fail(c"String [:] Slice Start Index Out of Bounds");
+   if end < 0_i64 or end > s_length then fail(c"String [:] Slice End Index Out of Bounds");
+   let start_offset = ((s.start-offset as I64) + begin) as USize;
+   let end_offset = ((s.start-offset as I64) + end) as USize;
+   String(start_offset, end_offset, s.data)
+);
 
-#let :Phi::Source print(s: String+(MustRelease::ToRelease<'a> ~> MustRelease::ToRelease<'a>)): Nil = (
-#   fwrite((s.data.data + s.start-offset) as C<"void">[], sizeof(U8) as USize, s.length as USize, stdout);
-#   ()
-#);
+let print(s: String): Nil = (
+   fwrite((s.data.data + s.start-offset) as C<"void">[], sizeof(U8) as USize, s.length as USize, stdout);
+   ()
+);
 
-#let :Phi::Source eprint(s: String+(MustRelease::ToRelease<'a> ~> MustRelease::ToRelease<'a>)): Nil = (
-#   fwrite((s.data.data + s.start-offset) as C<"void">[], sizeof(U8) as USize, s.length as USize, stderr);
-#   ()
-#);
+let eprint(s: String): Nil = (
+   fwrite((s.data.data + s.start-offset) as C<"void">[], sizeof(U8) as USize, s.length as USize, stderr);
+   ()
+);
 
 let $"+"(l: String, r: String): String = (
    let l_length = l.length;

--- a/tests/promises/string/comparison.lsts
+++ b/tests/promises/string/comparison.lsts
@@ -28,18 +28,13 @@ assert( "a" + "b" == "ab" );
 assert( "ab" + "" == "ab" );
 assert( safe-alloc-block-count == 0 );
 
-#assert( "a"[1 : 1] == "" );
-#assert( "ab"[0 : 1] == "a" );
-#assert( "ab"[1 : 2] == "b" );
-#assert( "a"[1 : ] == "" );
-#assert( "ab"[1 : ] == "b" );
-#assert( "ab"[ : 1] == "a" );
-#assert( "ab"[-1 : ] == "b" );
-#assert( "ab"[ : -1] == "a" );
-#assert( "ab"[ : ] == "ab" );
-
-#assert( "abc"[0] == 'a' );
-#assert( "abc"[1] == 'b' );
-#assert( "abc"[2] == 'c' );
-
+assert( "a"[1 : 1] == "" );
+assert( "ab"[0 : 1] == "a" );
+assert( "ab"[1 : 2] == "b" );
+assert( "a"[1 : ] == "" );
+assert( "ab"[1 : ] == "b" );
+assert( "ab"[ : 1] == "a" );
+assert( "ab"[-1 : ] == "b" );
+assert( "ab"[ : -1] == "a" );
+assert( "ab"[ : ] == "ab" );
 assert( safe-alloc-block-count == 0 );


### PR DESCRIPTION
## Describe your changes
Features:
* All current bedrock functionality for String is working with GC-enabled
* there are currently 0 (!!!) additional annotations necessary to accomplish this
* GC-enabled string requires
   * mark the base type as `MustRetain, MustRelease`
   * implement appropriate `.retain` and `.release` functions

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1675

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
