### PR TITLE
Lm23 tctx fsppsps

### DIFF
--- a/LM23COMMON/index.lsts
+++ b/LM23COMMON/index.lsts
@@ -1,4 +1,5 @@
 
 import LM23COMMON/unit-type-core.lsts;
 import LM23COMMON/unit-ast-core.lsts;
+import LM23COMMON/unit-tctx-core.lsts;
 

--- a/LM23COMMON/tctx-bind.lsts
+++ b/LM23COMMON/tctx-bind.lsts
@@ -1,0 +1,20 @@
+
+let .bind(tctx: TypeContext?, k: CString, kt: Type, blame: AST): TypeContext? = (
+   Some(TypeContext(
+      cons( TypeContextRow(k, kt, kt, blame), tctx.get-or(mk-tctx()).tctx ),
+      tctx.get-or(mk-tctx()).pctx,
+      tctx.get-or(mk-tctx()).is-unsafe,
+      tctx.get-or(mk-tctx()).is-blob,
+      tctx.get-or(mk-tctx()).function-name
+   ));
+);
+
+let .bind-phi(tctx: TypeContext?, k: CString, kt: Type, blame: AST): TypeContext? = (
+   Some(TypeContext(
+      tctx.get-or(mk-tctx()).tctx,
+      cons( PhiContextRow(k,kt,blame) , tctx.get-or(mk-tctx()).pctx ),
+      tctx.get-or(mk-tctx()).is-unsafe,
+      tctx.get-or(mk-tctx()).is-blob,
+      tctx.get-or(mk-tctx()).function-name
+   ));
+);

--- a/LM23COMMON/tctx-definition.lsts
+++ b/LM23COMMON/tctx-definition.lsts
@@ -1,5 +1,5 @@
 
-type TypeContextRow = { key: CString, nt: Type, dt: Type, def: AST };
-type PhiContextRow = { phi-id: CString, phi-tt: Type, blame: AST };
+type TypeContextRow = NullTypeContextRow | TypeContextRow { key: CString, nt: Type, dt: Type, blame: AST };
+type PhiContextRow = NullPhiContextRow | PhiContextRow { phi-id: CString, phi-tt: Type, blame: AST };
 type TypeContext = { tctx:List<TypeContextRow>, pctx: List<PhiContextRow>, is-unsafe: U64, is-blob: U64, function-name:CString };
 let mk-tctx(): TypeContext = TypeContext( [] : List<TypeContextRow>, [] : List<PhiContextRow>, false, false, c"" );

--- a/LM23COMMON/tctx-definition.lsts
+++ b/LM23COMMON/tctx-definition.lsts
@@ -1,0 +1,5 @@
+
+type TypeContextRow = { key: CString, nt: Type, dt: Type, def: AST };
+type PhiContextRow = { phi-id: CString, phi-tt: Type, blame: AST };
+type TypeContext = { tctx:List<TypeContextRow>, pctx: List<PhiContextRow>, is-unsafe: U64, is-blob: U64, function-name:CString };
+let mk-tctx(): TypeContext = TypeContext( [] : List<TypeContextRow>, [] : List<PhiContextRow>, false, false, c"" );

--- a/LM23COMMON/tctx-definition.lsts
+++ b/LM23COMMON/tctx-definition.lsts
@@ -3,3 +3,47 @@ type TypeContextRow = NullTypeContextRow | TypeContextRow { key: CString, nt: Ty
 type PhiContextRow = NullPhiContextRow | PhiContextRow { phi-id: CString, phi-tt: Type, blame: AST };
 type TypeContext = { tctx:List<TypeContextRow>, pctx: List<PhiContextRow>, is-unsafe: U64, is-blob: U64, function-name:CString };
 let mk-tctx(): TypeContext = TypeContext( [] : List<TypeContextRow>, [] : List<PhiContextRow>, false, false, c"" );
+
+let .key(tr: TypeContextRow): CString = (
+   match tr {
+      TypeContextRow{ key=key } => key;
+      _ => c"";
+   }
+);
+let .nt(tr: TypeContextRow): Type = (
+   match tr {
+      TypeContextRow{ nt=nt } => nt;
+      _ => ta;
+   }
+);
+let .dt(tr: TypeContextRow): Type = (
+   match tr {
+      TypeContextRow{ dt=dt } => dt;
+      _ => ta;
+   }
+);
+let .blame(tr: TypeContextRow): AST = (
+   match tr {
+      TypeContextRow{ blame=blame } => blame;
+      _ => ASTEOF;
+   }
+);
+
+let .phi-id(tr: PhiContextRow): CString = (
+   match tr {
+      PhiContextRow{ phi-id=phi-id } => phi-id;
+      _ => c"";
+   }
+);
+let .phi-tt(tr: PhiContextRow): Type = (
+   match tr {
+      PhiContextRow{ phi-tt=phi-tt } => phi-tt;
+      _ => ta;
+   }
+);
+let .blame(tr: PhiContextRow): AST = (
+   match tr {
+      PhiContextRow{ blame=blame } => blame;
+      _ => ASTEOF;
+   }
+);

--- a/LM23COMMON/tctx-lookup.lsts
+++ b/LM23COMMON/tctx-lookup.lsts
@@ -1,7 +1,7 @@
 
-let .lookup(tctx: TypeContext?, key: CString): TypeContextRow = (
+let .lookup(tctx: TypeContext?, key: CString): TypeContextRow = tctx.get-or(mk-tctx()).tctx.lookup(key);
+let .lookup(trs: List<TypeContextRow>, key: CString): TypeContextRow = (
    let default = NullTypeContextRow;
-   let trs = tctx.get-or(mk-tctx()).tctx;
    let continue = true;
    for tr in trs { if continue {
       if tr.key == key {
@@ -12,9 +12,9 @@ let .lookup(tctx: TypeContext?, key: CString): TypeContextRow = (
    default
 );
 
-let .lookup-phi(tctx: TypeContext?, key: CString): PhiContextRow = (
+let .lookup-phi(tctx: TypeContext?, key: CString): PhiContextRow = tctx.get-or(mk-tctx()).pctx.lookup(key);
+let .lookup(trs: List<PhiContextRow>, key: CString): PhiContextRow = (
    let default = NullPhiContextRow;
-   let trs = tctx.get-or(mk-tctx()).pctx;
    let continue = true;
    for tr in trs { if continue {
       if tr.phi-id == key {

--- a/LM23COMMON/tctx-lookup.lsts
+++ b/LM23COMMON/tctx-lookup.lsts
@@ -1,0 +1,26 @@
+
+let .lookup(tctx: TypeContext?, key: CString): TypeContextRow = (
+   let default = NullTypeContextRow;
+   let trs = tctx.get-or(mk-tctx()).tctx;
+   let continue = true;
+   for tr in trs { if continue {
+      if tr.key == key {
+         default = tr;
+         continue = false;
+      }
+   }};
+   default
+);
+
+let .lookup-phi(tctx: TypeContext?, key: CString): PhiContextRow = (
+   let default = NullPhiContextRow;
+   let trs = tctx.get-or(mk-tctx()).pctx;
+   let continue = true;
+   for tr in trs { if continue {
+      if tr.phi-id == key {
+         default = tr;
+         continue = false;
+      }
+   }};
+   default
+);

--- a/LM23COMMON/unit-ast-core.lsts
+++ b/LM23COMMON/unit-ast-core.lsts
@@ -1,2 +1,3 @@
 
+import LM23COMMON/unit-type-core.lsts;
 import LM23COMMON/ast-definition.lsts;

--- a/LM23COMMON/unit-tctx-core.lsts
+++ b/LM23COMMON/unit-tctx-core.lsts
@@ -2,3 +2,4 @@
 import LM23COMMON/unit-ast-core.lsts;
 import LM23COMMON/tctx-definition.lsts;
 import LM23COMMON/tctx-bind.lsts;
+import LM23COMMON/tctx-lookup.lsts;

--- a/LM23COMMON/unit-tctx-core.lsts
+++ b/LM23COMMON/unit-tctx-core.lsts
@@ -1,0 +1,3 @@
+
+import LM23COMMON/unit-ast-core.lsts;
+import LM23COMMON/tctx-definition.lsts;

--- a/LM23COMMON/unit-tctx-core.lsts
+++ b/LM23COMMON/unit-tctx-core.lsts
@@ -1,3 +1,4 @@
 
 import LM23COMMON/unit-ast-core.lsts;
 import LM23COMMON/tctx-definition.lsts;
+import LM23COMMON/tctx-bind.lsts;

--- a/SRC/ast-definitions.lsts
+++ b/SRC/ast-definitions.lsts
@@ -50,7 +50,7 @@ let .dt(tr: TypeContextRow): Type = (
 let .phi-id(tr: PhiContextRow): CString = (
    match tr {
       PhiContextRow{ phi-id=phi-id } => phi-id;
-      _ => ta;
+      _ => c"";
    }
 );
 let .phi-tt(tr: PhiContextRow): Type = (
@@ -62,7 +62,7 @@ let .phi-tt(tr: PhiContextRow): Type = (
 let .blame(tr: PhiContextRow): AST = (
    match tr {
       PhiContextRow{ blame=blame } => blame;
-      _ => ta;
+      _ => ASTEOF;
    }
 );
 

--- a/SRC/ast-definitions.lsts
+++ b/SRC/ast-definitions.lsts
@@ -5,30 +5,49 @@ type AST implements DefaultFormattable;
 # constructor with a default argument
 let $"App"(left: AST[], right: AST[]): AST = App ( false, left, right );
 
-let .direct-type(tr: TypeContextRow): Type = if non-zero(tr.nt) then tr.nt else tr.dt;
-let .normalized-type(tr: TypeContextRow): Type = if non-zero(tr.nt) then tr.nt else normalize(tr.dt);
-let .denormalized-type(tr: TypeContextRow): Type = if non-zero(tr.dt) then tr.dt else denormalize(tr.nt);
+let .direct-type(tr: TypeContextRow): Type = (
+   match tr {
+      TypeContextRow{ nt=nt, dt=dt } => if non-zero(nt) then nt else dt;
+      _ => ta;
+   }
+);
+let .normalized-type(tr: TypeContextRow): Type = (
+   match tr {
+      TypeContextRow{ nt=nt, dt=dt } => if non-zero(nt) then nt else normalize(dt);
+      _ => ta;
+   }
+);
+let .denormalized-type(tr: TypeContextRow): Type = (
+   match tr {
+      TypeContextRow{ nt=nt, dt=dt } => if non-zero(dt) then dt else denormalize(nt);
+      _ => ta;
+   }
+);
+let .def(tr: TypeContextRow): AST = (
+   match tr {
+      TypeContextRow{ blame=blame } => blame;
+      _ => ASTEOF;
+   }
+);
+let .key(tr: TypeContextRow): CString = (
+   match tr {
+      TypeContextRow{ key=key } => key;
+      _ => c"";
+   }
+);
+let .nt(tr: TypeContextRow): Type = (
+   match tr {
+      TypeContextRow{ nt=nt } => nt;
+      _ => ta;
+   }
+);
+let .dt(tr: TypeContextRow): Type = (
+   match tr {
+      TypeContextRow{ dt=dt } => dt;
+      _ => ta;
+   }
+);
 let .denormalized-and-phi-type(tr: TypeContextRow, tctx: TypeContext?): Type = phi-state(tctx,tr.denormalized-type,tr.def);
-let .lookup(trs: List<TypeContextRow>, key: CString, default: TypeContextRow): TypeContextRow = (
-   let continue = true;
-   for tr in trs { if continue {
-      if tr.key == key {
-         default = tr;
-         continue = false;
-      }
-   }};
-   default
-);
-let .lookup(trs: List<PhiContextRow>, key: CString, default: Type): Type = (
-   let continue = true;
-   for tr in trs { if continue {
-      if tr.phi-id == key {
-         default = tr.phi-tt;
-         continue = false;
-      }
-   }};
-   default
-);
 let .into(tr: TypeContextRow, tt: Type<String>): String = "TypeContextRow{ key: \"\{tr.key}\", dt: \"\{tr.dt}\" }";
 
 type alias AContext = List<(CString,AST)>;

--- a/SRC/ast-definitions.lsts
+++ b/SRC/ast-definitions.lsts
@@ -29,42 +29,6 @@ let .def(tr: TypeContextRow): AST = (
       _ => ASTEOF;
    }
 );
-let .key(tr: TypeContextRow): CString = (
-   match tr {
-      TypeContextRow{ key=key } => key;
-      _ => c"";
-   }
-);
-let .nt(tr: TypeContextRow): Type = (
-   match tr {
-      TypeContextRow{ nt=nt } => nt;
-      _ => ta;
-   }
-);
-let .dt(tr: TypeContextRow): Type = (
-   match tr {
-      TypeContextRow{ dt=dt } => dt;
-      _ => ta;
-   }
-);
-let .phi-id(tr: PhiContextRow): CString = (
-   match tr {
-      PhiContextRow{ phi-id=phi-id } => phi-id;
-      _ => c"";
-   }
-);
-let .phi-tt(tr: PhiContextRow): Type = (
-   match tr {
-      PhiContextRow{ phi-tt=phi-tt } => phi-tt;
-      _ => ta;
-   }
-);
-let .blame(tr: PhiContextRow): AST = (
-   match tr {
-      PhiContextRow{ blame=blame } => blame;
-      _ => ASTEOF;
-   }
-);
 
 let .denormalized-and-phi-type(tr: TypeContextRow, tctx: TypeContext?): Type = phi-state(tctx,tr.denormalized-type,tr.def);
 let .into(tr: TypeContextRow, tt: Type<String>): String = "TypeContextRow{ key: \"\{tr.key}\", dt: \"\{tr.dt}\" }";

--- a/SRC/ast-definitions.lsts
+++ b/SRC/ast-definitions.lsts
@@ -5,14 +5,10 @@ type AST implements DefaultFormattable;
 # constructor with a default argument
 let $"App"(left: AST[], right: AST[]): AST = App ( false, left, right );
 
-type TypeContextRow = { key: CString, nt: Type, dt: Type, def: AST };
-type PhiContextRow = { phi-id: CString, phi-tt: Type, blame: AST };
 let .direct-type(tr: TypeContextRow): Type = if non-zero(tr.nt) then tr.nt else tr.dt;
 let .normalized-type(tr: TypeContextRow): Type = if non-zero(tr.nt) then tr.nt else normalize(tr.dt);
 let .denormalized-type(tr: TypeContextRow): Type = if non-zero(tr.dt) then tr.dt else denormalize(tr.nt);
 let .denormalized-and-phi-type(tr: TypeContextRow, tctx: TypeContext?): Type = phi-state(tctx,tr.denormalized-type,tr.def);
-type TypeContext = { tctx:List<TypeContextRow>, pctx: List<PhiContextRow>, is-unsafe: U64, is-blob: U64, function-name:CString };
-let mk-tctx(): TypeContext = TypeContext( [] : List<TypeContextRow>, [] : List<PhiContextRow>, false, false, c"" );
 let .lookup(trs: List<TypeContextRow>, key: CString, default: TypeContextRow): TypeContextRow = (
    let continue = true;
    for tr in trs { if continue {

--- a/SRC/ast-definitions.lsts
+++ b/SRC/ast-definitions.lsts
@@ -47,6 +47,25 @@ let .dt(tr: TypeContextRow): Type = (
       _ => ta;
    }
 );
+let .phi-id(tr: PhiContextRow): CString = (
+   match tr {
+      PhiContextRow{ phi-id=phi-id } => phi-id;
+      _ => ta;
+   }
+);
+let .phi-tt(tr: PhiContextRow): Type = (
+   match tr {
+      PhiContextRow{ phi-tt=phi-tt } => phi-tt;
+      _ => ta;
+   }
+);
+let .blame(tr: PhiContextRow): AST = (
+   match tr {
+      PhiContextRow{ blame=blame } => blame;
+      _ => ta;
+   }
+);
+
 let .denormalized-and-phi-type(tr: TypeContextRow, tctx: TypeContext?): Type = phi-state(tctx,tr.denormalized-type,tr.def);
 let .into(tr: TypeContextRow, tt: Type<String>): String = "TypeContextRow{ key: \"\{tr.key}\", dt: \"\{tr.dt}\" }";
 

--- a/SRC/phi-merge.lsts
+++ b/SRC/phi-merge.lsts
@@ -3,7 +3,7 @@ let phi-merge(tctx-globals: TypeContext?, tctx-primary: List<PhiContextRow>, tct
    let seen = mk-vector(type(CString));
    for Tuple{ sid=phi-id, st=phi-tt, pblame=blame } in tctx-secondary {
       if not(seen.contains(sid)) {
-         let pt = tctx-primary.lookup(sid,ta);
+         let pt = tctx-primary.lookup(sid).phi-tt;
          if not(non-zero(pt)) then tctx-primary = cons( PhiContextRow(sid,st,pblame), tctx-primary )
          else (
             let rt = phi-merge(tctx-globals, pt, st, blame);
@@ -24,7 +24,7 @@ let phi-append(tctx-primary: List<PhiContextRow>, tctx-secondary: List<PhiContex
    let seen = mk-vector(type(CString));
    for Tuple{ sid=phi-id, st=phi-tt, pblame=blame } in tctx-secondary {
       if not(seen.contains(sid)) {
-         let pt = tctx-primary.lookup(sid,ta);
+         let pt = tctx-primary.lookup(sid).phi-tt;
          if not(non-zero(pt)) then tctx-primary = cons( PhiContextRow(sid,st,pblame), tctx-primary );
          seen = seen.push(sid);
       };

--- a/SRC/phi-specialize.lsts
+++ b/SRC/phi-specialize.lsts
@@ -17,7 +17,7 @@ let .phi-specialize(tt: Type, tctx: TypeContext?, blame: AST, is-return: U64): T
          t2(c"Arrow", dom.phi-specialize(tctx, blame, false), rng.phi-specialize(tctx, blame, true))
       );
       TGround{tag:c"Phi::Id",parameters:[TGround{phi-id=tag,parameters:[]}..]} => (
-         let phi-state = tctx.get-or(mk-tctx()).pctx.lookup(phi-id, ta);
+         let phi-state = tctx.lookup-phi(phi-id).phi-tt;
          if not(non-zero(phi-state)) then ta
          else if is-return
          then t1(c"Phi::Initialize", phi-state)

--- a/SRC/phi-state.lsts
+++ b/SRC/phi-state.lsts
@@ -19,7 +19,7 @@ let phi-state-internal(tctx: TypeContext?, tt: Type, top-level-tt: Type, blame: 
          TAnd(new-conjugate)
       );
       TGround{tag:c"Phi::Id",parameters:[TGround{phi-id=tag,parameters:[]}..]} => (
-         let phi-state = tctx.get-or(mk-tctx()).pctx.lookup(phi-id, ta);
+         let phi-state = tctx.lookup-phi(phi-id).phi-tt;
          if not(non-zero(phi-state)) then exit-error("Unable to find Phi::Id<\{phi-id}> \{top-level-tt} \{blame}\n", blame);
          tt && t1(c"Phi::State",phi-state);
       );

--- a/SRC/tctx-bind.lsts
+++ b/SRC/tctx-bind.lsts
@@ -16,16 +16,6 @@ let .bind(tctx: TypeContext?, k: CString, kt-normal: Type, kt-denormal: Type, kv
    ));
 );
 
-let .bind-phi(tctx: TypeContext?, k: CString, kt: Type, blame: AST): TypeContext? = (
-   Some(TypeContext(
-      tctx.get-or(mk-tctx()).tctx,
-      cons( PhiContextRow(k,kt,blame) , tctx.get-or(mk-tctx()).pctx ),
-      tctx.get-or(mk-tctx()).is-unsafe,
-      tctx.get-or(mk-tctx()).is-blob,
-      tctx.get-or(mk-tctx()).function-name
-   ));
-);
-
 let .with-pctx(tctx: TypeContext?, pctx: List<PhiContextRow>): TypeContext? = (
    Some(TypeContext(
       tctx.get-or(mk-tctx()).tctx,

--- a/SRC/tctx-substitute.lsts
+++ b/SRC/tctx-substitute.lsts
@@ -26,7 +26,7 @@ let substitute(tctx: Maybe<TypeContext>, tt: Type): Type = (
       TGround{tag:c"Arrow",parameters=parameters} => TGround(c"Arrow",close(substitute(tctx,parameters)));
       TGround{tag=tag,parameters=parameters} => TGround(tag,close(substitute-normalized(tctx,parameters)));
       TVar{name=name} => (
-         let tn = tctx.get-or(mk-tctx()).tctx.lookup(name,TypeContextRow(c"",ta,ta,mk-eof())).direct-type;
+         let tn = tctx.lookup(name).direct-type;
          tn = normalize(tn).without-phi-id && tn.with-only-phi-state;
          if non-zero(tn) then tn else tt;
       );

--- a/SRC/tctx-substitute.lsts
+++ b/SRC/tctx-substitute.lsts
@@ -59,7 +59,7 @@ let substitute-normalized(tctx: Maybe<TypeContext>, tt: Type): Type = (
       TGround{tag:c"Linear",parameters:[TGround{tag:c"Phi::Live"}..]} => tt;
       TGround{tag=tag,parameters=parameters} => TGround(tag,close(substitute-normalized(tctx,parameters)));
       TVar{name=name} => (
-         let tn = tctx.get-or(mk-tctx()).tctx.lookup(name,TypeContextRow(c"",ta,ta,mk-eof())).normalized-type;
+         let tn = tctx.lookup(name).normalized-type;
          if non-zero(tn) then tn else tt;
       );
       _ => tt;
@@ -92,7 +92,7 @@ let substitute-macro(tctx: Maybe<TypeContext>, tt: Type): Type = (
       TGround{tag:c"Linear",parameters:[TGround{tag:c"Phi::Live"}..]} => tt;
       TGround{tag=tag,parameters=parameters} => TGround(tag,close(substitute-macro(tctx,parameters)));
       TVar{name=name} => (
-         let tn = tctx.get-or(mk-tctx()).tctx.lookup(name,TypeContextRow(c"",ta,ta,mk-eof())).normalized-type;
+         let tn = tctx.lookup(name).normalized-type;
          if non-zero(tn) then tn else tt;
       );
       _ => tt;

--- a/tests/promises/lm-tctx/bind.lsts
+++ b/tests/promises/lm-tctx/bind.lsts
@@ -1,0 +1,32 @@
+
+import LM23COMMON/unit-tctx-core.lsts;
+
+let tctx0 = Some(mk-tctx());
+let tctx1 = tctx0.bind(c"a", t0(c"A"), ASTEOF);
+let tctx2 = tctx1.bind(c"b", t0(c"B"), ASTEOF);
+let tctx3 = tctx2.bind(c"a", t0(c"AB"), ASTEOF);
+
+assert( tctx0.lookup(c"a").nt == ta );
+assert( tctx0.lookup(c"a").dt == ta );
+assert( tctx1.lookup(c"a").key == c"a" );
+assert( tctx1.lookup(c"a").nt == t0(c"A") );
+assert( tctx1.lookup(c"a").dt == t0(c"A") );
+assert( tctx2.lookup(c"b").key == c"b" );
+assert( tctx2.lookup(c"b").nt == t0(c"B") );
+assert( tctx2.lookup(c"b").dt == t0(c"B") );
+assert( tctx3.lookup(c"a").key == c"a" );
+assert( tctx3.lookup(c"a").nt == t0(c"AB") );
+assert( tctx3.lookup(c"a").dt == t0(c"AB") );
+
+let pctx0 = Some(mk-tctx());
+let pctx1 = pctx0.bind-phi(c"a", t0(c"A"), ASTEOF);
+let pctx2 = pctx1.bind-phi(c"b", t0(c"B"), ASTEOF);
+let pctx3 = pctx2.bind-phi(c"a", t0(c"AB"), ASTEOF);
+
+assert( pctx0.lookup-phi(c"a").phi-tt == ta );
+assert( pctx1.lookup-phi(c"a").phi-id == c"a" );
+assert( pctx1.lookup-phi(c"a").phi-tt == t0(c"A") );
+assert( pctx2.lookup-phi(c"b").phi-id == c"b" );
+assert( pctx2.lookup-phi(c"b").phi-tt == t0(c"B") );
+assert( pctx3.lookup-phi(c"a").phi-id == c"a" );
+assert( pctx3.lookup-phi(c"a").phi-tt == t0(c"AB") );


### PR DESCRIPTION
## Describe your changes
Features:
* create a promise for tctx definition, bind, and lookup-by-key
* TypeContext is the core of inference, so this is reaching really far into the heart of the compiler
* these APIs can still be considered stable though, they are very conservative and extensible
* for example, lookup returns a `TypeContextRow` or `PhiContextRow` instead of individual values
* this allows for simple extension if necessary
* one of the good outcomes of this rewrite in the compiler is that top-to-bottom these APIs can finally be stabilized with promises
* I really don't see much room for any more changes in these design choices
* So once a compiler feature is covered by a promise it will stick around and be backwards compatible
* this doesn't mean that everything in LM23COMMON is stable though. Some things aren't covered by promises yet.

Next we will stabilize tctx-lookup-by-key-and-parameters, which is a core part of inference: the specialization feature.

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
