### PR TITLE
Lib2 compiler v3 steady progress

### DIFF
--- a/LM/type-compare.lsts
+++ b/LM/type-compare.lsts
@@ -1,0 +1,38 @@
+
+let cmp(left: Type, right: Type): Ord = (
+   match left {
+      #TGround { ltag=tag, lparameters=parameters } => (match right {
+      #   TGround { rtag=tag, rparameters=parameters } => (
+      #      let c1 = cmp(ltag,rtag);
+      #      if c1!=Equal() then c1 else cmp(lparameters, rparameters)
+      #   );
+      #   _ => cmp($".discriminator-case-tag"(left), $".discriminator-case-tag"(right));
+      #});
+      #TAnd{ lconjugate=conjugate } => (match right {
+      #   TAnd{ rconjugate=conjugate } => (
+      #      let result = Equal();
+      #      if lconjugate.length < rconjugate.length then result = LessThan()
+      #      else if lconjugate.length > rconjugate.length then result = GreaterThan()
+      #      else {
+      #         let ci = 0_u64;
+      #         while ci < lconjugate.length && result==(Equal()) {
+      #            result = result && cmp(lconjugate[ci], rconjugate[ci]);
+      #            ci = ci + 1;
+      #         };
+      #      };
+      #      result;
+      #   );
+      #   _ => cmp($".discriminator-case-tag"(left), $".discriminator-case-tag"(right));
+      #});
+      #TVar{ left-name=name } => (match right {
+      #   TVar{ right-name=name } => (
+      #      cmp(left-name,right-name)
+      #   );
+      #   _ => cmp($".discriminator-case-tag"(left), $".discriminator-case-tag"(right));
+      #});
+      TAny{} => (match right {
+         TAny{} => Equal;
+      #   _ => cmp($".discriminator-case-tag"(left), $".discriminator-case-tag"(right));
+      });
+   }
+);

--- a/LM/type-constructor.lsts
+++ b/LM/type-constructor.lsts
@@ -1,0 +1,2 @@
+
+let ta = TAny;

--- a/LM/type-definition.lsts
+++ b/LM/type-definition.lsts
@@ -1,7 +1,9 @@
 
 # TGround needs to be the first type (tag 0) or else sorted unification will not work right
 type Type zero TAny
-        = TGround { tag:CString, parameters:Vector<Type> }
+        =
+        #| TGround { tag:CString, parameters:Vector<Type> }
         | TAny	
-        | TVar { name:CString }
-        | TAnd { conjugate:Vector<Type> };
+        #| TVar { name:CString }
+        #| TAnd { conjugate:Vector<Type> };
+        ;

--- a/LM/type-definition.lsts
+++ b/LM/type-definition.lsts
@@ -1,9 +1,7 @@
 
 # TGround needs to be the first type (tag 0) or else sorted unification will not work right
 type Type zero TAny
-        =
-        #| TGround { tag:CString, parameters:Vector<Type> }
+        = TGround { tag:CString, parameters:Vector<Type> }
         | TAny	
-        #| TVar { name:CString }
-        #| TAnd { conjugate:Vector<Type> };
-        ;
+        | TVar { name:CString }
+        | TAnd { conjugate:Vector<Type> };

--- a/LM/unit-type-core.lsts
+++ b/LM/unit-type-core.lsts
@@ -1,2 +1,5 @@
 
+import lib2/core/bedrock.lsts;
 import LM/type-definition.lsts;
+import LM/type-constructor.lsts;
+import LM/type-compare.lsts;

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -90,30 +90,50 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          ascript(term, tt);
       );
       App{left:App{ left:App{ ifv=left:Var{key:c"if"}, cond=right }, t=right }, f=right} => (
-         if is-scoped {
-            (let tctx-inner, let new-cond) = std-infer-expr(tctx, cond, false, Tail(), ta);
-            tctx = tctx.with-pctx(tctx-inner.get-or(mk-tctx()).pctx);
-            (let tctx-t, let new-t) = std-infer-expr(tctx-inner, t, false, Tail(), ta);
-            (let tctx-f, let new-f) = std-infer-expr(tctx, f, false, Tail(), ta);
-            if not(is(cond,new-cond)) || not(is(t,new-t)) || not(is(f,new-f))
-            then { cond = new-cond; t = new-t; f = new-f; term = mk-app(mk-app(mk-app(ifv,new-cond),new-t),new-f) };
-            tctx = tctx.with-pctx( phi-merge(tctx,tctx-t.get-or(mk-tctx()).pctx,tctx-f.get-or(mk-tctx()).pctx,term) );
+         let short-circuit = ASTEOF;
+         match cond {
+            App{ left:Var{key:c"<:"}, right:App{left:AType{lt=tt},right:AType{rt=tt}} } => (
+               lt = denormalize-strong(lt.slot(c"Type",1).l1);
+               rt = denormalize-strong(rt.slot(c"Type",1).l1);
+               if non-zero(lt) && non-zero(rt) {
+                  if can-unify(rt, lt) {
+                     (tctx, short-circuit) = std-infer-expr(tctx, t, false, Tail, ta);
+                  } else {
+                     (tctx, short-circuit) = std-infer-expr(tctx, f, false, Tail, ta);
+                  }
+               };
+            );
+            _ => ();
+         };
+         if non-zero(short-circuit) {
+            term = short-circuit;
          } else {
-            (tctx, let new-cond) = std-infer-expr(tctx, cond, false, Tail(), ta);
-            (let tctx-t, let new-t) = std-infer-expr(tctx, t, false, Tail(), ta);
-            (let tctx-f, let new-f) = std-infer-expr(tctx, f, false, Tail(), ta);
-            tctx = tctx-t;
-            if not(is(cond,new-cond)) || not(is(t,new-t)) || not(is(f,new-f))
-            then { cond = new-cond; t = new-t; f = new-f; term = mk-app(mk-app(mk-app(ifv,new-cond),new-t),new-f) };
-            tctx = tctx.with-pctx( phi-merge(tctx,tctx-t.get-or(mk-tctx()).pctx,tctx-f.get-or(mk-tctx()).pctx,term) );
-         };
-         if not(typeof-term(cond).is-t(c"Bool",0)) {
-            apply-global-callable(tctx, c"into-branch-conditional", typeof-term(cond), cond);
-         };
-         let lub = if typeof-term(t).is-t(c"Never",0) then typeof-term(f)
-         else if typeof-term(f).is-t(c"Never",0) || typeof-term(f).is-t(c"Nil",0) then typeof-term(t)
-         else { (tctx, let lub) = least-upper-bound(tctx, typeof-term(t), typeof-term(f), term); lub.get-or(ta); };
-         ascript(term, lub);
+            if is-scoped {
+               (let tctx-inner, let new-cond) = std-infer-expr(tctx, cond, false, Tail(), ta);
+               tctx = tctx.with-pctx(tctx-inner.get-or(mk-tctx()).pctx);
+
+               (let tctx-t, let new-t) = std-infer-expr(tctx-inner, t, false, Tail(), ta);
+               (let tctx-f, let new-f) = std-infer-expr(tctx, f, false, Tail(), ta);
+               if not(is(cond,new-cond)) || not(is(t,new-t)) || not(is(f,new-f))
+               then { cond = new-cond; t = new-t; f = new-f; term = mk-app(mk-app(mk-app(ifv,new-cond),new-t),new-f) };
+               tctx = tctx.with-pctx( phi-merge(tctx,tctx-t.get-or(mk-tctx()).pctx,tctx-f.get-or(mk-tctx()).pctx,term) );
+            } else {
+               (tctx, let new-cond) = std-infer-expr(tctx, cond, false, Tail(), ta);
+               (let tctx-t, let new-t) = std-infer-expr(tctx, t, false, Tail(), ta);
+               (let tctx-f, let new-f) = std-infer-expr(tctx, f, false, Tail(), ta);
+               tctx = tctx-t;
+               if not(is(cond,new-cond)) || not(is(t,new-t)) || not(is(f,new-f))
+               then { cond = new-cond; t = new-t; f = new-f; term = mk-app(mk-app(mk-app(ifv,new-cond),new-t),new-f) };
+               tctx = tctx.with-pctx( phi-merge(tctx,tctx-t.get-or(mk-tctx()).pctx,tctx-f.get-or(mk-tctx()).pctx,term) );
+            };
+            if not(typeof-term(cond).is-t(c"Bool",0)) {
+               apply-global-callable(tctx, c"into-branch-conditional", typeof-term(cond), cond);
+            };
+            let lub = if typeof-term(t).is-t(c"Never",0) then typeof-term(f)
+            else if typeof-term(f).is-t(c"Never",0) || typeof-term(f).is-t(c"Nil",0) then typeof-term(t)
+            else { (tctx, let lub) = least-upper-bound(tctx, typeof-term(t), typeof-term(f), term); lub.get-or(ta); };
+            ascript(term, lub);
+         }
       );
       ASTEOF{} => ascript(term, t1(c"Nil"));
       ASTNil{} => ascript(term, t1(c"Nil"));

--- a/lib2/core/common-macros.lsts
+++ b/lib2/core/common-macros.lsts
@@ -5,6 +5,10 @@ deprecated macro ( rl"assert"(c) ) (
         ()
 );
 
+deprecated macro ( rl"macro::define-zero"(base-type,constructor,con-tag) ) (
+   let non-zero(t: base-type): Bool = t.discriminator-case-tag != (t as con-tag).discriminator-case-tag;
+);
+
 typed macro macro::let(lhs: lazy, rhs: lazy): lazy = (
    (fn(lhs) = ()) (rhs)
 );

--- a/lib2/core/owned-data.lsts
+++ b/lib2/core/owned-data.lsts
@@ -37,10 +37,7 @@ let .pop(od: OwnedData<t>[]): t = (
    od.data[od.current-length]
 );
 
-let :Blob .release(_: Any): Nil = ();
 let .release(od: OwnedData<t>[]): Nil = (
-   # TODO: make the default release implementation unnecessary here
-   # TODO: the insides of this if statement should not be typechecked if the condition is false
    if type(t) <: type(MustRelease) {
       let dlo = 0_sz;
       let dhi = od.current-length;

--- a/lib2/core/vector.lsts
+++ b/lib2/core/vector.lsts
@@ -61,24 +61,3 @@ let .push(v: Vector<t>, i: x): Vector<t> = (
    v.end-offset = v.end-offset + 1_sz;
    v
 );
-
-#let .pop-front(v: Vector<t>): Tuple<t, Vector<t>> = (
-#    if v.length == 0 then fail(c"Tried to pop from empty Vector.");
-#
-#    let x = v[0];
-#    v = v.remove-front(1);
-#
-#    Tuple ( x, v )
-#);
-
-#let .pop(v: Vector<t>): Tuple<t, Vector<t>> = (
-#   if v.length() == 0 {
-#      fail("Tried to pop from empty Vector.");
-#   };
-#
-#   let lasti = v.length - 1;
-#   let last = v[lasti as U64];
-#   v = v.remove-back(1);
-#
-#   Tuple ( last, v )
-#);

--- a/tests/promises/lm-type/constructor.lsts
+++ b/tests/promises/lm-type/constructor.lsts
@@ -1,5 +1,5 @@
 
 import LM/unit-type-core.lsts;
 
-t1(c"T1");
+assert( ta == ta );
 assert( safe-alloc-block-count == 0 );

--- a/tests/promises/vector/constructor.lsts
+++ b/tests/promises/vector/constructor.lsts
@@ -13,5 +13,8 @@ assert( safe-alloc-block-count == 0 );
 mk-vector(type(String), 2).push("A");
 assert( safe-alloc-block-count == 0 );
 
-#assert( mk-vector(type(U64), 2).push(123).push(456).pop() == 123 );
-#assert( safe-alloc-block-count == 0 );
+assert( mk-vector(type(U64), 2).push(123).push(456)[0] == 123 );
+assert( safe-alloc-block-count == 0 );
+
+assert( mk-vector(type(U64), 2).push(123).push(456)[1] == 456 );
+assert( safe-alloc-block-count == 0 );


### PR DESCRIPTION
## Describe your changes
Features:
* `if type(x) <: type(y)` will always result in a conditional compilation switch
* conditional compilation only compiles the true code path and can be used to avoid compiling certain code in certain situations
* the default `.release` implementation is no longer necessary this way

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1649

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
