### PR TITLE
Gc enabled tand fpsfjksp

### DIFF
--- a/LM/type-constructor.lsts
+++ b/LM/type-constructor.lsts
@@ -8,9 +8,9 @@ let t2(tag: String, p1: Type, p2: Type): Type = TGround(tag, mk-vector(type(Type
 let tv(name: String): Type = TVar(name);
 
 let $"&&"(lt: Type, rt: Type): Type = (
-   match (lt, rt) {
-      Tuple{first:TAny{}} => rt;
-      Tuple{second:TAny{}} => lt;
+   #match (lt, rt) {
+   #   Tuple{first:TAny{}} => rt;
+   #   Tuple{second:TAny{}} => lt;
       #Tuple{first:TAnd{lconjugate=conjugate},second:TAnd{rconjugate=conjugate}} => (
       #   let result = mk-vector(type(Type), lconjugate.length+rconjugate.length);
       #   #for c in lconjugate { result = result.push(c) };
@@ -35,6 +35,6 @@ let $"&&"(lt: Type, rt: Type): Type = (
       #   result = result.push(second);
       #   TAnd(result)#.sort
       #);
-   };
+   #};
    lt
 );

--- a/LM/type-constructor.lsts
+++ b/LM/type-constructor.lsts
@@ -10,30 +10,30 @@ let tv(name: String): Type = TVar(name);
 let $"&&"(lt: Type, rt: Type): Type = (
    match (lt, rt) {
       Tuple{first:TAny{}} => rt;
-      #Tuple{second:TAny{}} => lt;
-      #Tuple{first:TAnd{lconjugate=conjugate},second:TAnd{rconjugate=conjugate}} => (
-      #   let result = mk-vector(type(Type), lconjugate.length+rconjugate.length);
+      Tuple{second:TAny{}} => lt;
+      Tuple{first:TAnd{lconjugate=conjugate},second:TAnd{rconjugate=conjugate}} => (
+         let result = mk-vector(type(Type), lconjugate.length+rconjugate.length);
       #   #for c in lconjugate { result = result.push(c) };
       #   #for c in rconjugate { result = result.push(c) };
-      #   TAnd(result)#.sort
-      #);
-      #Tuple{first=first,second:TAnd{rconjugate=conjugate}} => (
-      #   let result = mk-vector(type(Type), 1+rconjugate.length);
-      #   result = result.push(first);
+         TAnd(result)#.sort
+      );
+      Tuple{first=first,second:TAnd{rconjugate=conjugate}} => (
+         let result = mk-vector(type(Type), 1+rconjugate.length);
+         result = result.push(first);
       #   #for c in rconjugate { result = result.push(c) };
-      #   TAnd(result)#.sort
-      #);
-      #Tuple{first:TAnd{lconjugate=conjugate},second=second} => (
-      #   let result = mk-vector(type(Type), lconjugate.length+1);
+         TAnd(result)#.sort
+      );
+      Tuple{first:TAnd{lconjugate=conjugate},second=second} => (
+         let result = mk-vector(type(Type), lconjugate.length+1);
       #   #for c in lconjugate { result = result.push(c) };
-      #   result = result.push(second);
-      #   TAnd(result)#.sort
-      #);
-      #Tuple{first=first,second=second} => (
-      #   let result = mk-vector(type(Type), 2);
-      #   result = result.push(first);
-      #   result = result.push(second);
-      #   TAnd(result)#.sort
-      #);
+         result = result.push(second);
+         TAnd(result)#.sort
+      );
+      Tuple{first=first,second=second} => (
+         let result = mk-vector(type(Type), 2);
+         result = result.push(first);
+         result = result.push(second);
+         TAnd(result)#.sort
+      );
    };
 );

--- a/LM/type-constructor.lsts
+++ b/LM/type-constructor.lsts
@@ -8,9 +8,9 @@ let t2(tag: String, p1: Type, p2: Type): Type = TGround(tag, mk-vector(type(Type
 let tv(name: String): Type = TVar(name);
 
 let $"&&"(lt: Type, rt: Type): Type = (
-   #match (lt, rt) {
-      #Tuple{first:TAny{}} => rt;
-      #Tuple{second:TAny{}} => lt;
+   match (lt, rt) {
+      Tuple{first:TAny{}} => rt;
+      Tuple{second:TAny{}} => lt;
       #Tuple{first:TAnd{lconjugate=conjugate},second:TAnd{rconjugate=conjugate}} => (
       #   let result = mk-vector(type(Type), lconjugate.length+rconjugate.length);
       #   #for c in lconjugate { result = result.push(c) };
@@ -35,6 +35,6 @@ let $"&&"(lt: Type, rt: Type): Type = (
       #   result = result.push(second);
       #   TAnd(result)#.sort
       #);
-   #};
+   };
    lt
 );

--- a/LM/type-constructor.lsts
+++ b/LM/type-constructor.lsts
@@ -8,32 +8,33 @@ let t2(tag: String, p1: Type, p2: Type): Type = TGround(tag, mk-vector(type(Type
 let tv(name: String): Type = TVar(name);
 
 let $"&&"(lt: Type, rt: Type): Type = (
-   match (lt, rt) {
-      Tuple{first:TAny{}} => rt;
-      Tuple{second:TAny{}} => lt;
-      Tuple{first:TAnd{lconjugate=conjugate},second:TAnd{rconjugate=conjugate}} => (
-         let result = mk-vector(type(Type), lconjugate.length+rconjugate.length);
+   #match (lt, rt) {
+      #Tuple{first:TAny{}} => rt;
+      #Tuple{second:TAny{}} => lt;
+      #Tuple{first:TAnd{lconjugate=conjugate},second:TAnd{rconjugate=conjugate}} => (
+      #   let result = mk-vector(type(Type), lconjugate.length+rconjugate.length);
       #   #for c in lconjugate { result = result.push(c) };
       #   #for c in rconjugate { result = result.push(c) };
-         TAnd(result)#.sort
-      );
-      Tuple{first=first,second:TAnd{rconjugate=conjugate}} => (
-         let result = mk-vector(type(Type), 1+rconjugate.length);
-         result = result.push(first);
+      #   TAnd(result)#.sort
+      #);
+      #Tuple{first=first,second:TAnd{rconjugate=conjugate}} => (
+      #   let result = mk-vector(type(Type), 1+rconjugate.length);
+      #   result = result.push(first);
       #   #for c in rconjugate { result = result.push(c) };
-         TAnd(result)#.sort
-      );
-      Tuple{first:TAnd{lconjugate=conjugate},second=second} => (
-         let result = mk-vector(type(Type), lconjugate.length+1);
+      #   TAnd(result)#.sort
+      #);
+      #Tuple{first:TAnd{lconjugate=conjugate},second=second} => (
+      #   let result = mk-vector(type(Type), lconjugate.length+1);
       #   #for c in lconjugate { result = result.push(c) };
-         result = result.push(second);
-         TAnd(result)#.sort
-      );
-      Tuple{first=first,second=second} => (
-         let result = mk-vector(type(Type), 2);
-         result = result.push(first);
-         result = result.push(second);
-         TAnd(result)#.sort
-      );
-   };
+      #   result = result.push(second);
+      #   TAnd(result)#.sort
+      #);
+      #Tuple{first=first,second=second} => (
+      #   let result = mk-vector(type(Type), 2);
+      #   result = result.push(first);
+      #   result = result.push(second);
+      #   TAnd(result)#.sort
+      #);
+   #};
+   lt
 );

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/string/comparison.lsts
+	lm tests/promises/lm-type/constructor.lsts
 	gcc tmp.c
 	./a.out
 

--- a/SRC/least-upper-bound.lsts
+++ b/SRC/least-upper-bound.lsts
@@ -51,10 +51,10 @@ let least-upper-bound(tctx: TypeContext?, left: Type, right: Type, blame: AST): 
             if not(non-zero(left-phi-id)) || not(non-zero(right-phi-id)) || not(non-zero(left-phi-state)) || not(non-zero(right-phi-state)) {
                exit-error("Unable to Merge Phi States: \{left-phi-state} x \{right-phi-state}", blame);
             };
-            let new-phi-state = phi-merge(tctx,left-phi-state,right-phi-state,blame);
-            tctx = tctx.bind-phi(left-phi-id, phi-linear-moved(new-phi-state), blame);
-            tctx = tctx.bind-phi(right-phi-id, phi-linear-moved(new-phi-state), blame);
+            tctx = tctx.bind-phi(left-phi-id, phi-linear-moved(left-phi-state), blame);
+            tctx = tctx.bind-phi(right-phi-id, phi-linear-moved(right-phi-state), blame);
             let new-phi-id = uuid();
+            let new-phi-state = phi-merge(tctx,left-phi-state,right-phi-state,blame);
             result = result.push(t2(c"Phi::Id",t1(new-phi-id)));
             tctx = tctx.bind-phi(new-phi-id, new-phi-state, blame);
          };

--- a/SRC/least-upper-bound.lsts
+++ b/SRC/least-upper-bound.lsts
@@ -1,6 +1,5 @@
 
 let least-upper-bound(tctx: TypeContext?, left: Type, right: Type, blame: AST): (TypeContext?, Type?) = (
-   print("LUB \{left} x \{right}\n");
    let rt = match (left, right) {
       Tuple{ first:TAnd{lconjugate=conjugate}, second:TAnd{rconjugate=conjugate} } => (
          let result = mk-vector(type(Type));

--- a/SRC/least-upper-bound.lsts
+++ b/SRC/least-upper-bound.lsts
@@ -51,10 +51,10 @@ let least-upper-bound(tctx: TypeContext?, left: Type, right: Type, blame: AST): 
             if not(non-zero(left-phi-id)) || not(non-zero(right-phi-id)) || not(non-zero(left-phi-state)) || not(non-zero(right-phi-state)) {
                exit-error("Unable to Merge Phi States: \{left-phi-state} x \{right-phi-state}", blame);
             };
-            tctx = tctx.bind-phi(left-phi-id, phi-linear-moved(left-phi-state), blame);
-            tctx = tctx.bind-phi(right-phi-id, phi-linear-moved(right-phi-state), blame);
-            let new-phi-id = uuid();
             let new-phi-state = phi-merge(tctx,left-phi-state,right-phi-state,blame);
+            tctx = tctx.bind-phi(left-phi-id, phi-linear-moved(new-phi-state), blame);
+            tctx = tctx.bind-phi(right-phi-id, phi-linear-moved(new-phi-state), blame);
+            let new-phi-id = uuid();
             result = result.push(t2(c"Phi::Id",t1(new-phi-id)));
             tctx = tctx.bind-phi(new-phi-id, new-phi-state, blame);
          };

--- a/SRC/least-upper-bound.lsts
+++ b/SRC/least-upper-bound.lsts
@@ -1,5 +1,6 @@
 
 let least-upper-bound(tctx: TypeContext?, left: Type, right: Type, blame: AST): (TypeContext?, Type?) = (
+   print("LUB \{left} x \{right}\n");
    let rt = match (left, right) {
       Tuple{ first:TAnd{lconjugate=conjugate}, second:TAnd{rconjugate=conjugate} } => (
          let result = mk-vector(type(Type));

--- a/SRC/phi-merge.lsts
+++ b/SRC/phi-merge.lsts
@@ -19,3 +19,15 @@ let phi-merge(tctx: TypeContext?, left-phi-state: Type, right-phi-state: Type, b
    if can-unify(left-phi-state,right-phi-state) && can-unify(right-phi-state,left-phi-state) then left-phi-state
    else apply-global-callable(tctx, c"phi", t3(c"Cons",left-phi-state,right-phi-state), blame).second;
 );
+
+let phi-append(tctx-primary: List<PhiContextRow>, tctx-secondary: List<PhiContextRow>): List<PhiContextRow> = (
+   let seen = mk-vector(type(CString));
+   for Tuple{ sid=phi-id, st=phi-tt, pblame=blame } in tctx-secondary {
+      if not(seen.contains(sid)) {
+         let pt = tctx-primary.lookup(sid,ta);
+         if not(non-zero(pt)) then tctx-primary = cons( PhiContextRow(sid,st,pblame), tctx-primary );
+         seen = seen.push(sid);
+      };
+   };
+   tctx-primary
+);

--- a/SRC/release-locals.lsts
+++ b/SRC/release-locals.lsts
@@ -39,6 +39,6 @@ let release-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AS
    for nd in needs-mark-release {
       tctx-after = phi-move(tctx-after, nd.denormalized-and-phi-type(tctx-after), term);
    };
-   tctx-before = tctx-before.with-pctx( phi-merge(tctx-before,tctx-after.get-or(mk-tctx()).pctx,tctx-before.get-or(mk-tctx()).pctx,term) );
+   tctx-before = tctx-before.with-pctx( phi-append(tctx-after.get-or(mk-tctx()).pctx,tctx-before.get-or(mk-tctx()).pctx) );
    (tctx-before, term)
 );

--- a/SRC/release-locals.lsts
+++ b/SRC/release-locals.lsts
@@ -1,5 +1,6 @@
 
 let release-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AST, hint: Type): (TypeContext?, AST) = (
+   tctx-after = tctx-after.with-pctx( phi-append(tctx-after.get-or(mk-tctx()).pctx,tctx-before.get-or(mk-tctx()).pctx) );
    let tctx-before-tctx = tctx-before.get-or(mk-tctx()).tctx;
    let tctx-after-tctx = tctx-after.get-or(mk-tctx()).tctx;
    let needs-release = [] : List<TypeContextRow>;
@@ -39,6 +40,6 @@ let release-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AS
    for nd in needs-mark-release {
       tctx-after = phi-move(tctx-after, nd.denormalized-and-phi-type(tctx-after), term);
    };
-   tctx-before = tctx-before.with-pctx( phi-append(tctx-after.get-or(mk-tctx()).pctx,tctx-before.get-or(mk-tctx()).pctx) );
+   tctx-before = tctx-before.with-pctx( tctx-after.get-or(mk-tctx()).pctx );
    (tctx-before, term)
 );

--- a/SRC/release-locals.lsts
+++ b/SRC/release-locals.lsts
@@ -1,6 +1,6 @@
 
 let release-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AST, hint: Type): (TypeContext?, AST) = (
-   tctx-after = tctx-after.with-pctx( phi-append(tctx-after.get-or(mk-tctx()).pctx,tctx-before.get-or(mk-tctx()).pctx) );
+   #tctx-after = tctx-after.with-pctx( phi-append(tctx-after.get-or(mk-tctx()).pctx,tctx-before.get-or(mk-tctx()).pctx) );
    let tctx-before-tctx = tctx-before.get-or(mk-tctx()).tctx;
    let tctx-after-tctx = tctx-after.get-or(mk-tctx()).tctx;
    let needs-release = [] : List<TypeContextRow>;

--- a/SRC/release-locals.lsts
+++ b/SRC/release-locals.lsts
@@ -40,6 +40,6 @@ let release-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AS
    for nd in needs-mark-release {
       tctx-after = phi-move(tctx-after, nd.denormalized-and-phi-type(tctx-after), term);
    };
-   tctx-before = tctx-before.with-pctx( tctx-after.get-or(mk-tctx()).pctx );
+   tctx-before = tctx-before.with-pctx( phi-merge(tctx-before,tctx-after.get-or(mk-tctx()).pctx,tctx-before.get-or(mk-tctx()).pctx,term) );
    (tctx-before, term)
 );

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -1,6 +1,5 @@
 
 let std-bind-term(tctx: Maybe<TypeContext>, key: CString, rhs: AST, def: AST, blame: AST, hint: Type): (TypeContext?, Type) = (
-   print("Bind \{key}\n");
    let rhs-tt = phi-state(tctx,typeof-term(rhs),blame);
    let tt = rhs-tt && t1(c"LocalVariable");
    (tctx, tt) = phi-fresh(tctx, tt, blame);
@@ -12,7 +11,6 @@ let std-bind-term(tctx: Maybe<TypeContext>, key: CString, rhs: AST, def: AST, bl
 );
 
 let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: IsUsed, hint: Type): (TypeContext?, AST) = (
-   print("Infer \{term}\n");
    match term {
       App{ left:Abs{def=lhs:Var{lname=key}, rhs:ASTNil{}, misc-tt=tt}, rhs=right } => (
          if typeof-var-raw(term, tctx, lname).is-t(c"LocalVariable",0)
@@ -190,7 +188,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          if key==c"__uninitialized" then ascript(term, hint)
          else (
             vt = typeof-var(term, tctx, key);
-            print("Var\n");
             vt = phi-state(tctx, vt, term);
          );
          mark-var-to-def-todo(tctx, key, ta, term);
@@ -313,7 +310,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                      tctx = phi-move(tctx, from-tt, term);
                   };
                };
-               print("App\n");
                rt = phi-state(tctx, rt, term);
                ascript(term, rt);
                if not(rt.is-t(c"Cons",2)) {
@@ -343,7 +339,6 @@ let wrap-call(tctx: TypeContext?, fname: CString, term: AST): (TypeContext?, AST
    let function-term = mk-var(fname); ascript(function-term, function-type);
    let result = mk-app(function-term, term);
    (tctx, let result-type) = apply-global-callable(tctx, fname, args-type, term);
-   print("Wrap call\n");
    result-type = phi-state(tctx, result-type, term);
    ascript(result, result-type);
    (tctx, result)

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -180,7 +180,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                let new-term = mk-glb(key,new-val);
                mark-var-to-def(new-term, term);
                term = new-term;
-               print("Term \{term}\n");
             };
          };
       );

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -12,6 +12,7 @@ let std-bind-term(tctx: Maybe<TypeContext>, key: CString, rhs: AST, def: AST, bl
 );
 
 let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: IsUsed, hint: Type): (TypeContext?, AST) = (
+   print("Infer \{term}\n");
    match term {
       App{ left:Abs{def=lhs:Var{lname=key}, rhs:ASTNil{}, misc-tt=tt}, rhs=right } => (
          if typeof-var-raw(term, tctx, lname).is-t(c"LocalVariable",0)

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -180,6 +180,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                let new-term = mk-glb(key,new-val);
                mark-var-to-def(new-term, term);
                term = new-term;
+               print("Term \{term}\n");
             };
          };
       );

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -1,5 +1,6 @@
 
 let std-bind-term(tctx: Maybe<TypeContext>, key: CString, rhs: AST, def: AST, blame: AST, hint: Type): (TypeContext?, Type) = (
+   print("Bind \{key}\n");
    let rhs-tt = phi-state(tctx,typeof-term(rhs),blame);
    let tt = rhs-tt && t1(c"LocalVariable");
    (tctx, tt) = phi-fresh(tctx, tt, blame);
@@ -188,6 +189,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          if key==c"__uninitialized" then ascript(term, hint)
          else (
             vt = typeof-var(term, tctx, key);
+            print("Var\n");
             vt = phi-state(tctx, vt, term);
          );
          mark-var-to-def-todo(tctx, key, ta, term);
@@ -310,6 +312,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                      tctx = phi-move(tctx, from-tt, term);
                   };
                };
+               print("App\n");
                rt = phi-state(tctx, rt, term);
                ascript(term, rt);
                if not(rt.is-t(c"Cons",2)) {
@@ -330,7 +333,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
    if used.is-unused && typeof-term(term).slot(c"Phi::State",1).l1.slot(c"MustRelease::ToRelease",1).l1.is-t(c"Linear",1) {
       (tctx, term) = wrap-call(tctx, c".release", term);
    };
-   phi-state(tctx,typeof-term(term),term); # TODO REMOVE
    (tctx, term);
 );
 
@@ -340,6 +342,7 @@ let wrap-call(tctx: TypeContext?, fname: CString, term: AST): (TypeContext?, AST
    let function-term = mk-var(fname); ascript(function-term, function-type);
    let result = mk-app(function-term, term);
    (tctx, let result-type) = apply-global-callable(tctx, fname, args-type, term);
+   print("Wrap call\n");
    result-type = phi-state(tctx, result-type, term);
    ascript(result, result-type);
    (tctx, result)

--- a/lib2/core/common-macros.lsts
+++ b/lib2/core/common-macros.lsts
@@ -1,7 +1,7 @@
 
 deprecated macro ( rl"assert"(c) ) (
    $"if"( not(c) )
-        ( fputs(c"Assertion Failed At ", stderr); fputs(p(rl":Location:") : Constant+Literal+CString, stderr); exit(1); )
+        ( fail(c"Assertion Failed At ", p(rl":Location:") : Constant+Literal+CString) )
         ()
 );
 
@@ -81,12 +81,12 @@ deprecated macro ( rl"while"(cond)(body) )
 
 deprecated macro (rl"match"(t)(ps)) (scope(
    let uuid(term) = open(t);
-   match-pats( uuid(term), ps, fail(c"Pattern Match Failure " + (p(rl":Location:") : Constant+Literal+CString)) );
+   match-pats( uuid(term), ps, fail(c"Pattern Match Failure ", p(rl":Location:") : Constant+Literal+CString) );
 ));
 
 deprecated macro (rl"match"(rl"macro::bind-raw"(t))(ps)) (scope(
    let uuid(term) = t;
-   match-pats( uuid(term), ps, fail(c"Pattern Match Failure " + (p(rl":Location:") : Constant+Literal+CString)) );
+   match-pats( uuid(term), ps, fail(c"Pattern Match Failure ", p(rl":Location:") : Constant+Literal+CString) );
 ));
 
 deprecated macro (rl"match"(
@@ -94,7 +94,7 @@ deprecated macro (rl"match"(
                      ps
                  )) (scope(
    let uuid(term) = f($"raw"(t));
-   match-pats( uuid(term), ps, fail(c"Pattern Match Failure " + (p(rl":Location:") : Constant+Literal+CString)) );
+   match-pats( uuid(term), ps, fail(c"Pattern Match Failure ", p(rl":Location:") : Constant+Literal+CString) );
 ));
 
 deprecated macro (rl"match-pats"(term,(),remainder))

--- a/lib2/core/common-macros.lsts
+++ b/lib2/core/common-macros.lsts
@@ -81,12 +81,12 @@ deprecated macro ( rl"while"(cond)(body) )
 
 deprecated macro (rl"match"(t)(ps)) (scope(
    let uuid(term) = open(t);
-   match-pats( uuid(term), ps, fail("Pattern Match Failure \{p(rl\":Location:\") : Constant+Literal+CString}") );
+   match-pats( uuid(term), ps, fail(c"Pattern Match Failure " + (p(rl":Location:") : Constant+Literal+CString)) );
 ));
 
 deprecated macro (rl"match"(rl"macro::bind-raw"(t))(ps)) (scope(
    let uuid(term) = t;
-   match-pats( uuid(term), ps, fail("Pattern Match Failure \{p(rl\":Location:\") : Constant+Literal+CString}") );
+   match-pats( uuid(term), ps, fail(c"Pattern Match Failure " + (p(rl":Location:") : Constant+Literal+CString)) );
 ));
 
 deprecated macro (rl"match"(
@@ -94,7 +94,7 @@ deprecated macro (rl"match"(
                      ps
                  )) (scope(
    let uuid(term) = f($"raw"(t));
-   match-pats( uuid(term), ps, fail("Pattern Match Failure \{p(rl\":Location:\") : Constant+Literal+CString}") );
+   match-pats( uuid(term), ps, fail(c"Pattern Match Failure " + (p(rl":Location:") : Constant+Literal+CString)) );
 ));
 
 deprecated macro (rl"match-pats"(term,(),remainder))

--- a/lib2/core/cstring.lsts
+++ b/lib2/core/cstring.lsts
@@ -10,6 +10,10 @@ let cmp(l: CString, r: CString): Ord = (
    else Equal
 );
 
+let $"+"(s1: CString, s2: CString): CString = (
+   strcat(s1 as C<"char">[], s2 as C<"char">[]) as CString
+);
+
 let fail(msg: CString): Nil = (
    fputs(msg, stderr);
    exit(1);

--- a/lib2/core/cstring.lsts
+++ b/lib2/core/cstring.lsts
@@ -10,17 +10,17 @@ let cmp(l: CString, r: CString): Ord = (
    else Equal
 );
 
-let fail(msg: CString): Nil = (
+let fail(msg: CString): Never = (
    fputs(msg, stderr);
    exit(1);
-   ()
+   () as Never
 );
 
-let fail(msg1: CString, msg2: CString): Nil = (
+let fail(msg1: CString, msg2: CString): Never = (
    fputs(msg1, stderr);
    fputs(msg2, stderr);
    exit(1);
-   ()
+   () as Never
 );
 
 let print(msg: CString): Nil = (

--- a/lib2/core/cstring.lsts
+++ b/lib2/core/cstring.lsts
@@ -10,12 +10,15 @@ let cmp(l: CString, r: CString): Ord = (
    else Equal
 );
 
-let $"+"(s1: CString, s2: CString): CString = (
-   strcat(s1 as C<"char">[], s2 as C<"char">[]) as CString
-);
-
 let fail(msg: CString): Nil = (
    fputs(msg, stderr);
+   exit(1);
+   ()
+);
+
+let fail(msg1: CString, msg2: CString): Nil = (
+   fputs(msg1, stderr);
+   fputs(msg2, stderr);
    exit(1);
    ()
 );


### PR DESCRIPTION
## Describe your changes
* Increase paranoia of pattern match failures and assert failures to use CString instead of String for error messages
* this code path completely avoids all allocations during error generation
* and instead only relies on fputs of string literals (hopefully located in .data)
* this way error messages should hopefully stay sane, even under extreme memory corruption
* make `fail` return `Never` which is good to know

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1745

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
