### PR TITLE
V2 v3 common code path

### DIFF
--- a/LM/index.lsts
+++ b/LM/index.lsts
@@ -1,2 +1,3 @@
 
+import LM23COMMON/index.lsts;
 import LM/unit-type-core.lsts;

--- a/LM/type-definition.lsts
+++ b/LM/type-definition.lsts
@@ -1,10 +1,5 @@
 
-# TGround needs to be the first type (tag 0) or else sorted unification will not work right
-type Type implies MustRetain, MustRelease zero TAny
-        = TGround { tag:String, parameters:Vector<Type> }
-        | TAny	
-        | TVar { name:String }
-        | TAnd { conjugate:Vector<Type> };
+type Type implies MustRetain, MustRelease;
 
 # TODO Remove: the problem is that OwnedData<Type> is somehow not reified
 # fixing this bug in the V2 compiler is lower priority though than migrating to V3

--- a/LM23COMMON/index.lsts
+++ b/LM23COMMON/index.lsts
@@ -1,13 +1,3 @@
 
-# TGround needs to be the first type (tag 0) or else sorted unification will not work right
-type Type zero TAny
-        = TGround { tag:String, parameters:Vector<Type> }
-        | TAny
-        | TVar { name:String }
-        | TAnd { conjugate:Vector<Type> };
+import LM23COMMON/type-definition.lsts;
 
-# TODO Remove: the problem is that OwnedData<Type> is somehow not reified
-# fixing this bug in the V2 compiler is lower priority though than migrating to V3
-let todo-remove(tt: Type): Nil = (
-   mk-owned-data(type(Type),0); ()
-);

--- a/LM23COMMON/index.lsts
+++ b/LM23COMMON/index.lsts
@@ -1,0 +1,13 @@
+
+# TGround needs to be the first type (tag 0) or else sorted unification will not work right
+type Type zero TAny
+        = TGround { tag:String, parameters:Vector<Type> }
+        | TAny
+        | TVar { name:String }
+        | TAnd { conjugate:Vector<Type> };
+
+# TODO Remove: the problem is that OwnedData<Type> is somehow not reified
+# fixing this bug in the V2 compiler is lower priority though than migrating to V3
+let todo-remove(tt: Type): Nil = (
+   mk-owned-data(type(Type),0); ()
+);

--- a/LM23COMMON/type-definition.lsts
+++ b/LM23COMMON/type-definition.lsts
@@ -1,0 +1,7 @@
+
+# TGround needs to be the first type (tag 0) or else sorted unification will not work right
+type Type zero TAny
+        = TGround { tag:CString, parameters:List<Type>[] }
+        | TAny
+        | TVar { name:CString }
+        | TAnd { conjugate:Vector<Type> };

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/lm-type/constructor.lsts
+	lm tests/promises/string/comparison.lsts
 	gcc tmp.c
 	./a.out
 

--- a/SRC/index.lsts
+++ b/SRC/index.lsts
@@ -1,6 +1,8 @@
 
 import std/minimal.lsts;
 
+import LM23COMMON/index.lsts;
+
 import SRC/unit-drivers.lsts;
 
 import SRC/unit-types.lsts;

--- a/SRC/types-definitions.lsts
+++ b/SRC/types-definitions.lsts
@@ -1,7 +1,3 @@
 
 # TGround needs to be the first type (tag 0) or else sorted unification will not work right
-type Type implements DefaultPrintable, DefaultFormattable zero TAny
-           = TGround { tag: CString, parameters: List<Type>[] }
-           | TVar { name: CString }
-           | TAny
-           | TAnd { conjugate:Vector<Type> };
+type Type implements DefaultPrintable, DefaultFormattable;


### PR DESCRIPTION
## Describe your changes
* create a common codepath to hold shared V2/V3 codebase
* this way we can gradually merge the two without having to maintain two codebases
* the only difference between V2/V3 mode for this code is that one is GC-enabled and the other is not
* but the code is identical, because GC *is implicit!*
* this way we can also start to create good test-coverage with promises during development, rather than after development

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
