### PR TITLE
V3 zero hardcoded normalize fpspsdps

### DIFF
--- a/LM23COMMON/prop-core.lsts
+++ b/LM23COMMON/prop-core.lsts
@@ -76,10 +76,12 @@ let add-weaken-quick-prop(pre: Type, pat: Type, post: Type): Nil = (
 );
 
 let weaken-quick-prop(base: Type): Type = (
-   weaken-quick-prop(base, base, base);
+   let rt = weaken-quick-prop(base, base, base);
+   rt
 );
 
 let weaken-quick-prop(original-base: Type, base: Type, pre: Type): Type = (
+   let early-base = base;
    match pre {
       TGround {} => (
          for Tuple { lt=first, rt=second } in weaken-quick-prop-index.lookup( pre.ground-tag-and-arity, ([] : List<(Type,Type)>) ) {

--- a/LM23COMMON/type-remove-info.lsts
+++ b/LM23COMMON/type-remove-info.lsts
@@ -18,7 +18,7 @@ let remove-info(base: Type, rm: Type): Type = (
          if rm.is-t(c"MustNotMove",0) && base.is-t(c"MustNotMove",0) then ta
          else if rm.is-t(c"MustNotRetain",0) && base.is-t(c"MustNotRetain",0) then ta
          else if rm.is-t(c"MustNotMove",0) || rm.is-t(c"MustNotRetain",0) then base
-         else if rm <: base || base <: rm then ta else base
+         else if base <: rm then ta else base
       );
       _ => base;
    }

--- a/LM23COMMON/type-remove-info.lsts
+++ b/LM23COMMON/type-remove-info.lsts
@@ -15,7 +15,10 @@ let remove-info(base: Type, rm: Type): Type = (
          else tand(result)
       );
       TGround{} => (
-         if can-unify(rm,base) || can-unify(base,rm) then ta else base
+         if rm.is-t(c"MustNotMove",0) && base.is-t(c"MustNotMove",0) then ta
+         else if rm.is-t(c"MustNotRetain",0) && base.is-t(c"MustNotRetain",0) then ta
+         else if rm.is-t(c"MustNotMove",0) || rm.is-t(c"MustNotRetain",0) then base
+         else if rm <: base || base <: rm then ta else base
       );
       _ => base;
    }

--- a/SRC/normalize.lsts
+++ b/SRC/normalize.lsts
@@ -5,9 +5,9 @@ let normalize(tt: Type): Type = (
    let ct = normalize-cache.lookup(tt, ta);
    if non-zero(ct) then ct else ( 
       ct = tt.rewrite-type-alias;
+      ct = weaken-quick-prop(ct);
       ct = ct.without-tag;
       ct = without-size-unless-class(ct);
-      ct = weaken-quick-prop(ct);
       normalize-cache = normalize-cache.bind(tt, ct);
       ct
    );

--- a/SRC/without-tag.lsts
+++ b/SRC/without-tag.lsts
@@ -16,21 +16,6 @@ let .without-tag(tt: Type): Type = (
          else tand(result)
       );
       TGround { tag:c"Arrow", parameters:[rng..dom..] } => t2(c"Arrow",dom.without-tag,rng.without-tag);
-      TGround { tag:c"Constructor" } => ta;
-      TGround { tag:c"CaseNumber" } => ta;
-      TGround { tag:c"C-FFI", parameters:[] } => ta;
-      TGround { tag:c"Raw" } => ta;
-      TGround { tag:c"LMStruct" } => ta;
-      TGround { tag:c"Constant" } => ta;
-      TGround { tag:c"Literal" } => ta;
-      TGround { tag:c"LocalVariable" } => ta;
-      TGround { tag:c"FlexibleArrayMember" } => ta;
-      TGround { tag:c"GlobalVariable" } => ta;
-      TGround { tag:c"Phi::Transition" } => ta;
-      TGround { tag:c"Phi::Initialize" } => ta;
-      TGround { tag:c"Phi::State" } => ta;
-      TGround { tag:c"MustNotRetain" } => ta;
-      TGround { tag:c"MustNotMove" } => ta;
       TGround { tag:tag } => if tag.has-prefix(c"Tag::") then ta
                         else if tag.has-prefix(c"Field::") then ta
                         else tt;


### PR DESCRIPTION
## Describe your changes
* remove special cases from `.without-tag`
* fix a bug in `remove-info` that had mismatched expectations for `<:` wrt `MustNotMove` property
* this property always unifies, which is causing problems
* These properties are weird and need to be handled differently somehow, but not right now

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
