### PR TITLE
dont deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,11 @@ build: compile-production
 	rm -f deploy1 deploy1.c deploy2.c
 	cargo test regression_tests
 
+test:
+	cargo test
+
 deploy: build smoke-test
-deploy-lite: build smoke-test-lite
+deploy-lite: test smoke-test-lite
 
 valgrind: install-bootstrap
 	valgrind --tool=callgrind lm --v2 SRC/index.lsts


### PR DESCRIPTION
## Describe your changes
* I think this should fix the Github task runners
* the task runners are timing out because they don't have enough memory and the deploy step is thrashing
* So *temporarily* we are just doing tests without deploy
* The deploy step is to catch accidental pushes that don't include a deploy manually
* so we just run `make deploy` habitually and we should be fine
* going to start a new ticket to re-add deploy to the task runners after V3 compiler fixes the memory problems

## Issue ticket number and link

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
