### PR TITLE
Lm normalize in v23 aliases and all fpslll

### DIFF
--- a/LM23COMMON/prop-core.lsts
+++ b/LM23COMMON/prop-core.lsts
@@ -8,7 +8,7 @@ let add-quick-prop(pre: Type, pat: Type, post: Type): Nil = (
    quick-prop = quick-prop.bind( key, val );
 );
 
-let enrich-quick-prop(base: Type): Type = (
+let .enrich(base: Type): Type = (
    # call twice to infer second-degree props without risk of diverging
    base = enrich-quick-prop(base, base);
    base = enrich-quick-prop(base, base);
@@ -89,9 +89,8 @@ let add-weaken-quick-prop(pre: Type, pat: Type, post: Type): Nil = (
    weaken-quick-prop-index = weaken-quick-prop-index.bind( key, val );
 );
 
-let weaken-quick-prop(base: Type): Type = (
-   let rt = weaken-quick-prop(base, base, base);
-   rt
+let .weaken(base: Type): Type = (
+   weaken-quick-prop(base, base, base)
 );
 
 let weaken-quick-prop(original-base: Type, base: Type, pre: Type): Type = (
@@ -120,7 +119,7 @@ let weaken-quick-prop(original-base: Type, base: Type, pre: Type): Type = (
       TGround { tag=tag, parameters=parameters } => (
          let new-parameters = [] : List<Type>;
          for p in parameters.reverse {
-            new-parameters = cons( weaken-quick-prop(p) , new-parameters );
+            new-parameters = cons( p.weaken , new-parameters );
          };
          base = ts(tag,new-parameters);
       );
@@ -131,7 +130,7 @@ let weaken-quick-prop(original-base: Type, base: Type, pre: Type): Type = (
                TGround { tag=tag, parameters=parameters } => (
                   let new-parameters = [] : List<Type>;
                   for p in parameters.reverse {
-                     new-parameters = cons( weaken-quick-prop(p) , new-parameters );
+                     new-parameters = cons( p.weaken , new-parameters );
                   };
                   result = result.push(ts(tag,new-parameters));
                );

--- a/LM23COMMON/type-alias.lsts
+++ b/LM23COMMON/type-alias.lsts
@@ -9,10 +9,10 @@ let .rewrite-type-alias(lt: Type): Type = (
       TGround{ tag=tag, parameters=parameters } => (
          let lt-rt = type-alias-index.lookup( lt.ground-tag-and-arity, Tuple( ta, ta ) );
          if non-zero(lt-rt.first) {
-            let tctx = unify(lt-rt.first, lt, ASTEOF);
+            let tctx = unify(lt-rt.first, lt, mk-eof());
             if non-zero(tctx) { lt = tctx.substitute(lt-rt.second); };
          } else {
-            lt = TGround( tag, close(parameters.rewrite-type-alias) );
+            lt = ts(tag, parameters.rewrite-type-alias);
          };
          lt
       );
@@ -49,10 +49,10 @@ let .rewrite-opaque-type-alias(lt: Type): Type = (
       TGround{ tag=tag, parameters=parameters } => (
          let lt-rt = opaque-type-alias-index.lookup( lt.ground-tag-and-arity, Tuple( ta, ta ) );
          if non-zero(lt-rt.first) {
-            let tctx = unify(lt-rt.first, lt, ASTEOF);
+            let tctx = unify(lt-rt.first, lt, mk-eof());
             if non-zero(tctx) { lt = tctx.substitute(lt-rt.second); };
          } else {
-            lt = TGround( tag, close(parameters.rewrite-opaque-type-alias) );
+            lt = ts(tag, parameters.rewrite-opaque-type-alias);
          };
          lt
       );

--- a/LM23COMMON/unit-prop-core.lsts
+++ b/LM23COMMON/unit-prop-core.lsts
@@ -1,3 +1,4 @@
 
 import LM23COMMON/unit-tctx-core.lsts;
 import LM23COMMON/prop-core.lsts;
+import LM23COMMON/type-alias.lsts;

--- a/SRC/denormalize.lsts
+++ b/SRC/denormalize.lsts
@@ -4,7 +4,7 @@ let denormalize-cache = mk-hashtable-is(type(Type), type(Type));
 let denormalize(tt: Type): Type = (
    tt = tt.rewrite-type-alias;
    tt = with-size(tt);
-   tt = enrich-quick-prop(tt);
+   tt = tt.enrich;
    tt = tt.sanitize-phi;
    tt
 );

--- a/SRC/normalize.lsts
+++ b/SRC/normalize.lsts
@@ -2,8 +2,5 @@
 let normalize-cache = mk-hashtable-is(type(Type), type(Type));
 
 let normalize(tt: Type): Type = (
-   tt = tt.rewrite-type-alias;
-   tt = weaken-quick-prop(tt);
-   tt = tt.without-tag;
-   tt
+   tt.rewrite-type-alias.weaken.without-tag
 );

--- a/SRC/unit-inference.lsts
+++ b/SRC/unit-inference.lsts
@@ -17,7 +17,6 @@ import SRC/most-special.lsts;
 import SRC/normalize.lsts;
 import SRC/denormalize.lsts;
 import SRC/denormalize-strong.lsts; # TODO, make this the normal denormalize
-import SRC/type-alias-index.lsts;
 import SRC/class-info-index.lsts;
 import SRC/with-size.lsts;
 import SRC/with-only-class.lsts;

--- a/SRC/with-phi.lsts
+++ b/SRC/with-phi.lsts
@@ -1,4 +1,4 @@
 
 let .with-phi(tt: Type): Type = (
-   tt && enrich-quick-prop(tt).with-only-phi-state
+   tt && tt.enrich.with-only-phi-state
 );

--- a/tests/promises/lm-prop/alias.lsts
+++ b/tests/promises/lm-prop/alias.lsts
@@ -1,0 +1,2 @@
+
+import LM23COMMON/unit-prop-core.lsts;

--- a/tests/promises/lm-prop/alias.lsts
+++ b/tests/promises/lm-prop/alias.lsts
@@ -1,2 +1,16 @@
 
 import LM23COMMON/unit-prop-core.lsts;
+
+add-type-alias(t0(c"A.1"), t0(c"A.2"));
+add-type-alias(t2(c"B.1",tv(c"x"),tv(c"y")), t2(c"B.2",tv(c"y"),tv(c"x")));
+
+assert( t0(c"A.1").rewrite-type-alias == t0(c"A.2") );
+assert( t2(c"B.1",t0(c"X"),t0(c"Y")).rewrite-type-alias == t2(c"B.2",t0(c"Y"),t0(c"X")) );
+assert( (t0(c"A.1") && t0(c"A.3")).rewrite-type-alias == (t0(c"A.2") && t0(c"A.3")) );
+
+add-opaque-type-alias(t0(c"C.1"), t0(c"C.2"));
+add-opaque-type-alias(t2(c"D.1",tv(c"x"),tv(c"y")), t2(c"D.2",tv(c"y"),tv(c"x")));
+
+assert( t0(c"C.1").rewrite-opaque-type-alias == t0(c"C.2") );
+assert( t2(c"D.1",t0(c"X"),t0(c"Y")).rewrite-opaque-type-alias == t2(c"D.2",t0(c"Y"),t0(c"X")) );
+assert( (t0(c"C.1") && t0(c"C.3")).rewrite-opaque-type-alias == (t0(c"C.2") && t0(c"C.3")) );

--- a/tests/promises/lm-prop/enrich.lsts
+++ b/tests/promises/lm-prop/enrich.lsts
@@ -4,34 +4,34 @@ import LM23COMMON/unit-prop-core.lsts;
 add-quick-prop( t0(c"A.1"), ta, t0(c"A.2") );
 add-weaken-quick-prop( t0(c"A.1"), ta, t0(c"A.2") );
 
-assert( enrich-quick-prop(t0(c"A.1")) == (t0(c"A.1") && t0(c"A.2")) );
-assert( weaken-quick-prop(t0(c"A.1") && t0(c"A.2")) == t0(c"A.1") );
+assert( t0(c"A.1").enrich == (t0(c"A.1") && t0(c"A.2")) );
+assert( (t0(c"A.1") && t0(c"A.2")).weaken == t0(c"A.1") );
 assert( safe-alloc-block-count == 0 );
 
 add-quick-prop( t0(c"B.1"), t0(c"B.2"), t0(c"B.3") );
 add-weaken-quick-prop( t0(c"B.1"), t0(c"B.2"), t0(c"B.3") );
 
-assert( enrich-quick-prop(t0(c"B.1")) == t0(c"B.1") );
-assert( enrich-quick-prop(t0(c"B.1") && t0(c"B.2")) == (t0(c"B.1") && t0(c"B.2") && t0(c"B.3")) );
-assert( weaken-quick-prop(t0(c"B.1") && t0(c"B.2") && t0(c"B.3")) == (t0(c"B.1") && t0(c"B.2")) );
-assert( weaken-quick-prop(t1(c"X",t0(c"B.1") && t0(c"B.2") && t0(c"B.3"))) == t1(c"X",t0(c"B.1") && t0(c"B.2")) );
+assert( t0(c"B.1").enrich == t0(c"B.1") );
+assert( (t0(c"B.1") && t0(c"B.2")).enrich == (t0(c"B.1") && t0(c"B.2") && t0(c"B.3")) );
+assert( (t0(c"B.1") && t0(c"B.2") && t0(c"B.3")).weaken == (t0(c"B.1") && t0(c"B.2")) );
+assert( (t1(c"X",t0(c"B.1") && t0(c"B.2") && t0(c"B.3"))).weaken == t1(c"X",t0(c"B.1") && t0(c"B.2")) );
 
 add-quick-prop( t1(c"C.1",t0(c"C.2")), ta, t0(c"C.3") );
 add-weaken-quick-prop( t1(c"C.1",t0(c"C.2")), ta, t0(c"C.3") );
 
-assert( enrich-quick-prop(t1(c"C.1",t0(c"C.2"))) == (t1(c"C.1",t0(c"C.2")) && t0(c"C.3")) );
-assert( weaken-quick-prop(t1(c"C.1",t0(c"C.2")) && t0(c"C.3")) == t1(c"C.1",t0(c"C.2")) );
-assert( weaken-quick-prop(t1(c"X",t1(c"C.1",t0(c"C.2")) && t0(c"C.3"))) == t1(c"X",t1(c"C.1",t0(c"C.2"))) );
+assert( (t1(c"C.1",t0(c"C.2"))).enrich == (t1(c"C.1",t0(c"C.2")) && t0(c"C.3")) );
+assert( (t1(c"C.1",t0(c"C.2")) && t0(c"C.3")).weaken == t1(c"C.1",t0(c"C.2")) );
+assert( (t1(c"X",t1(c"C.1",t0(c"C.2")) && t0(c"C.3"))).weaken == t1(c"X",t1(c"C.1",t0(c"C.2"))) );
 
 add-quick-prop( t1(c"D.1",t0(c"D.2")), t0(c"D.3"), t0(c"D.4") );
 add-weaken-quick-prop( t1(c"D.1",t0(c"D.2")), t0(c"D.3"), t0(c"D.4") );
 
-assert( enrich-quick-prop(t1(c"D.1",t0(c"D.2"))) == t1(c"D.1",t0(c"D.2")) );
-assert( enrich-quick-prop(t1(c"D.1",t0(c"D.2")) && t0(c"D.3")) == (t1(c"D.1",t0(c"D.2")) && t0(c"D.3") && t0(c"D.4")) );
-assert( weaken-quick-prop(t1(c"D.1",t0(c"D.2")) && t0(c"D.3") && t0(c"D.4")) == (t1(c"D.1",t0(c"D.2")) && t0(c"D.3")) );
-assert( weaken-quick-prop(t1(c"X",t1(c"D.1",t0(c"D.2")) && t0(c"D.3") && t0(c"D.4"))) == t1(c"X",t1(c"D.1",t0(c"D.2")) && t0(c"D.3")) );
+assert( (t1(c"D.1",t0(c"D.2"))).enrich == t1(c"D.1",t0(c"D.2")) );
+assert( (t1(c"D.1",t0(c"D.2")) && t0(c"D.3")).enrich == (t1(c"D.1",t0(c"D.2")) && t0(c"D.3") && t0(c"D.4")) );
+assert( (t1(c"D.1",t0(c"D.2")) && t0(c"D.3") && t0(c"D.4")).weaken == (t1(c"D.1",t0(c"D.2")) && t0(c"D.3")) );
+assert( (t1(c"X",t1(c"D.1",t0(c"D.2")) && t0(c"D.3") && t0(c"D.4"))).weaken == t1(c"X",t1(c"D.1",t0(c"D.2")) && t0(c"D.3")) );
 
 add-weaken-quick-prop( t2(c"Arr",ta,ta), t0(c"Sized"), t0(c"Sized") );
 
-assert( weaken-quick-prop(t2(c"Arr",t0(c"A"),ta) && t0(c"Sized")) == t2(c"Arr",t0(c"A"),ta) );
-assert( weaken-quick-prop(t1(c"X",t2(c"Arr",t0(c"A"),ta) && t0(c"Sized"))) == t1(c"X",t2(c"Arr",t0(c"A"),ta)) );
+assert( (t2(c"Arr",t0(c"A"),ta) && t0(c"Sized")).weaken == t2(c"Arr",t0(c"A"),ta) );
+assert( (t1(c"X",t2(c"Arr",t0(c"A"),ta) && t0(c"Sized"))).weaken == t1(c"X",t2(c"Arr",t0(c"A"),ta)) );


### PR DESCRIPTION
## Describe your changes
* move type alias features to 2/3 common
* add promises tests for type aliases
* rename `enrich-quick-prop` as `.enrich`
* rename `weaken-quick-prop` as `.weaken`
* these promises are not stable UNTIL the V3 release with the V1 language standard
* hopefully they won't change too much, but there are small things like naming conventions
* this naming change is caused by coding conventions for methods:
   * https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/wiki/Coding-Conventions#methods--functions

Normalize is *almost* stable now. Just need to add support for `Tag::*` and `Field::*` wildcard properties.

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
