### PR TITLE
Tctx substitute fspspsl

### DIFF
--- a/LM23COMMON/prop-core.lsts
+++ b/LM23COMMON/prop-core.lsts
@@ -23,7 +23,7 @@ let enrich-quick-prop(base: Type, pre: Type): Type = (
             if can-unify(lt, base) then (
                let post = if rt.is-open then (
                   let tctx = unify(lt, base, ASTEOF);
-                  substitute(tctx, rt);
+                  tctx.substitute(rt);
                ) else rt;
                if not(can-unify(post,pre)) && not(can-unify(post, base)) {
                   pre = pre && post;

--- a/LM23COMMON/tctx-substitute.lsts
+++ b/LM23COMMON/tctx-substitute.lsts
@@ -1,17 +1,17 @@
 
-let substitute(tctx: TypeContext?, tt: List<Type>): List<Type> = (
+let .substitute(tctx: TypeContext?, tt: List<Type>): List<Type> = (
    match tt {
-      LCons{head=head,tail=tail} => cons( substitute(tctx,head), substitute(tctx,tail) );
+      LCons{head=head,tail=tail} => cons( tctx.substitute(head), tctx.substitute(tail) );
       _ => tt;
    }
 );
 
-let substitute(tctx: TypeContext?, tt: Type): Type = (
+let .substitute(tctx: TypeContext?, tt: Type): Type = (
    match tt {
       TAnd{conjugate=conjugate} => (
          let result = mk-vector(type(Type), 0_u64);
          for c in conjugate {
-            match substitute(tctx,c) {
+            match tctx.substitute(c) {
                TAnd{rconjugate=conjugate} => for rc in rconjugate { result = result.push(rc) };
                TAny{} => ();
                rc => ( result = result.push(rc); () );
@@ -21,7 +21,7 @@ let substitute(tctx: TypeContext?, tt: Type): Type = (
          else if result.length==1 then result[0]
          else tand(result)
       );
-      TGround{tag=tag,parameters=parameters} => TGround(tag,close(substitute(tctx,parameters)));
+      TGround{tag=tag,parameters=parameters} => TGround(tag,close(tctx.substitute(parameters)));
       TVar{name=name} => (
          let tn = tctx.lookup(name).direct-type;
          if non-zero(tn) then tn else tt;

--- a/LM23COMMON/tctx-substitute.lsts
+++ b/LM23COMMON/tctx-substitute.lsts
@@ -21,9 +21,6 @@ let substitute(tctx: TypeContext?, tt: Type): Type = (
          else if result.length==1 then result[0]
          else tand(result)
       );
-      TGround{tag:c"Linear",parameters:[TGround{tag:c"Phi::Live"}..]} => tt;
-      TGround{tag:c"Cons",parameters=parameters} => TGround(c"Cons",close(substitute(tctx,parameters)));
-      TGround{tag:c"Arrow",parameters=parameters} => TGround(c"Arrow",close(substitute(tctx,parameters)));
       TGround{tag=tag,parameters=parameters} => TGround(tag,close(substitute(tctx,parameters)));
       TVar{name=name} => (
          let tn = tctx.lookup(name).direct-type;

--- a/LM23COMMON/tctx-unify.lsts
+++ b/LM23COMMON/tctx-unify.lsts
@@ -147,7 +147,7 @@ let unify-inner(fpt: Type, pt: Type, blame: AST): Maybe<TypeContext> = (
           let tctx = unify-inner(rdom, ldom, blame);
           if tctx.is-some {
             if rdom.is-open {
-               ctx = tctx && unify-inner(lrng, substitute(tctx,rrng), blame);
+               ctx = tctx && unify-inner(lrng, tctx.substitute(rrng), blame);
             } else {
                ctx = tctx && unify-inner(lrng, rrng, blame)
             }

--- a/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
@@ -32,7 +32,7 @@ let std-c-compile-type-typedef-concrete(tctx: Maybe<TypeContext>, concrete-type:
    let is-incomplete = false;
    for Tuple{case-tag=first, case-fields=second} in cases {
       for Tuple{field-name=first, field-type=second} in case-fields {
-         field-type = substitute(tctx, field-type).rewrite-type-alias;
+         field-type = tctx.substitute(field-type).rewrite-type-alias;
          if is-incomplete-typedef(field-type) {
             is-incomplete = true;
          }
@@ -50,7 +50,7 @@ let std-c-compile-type-typedef-concrete(tctx: Maybe<TypeContext>, concrete-type:
          if case-tag==c"" {
             for Tuple{field-name=first, field-type=second} in case-fields {
                let mangled-field-name = c"0_" + field-name;
-               field-type = substitute(tctx, field-type);
+               field-type = tctx.substitute(field-type);
                (let pre-tt, let post-tt) = std-c-mangle-declaration(field-type, td);
                assemble-types-section = assemble-types-section + SAtom(c"  ") + pre-tt + SAtom(c" ") + mangle-identifier(mangled-field-name) + post-tt + SAtom(c";\n");
             }
@@ -67,7 +67,7 @@ let std-c-compile-type-typedef-concrete(tctx: Maybe<TypeContext>, concrete-type:
                assemble-types-section = assemble-types-section + SAtom(c"    struct {\n");
                for Tuple{field-name=first, field-type=second} in case-fields {
                   let mangled-field-name = to-string(case-number) + c"_" + field-name;
-                  field-type = substitute(tctx, field-type);
+                  field-type = tctx.substitute(field-type);
                   (let pre-tt, let post-tt) = std-c-mangle-declaration(field-type, td);
                   assemble-types-section = assemble-types-section + SAtom(c"      ") + pre-tt + SAtom(c" ") + mangle-identifier(mangled-field-name) + post-tt + SAtom(c";\n");
                };

--- a/SRC/apply-and-specialize.lsts
+++ b/SRC/apply-and-specialize.lsts
@@ -11,10 +11,10 @@ let apply-and-specialize(tctx: TypeContext?, fname: CString, ft: Type, ft-denorm
    };
    tctx = apply-move-args(tctx, ft-denormal, at, blame);
    if not(tctx.get-or(mk-tctx()).is-blob) && inner-tctx.has-moved then exit-error("Linear Value Used After Move In Call To \{fname} : \{ft-denormal}\nWith Arg \{at}", blame);
-   let closed-type = substitute(inner-tctx, ft);
+   let closed-type = inner-tctx.substitute(ft);
    if not(ft.is-t(c"Blob",0) || ft.is-t(c"FFI",0)) then closed-type = closed-type.phi-specialize(tctx, blame);
    if closed-type.is-open then exit-error("Unification Did Not Close Before Specialization\nfunction: \{fname} \{ft}\nargs: \{at}", blame);
-   let r = substitute(inner-tctx, ft.range);
+   let r = inner-tctx.substitute(ft.range);
    (tctx, r) = phi-initialize(tctx, r, blame);
    if not(r.is-t(c"Phi::Id",1)) then (tctx, r) = phi-initialize-parameter(tctx, r.expand-implied-phi, blame);
    if ft.is-t(c"Prop",0) then r = r && cons-root(at);

--- a/SRC/assert-no-infinite-types.lsts
+++ b/SRC/assert-no-infinite-types.lsts
@@ -27,8 +27,8 @@ let assert-no-infinite-type(fields-of-type: HashtableEq<(CString,U64),Vector<(Ty
                             seen: List<(CString,U64)>, visiting: Type, root-type: Type, blame: AST): Nil = (
    for Tuple{base-type=first,field-type=second} in fields-of-type.lookup(visiting.ground-tag-and-arity, mk-vector(type((Type,Type)))) {
       let tctx = unify(base-type, visiting, blame).normalize;
-      base-type = substitute(tctx, base-type);
-      field-type = substitute(tctx, field-type);
+      base-type = tctx.substitute(base-type);
+      field-type = tctx.substitute(field-type);
       if seen.contains(field-type.ground-tag-and-arity) then fail("Type definition has infinite size: \{root-type} at \{blame.location}\n");
       assert-no-infinite-type(fields-of-type, cons( visiting.ground-tag-and-arity, seen ), field-type, root-type, blame);
    };

--- a/SRC/find-global-callable.lsts
+++ b/SRC/find-global-callable.lsts
@@ -59,7 +59,7 @@ let apply-global-constructor(tctx: TypeContext?, fname: CString, hint: Type, arg
       for Tuple{ot=first, kt=second, t=third} in global-type-context-denormal.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
          if (not(non-zero(hint)) || can-receive(ot, hint)) && (not(non-zero(arg-types)) || can-apply(ot, arg-types)) {
             let next = if non-zero(hint)
-            then substitute(unify(ot.range,hint,blame).normalize,kt)
+            then unify(ot.range,hint,blame).normalize.substitute(kt)
             else kt;
             simple = ot;
             if non-zero(result) then result = result && next else result = next;
@@ -82,9 +82,9 @@ let apply-global-constructor(tctx: TypeContext?, fname: CString, hint: Type, arg
       let inner-tctx = if non-zero(hint)
       then unify(simple.range, hint, blame).normalize
       else unify(simple.domain, arg-types, blame).normalize;
-      let closed-type = substitute(inner-tctx, simple);
+      let closed-type = inner-tctx.substitute(simple);
       if simple.is-open then try-specialize(fname, simple, inner-tctx, closed-type);
-      result = substitute(inner-tctx, simple.range);
+      result = inner-tctx.substitute(simple.range);
       for prow in inner-tctx.get-or(mk-tctx()).pctx {
          tctx = tctx.bind-phi(prow.phi-id, prow.phi-tt, blame);
       };

--- a/SRC/substitute.lsts
+++ b/SRC/substitute.lsts
@@ -74,7 +74,7 @@ let substitute-lhs(tctx: TypeContext?, t: AST, idx: U64): AST = (
       App{ left:Lit{key:c":",ctk=token}, right:App{ left:Var{v=key,vtk=token}, right:AType{vt=tt} } } => (
          vt = substitute-macro(tctx, vt.accept-interface(idx)).phi-specialize(tctx,t);
          mk-app( mk-lit(c":",unique(ctk)), mk-app(
-            mk-var(v,unique(vtk)), mk-atype(substitute(tctx, vt.accept-interface(idx)))
+            mk-var(v,unique(vtk)), mk-atype(tctx.substitute(vt.accept-interface(idx)))
          ))
       );
       App{ ps=left, right:Var{v=key,vtk=token} } => mk-app(substitute-lhs(tctx,ps),mk-var(v,unique(vtk)));
@@ -106,8 +106,8 @@ let substitute(tctx: TypeContext?, t: AST, is-return: U64): AST = (
       );
       Lit{v=key,vtk=token} => mk-lit(v,unique(vtk));
       Var{v=key,vtk=token} => mk-var(v,unique(vtk));
-      Abs{lhs=lhs,rhs=rhs,tt=tt} => mk-abs(substitute-lhs(tctx,lhs),substitute(tctx,rhs,true),substitute(tctx,tt));
-      AType{tt=tt} => mk-atype(substitute(tctx,tt));
+      Abs{lhs=lhs,rhs=rhs,tt=tt} => mk-abs(substitute-lhs(tctx,lhs),substitute(tctx,rhs,true),tctx.substitute(tt));
+      AType{tt=tt} => mk-atype(tctx.substitute(tt));
       App{is-cons=is-cons,lt=left,rt=right} => mk-cons-or-app(is-cons,substitute(tctx,lt),substitute(tctx,rt));
       Seq{seq=seq} => (
          t = mk-eof();

--- a/SRC/type-alias-index.lsts
+++ b/SRC/type-alias-index.lsts
@@ -10,7 +10,7 @@ let .rewrite-type-alias(lt: Type): Type = (
          let lt-rt = type-alias-index.lookup( lt.ground-tag-and-arity, Tuple( ta, ta ) );
          if non-zero(lt-rt.first) {
             let tctx = unify(lt-rt.first, lt, ASTEOF);
-            if non-zero(tctx) { lt = substitute(tctx, lt-rt.second); };
+            if non-zero(tctx) { lt = tctx.substitute(lt-rt.second); };
          } else {
             lt = TGround( tag, close(parameters.rewrite-type-alias) );
          };
@@ -50,7 +50,7 @@ let .rewrite-opaque-type-alias(lt: Type): Type = (
          let lt-rt = opaque-type-alias-index.lookup( lt.ground-tag-and-arity, Tuple( ta, ta ) );
          if non-zero(lt-rt.first) {
             let tctx = unify(lt-rt.first, lt, ASTEOF);
-            if non-zero(tctx) { lt = substitute(tctx, lt-rt.second); };
+            if non-zero(tctx) { lt = tctx.substitute(lt-rt.second); };
          } else {
             lt = TGround( tag, close(parameters.rewrite-opaque-type-alias) );
          };

--- a/SRC/validate-interfaces.lsts
+++ b/SRC/validate-interfaces.lsts
@@ -5,8 +5,8 @@ let validate-interfaces(): Nil = (
       let tctx = union( unify(self-type, base-type, ASTEOF).normalize, unify(interface-type, reified-interface-type, ASTEOF).normalize );
       for Tuple{ symbol-name=first, args-type=second, return-type=third } in
           interface-shape-index.lookup(interface-type.ground-tag-and-arity, [] : List<(CString,Type,Type)>) {
-         args-type = denormalize(substitute(tctx, args-type).reify-type-variables);
-         return-type = substitute(tctx, return-type).reify-type-variables;
+         args-type = denormalize(tctx.substitute(args-type).reify-type-variables);
+         return-type = tctx.substitute(return-type).reify-type-variables;
          let function-type = typeof-var-raw( blame, (None : Maybe<TypeContext>)(), symbol-name );
          (_, let apply-return-type) = apply-global-callable(None : TypeContext?, symbol-name, args-type, blame);
          if not(can-unify(return-type, denormalize(apply-return-type))) {

--- a/tests/promises/lm-tctx/substitute.lsts
+++ b/tests/promises/lm-tctx/substitute.lsts
@@ -1,0 +1,2 @@
+
+import LM23COMMON/unit-tctx-core.lsts;

--- a/tests/promises/lm-tctx/substitute.lsts
+++ b/tests/promises/lm-tctx/substitute.lsts
@@ -1,2 +1,13 @@
 
 import LM23COMMON/unit-tctx-core.lsts;
+
+let tctx = Some(mk-tctx())
+          .bind(c"a", t0(c"A"), mk-eof())
+          .bind(c"b", t0(c"B"), mk-eof());
+
+
+assert( tctx.substitute(tv(c"a")) == t0(c"A") );
+assert( tctx.substitute(tv(c"b")) == t0(c"B") );
+assert( tctx.substitute(t1(c"A",tv(c"a"))) == t1(c"A",t0(c"A")) );
+assert( tctx.substitute(t2(c"B",tv(c"a"),tv(c"b"))) == t2(c"B",t0(c"A"),t0(c"B")) );
+assert( safe-alloc-block-count == 0 );


### PR DESCRIPTION
## Describe your changes
* remove special cases from `tctx.substitute`
* rename `substitute(tctx,tt)` to `tctx.substitute(tt)`
* add tests for `tctx.substitute`

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
