### PR TITLE
Simplify find queries faalsl

### DIFF
--- a/LM23COMMON/prop-tctx-find-callable.lsts
+++ b/LM23COMMON/prop-tctx-find-callable.lsts
@@ -1,0 +1,35 @@
+
+# .find-callable is the central hub for all function and constructor calls
+let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST): TypeContextRow = (
+   arg-types = denormalize-strong(arg-types);
+   let match-set = mk-vector(type(TypeContextRow));
+   for tr in tctx.lookups(fname) {
+      if can-apply(tr.dt, arg-types) {
+         match-set = match-set.push(tr);
+      }
+   };
+   let result = None : TypeContextRow?;
+   for tr1 in match-set { if not(non-zero(result)) {
+      let all-accept = true;
+      for tr2 in match-set {
+         if is(tr1,tr2) then ()
+         else if most-special(tr1.dt,tr2.dt)!=tr1.dt then all-accept = false;
+      };
+      if all-accept { result = Some(tr1) };
+   }};
+   if not(non-zero(result)) && match-set.length > 0 {
+      eprint("Unable to find unambiguous callable: \{fname} \{arg-types}\nAt: \{blame.location}\n");
+      for tr in match-set {
+         eprint("\{tr.dt}\n");
+      };
+      exit(1);
+   };
+   if not(non-zero(result)) then {
+      print("Unable to find appropriate callable: \{fname} \{arg-types}\nAt: \{blame.location}\n");
+      for tr in tctx.lookups(fname) {
+         print("Candidate: \{tr.dt}\n");
+      };
+      exit(1);
+   };
+   result.get-or-panic
+);

--- a/LM23COMMON/type-most-special.lsts
+++ b/LM23COMMON/type-most-special.lsts
@@ -2,8 +2,8 @@
 # specialization does not always choose the lowest on the subsumption hierarchy
 # for example: x -> x <: A -> A
 # but for specialization we choose: A -> A
-# This is because specialization chooses the most specific covariant,covariant domain,range pair
-# This is different than the traditional contravariant,covariant unification for arrows
+# This is because specialization chooses the most specific domain, irrespective of range
+# This is different than the traditional contravariant domain for arrows
 # Theoretically this is justified by flow-of-information during disambiguation
 #    f(x) is interpreted as "f informed by x"
 #    rather than as simply "f of x"

--- a/LM23COMMON/unit-prop-core.lsts
+++ b/LM23COMMON/unit-prop-core.lsts
@@ -6,3 +6,4 @@ import LM23COMMON/prop-normalize.lsts;
 import LM23COMMON/prop-denormalize.lsts;
 import LM23COMMON/prop-tctx-apply.lsts;
 import LM23COMMON/prop-tctx-normalize.lsts;
+import LM23COMMON/prop-tctx-find-callable.lsts;

--- a/LM23COMMON/unit-type-core.lsts
+++ b/LM23COMMON/unit-type-core.lsts
@@ -31,3 +31,4 @@ import LM23COMMON/type-can-apply.lsts;
 import LM23COMMON/type-can-receive.lsts;
 import LM23COMMON/type-without-phi-keep-state.lsts;
 import LM23COMMON/type-with-phi-id-if-phi-state.lsts;
+import LM23COMMON/type-most-special.lsts;

--- a/PLUGINS/BACKEND/C/cc-blob.lsts
+++ b/PLUGINS/BACKEND/C/cc-blob.lsts
@@ -1,6 +1,6 @@
 
 let cc-blob(callee-ctx: FContext, function-name: CString, args-tt: Type, blame: AST): Fragment = (
-   let f = find-global-callable(function-name, args-tt, blame);
+   let f = Some(mk-tctx()).find-callable(function-name, args-tt, blame).blame;
    match f {
       Glb{val:Abs{rhs=rhs}} => (
          let r = blob-render(callee-ctx, rhs, mk-fragment());

--- a/PLUGINS/BACKEND/C/std-c-compile-call.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-call.lsts
@@ -5,7 +5,7 @@ let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor
    let fterm = if non-zero(return-hint-if-constructor) {
       find-global-constructor(fname, return-hint-if-constructor, typeof-term(args), args);
    } else {
-      find-global-callable(fname, typeof-term(args), args);
+      Some(mk-tctx()).find-callable(fname, typeof-term(args), args).blame;
    };
    if not(non-zero(fterm)) then fail("std-c-compile-call Function was null: \{fterm}\nArguments: \{typeof-term(args)}\n");
    if typeof-term(fterm).is-t(c"Blob",0) {
@@ -27,7 +27,7 @@ let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor
       let inner-ctx = mk-fctx().bind(c"ictx", t0(c"ImplicitContext"), ictx)
                                .bind(c"args", typeof-term(args), push-args);
       let r = mk-fragment();
-      match find-global-callable(c"primitive::call", t2(c"Cons",t0(c"ImplicitContext"),typeof-term(args)), args) {
+      match Some(mk-tctx()).find-callable(c"primitive::call", t2(c"Cons",t0(c"ImplicitContext"),typeof-term(args)), args).blame {
          Glb{val:Abs{lhs=lhs, rhs=rhs}} => (
             r = blob-render(inner-ctx, rhs, r);
             r.context = close(ctx);

--- a/SRC/find-global-callable.lsts
+++ b/SRC/find-global-callable.lsts
@@ -1,38 +1,4 @@
 
-let find-global-callable(fname: CString, arg-types: Type, blame: AST): AST = (
-   arg-types = denormalize-strong(arg-types);
-   let match-set = mk-vector(type((Type,AST)), 16);
-   for Tuple{kt=second, t=third} in global-type-context-denormal.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
-      if can-apply(kt, arg-types) {
-         match-set = match-set.push( (kt, t) );
-      }
-   };
-   let result = mk-eof();
-   for Tuple{kt0=first, t0=second} in match-set { if not(non-zero(result)) {
-      let all-accept = true;
-      for Tuple{kt1=first, t1=second} in match-set {
-         if is(t0,t1) then ()
-         else if most-special(kt0,kt1)!=kt0 then all-accept = false;
-      };
-      if all-accept { result = t0 };
-   }};
-   if not(non-zero(result)) && match-set.length > 0 {
-      eprint("Unable to find unambiguous global callable: \{fname} \{arg-types}\nAt: \{blame.location}\n");
-      for Tuple{kt=first, t=second} in match-set {
-         eprint("\{kt}\n");
-      };
-      exit(1);
-   };
-   if not(non-zero(result)) then {
-      print("Unable to find appropriate global callable: \{fname} \{arg-types}\nAt: \{blame.location}\n");
-      for Tuple{kt=second, t=third} in global-type-context-denormal.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
-         print("Candidate: \{kt}\n");
-      };
-      exit(1);
-   };
-   result
-);
-
 let find-global-constructor(fname: CString, hint: Type, arg-types: Type, blame: AST): AST = (
    hint = hint.rewrite-type-alias.without-phi;
    let result = ASTEOF();

--- a/SRC/infer-global-terms.lsts
+++ b/SRC/infer-global-terms.lsts
@@ -101,7 +101,7 @@ let infer-global-context(term: AST): Nil = (
             ascript(frhs, ft);
             global-type-context-normal = global-type-context-normal.bind(k.key, ft, term);
             global-type-context-denormal = global-type-context-denormal.bind(k.key, ft, term);
-            Some(mk-tctx()).bind-global(k.key, ft, ft, term);
+            Some(mk-tctx()).bind-global(k.key, ft, denormalize-strong(ft), term);
          };
       );
       _ => ();

--- a/SRC/infer-type-definition.lsts
+++ b/SRC/infer-type-definition.lsts
@@ -12,17 +12,18 @@ let visit-field-template(field-name: CString, base-type: Type, field-type: Type,
    ctx = ctx.bind( c"primitive::field-set", ta, ta, mk-var(c"set."+field-name) );
    ctx = ctx.bind( c"primitive::field-get-indirect", ta, ta, mk-var(c"."+field-name) );
    ctx = ctx.bind( c"primitive::field-set-indirect", ta, ta, mk-var(c"set."+field-name) );
-   let field-get = substitute(ctx, find-global-callable(c"primitive::field-get", base-type, blame));
-   let field-set = substitute(ctx, find-global-callable(c"primitive::field-set", t2(c"Cons", base-type, field-type), blame));
-   let field-get-indirect = substitute(ctx, find-global-callable(c"primitive::field-get-indirect", t2(c"Array",base-type,ta), blame));
-   let field-set-indirect = substitute(ctx, find-global-callable(c"primitive::field-set-indirect", t2(c"Cons", t2(c"Array",base-type,ta), field-type), blame));
+   let global-tctx = Some(mk-tctx());
+   let field-get = substitute(ctx, global-tctx.find-callable(c"primitive::field-get", base-type, blame));
+   let field-set = substitute(ctx, global-tctx.find-callable(c"primitive::field-set", t2(c"Cons", base-type, field-type), blame));
+   let field-get-indirect = substitute(ctx, global-tctx.find-callable(c"primitive::field-get-indirect", t2(c"Array",base-type,ta), blame));
+   let field-set-indirect = substitute(ctx, global-tctx.find-callable(c"primitive::field-set-indirect", t2(c"Cons", t2(c"Array",base-type,ta), field-type), blame));
 
    ctx = (None : Maybe<TypeContext>)();
    ctx = ctx.bind( c"base-type", base-type, denormalize(base-type), mk-eof() );
    ctx = ctx.bind( c"field-type", field-type, denormalize(field-type), mk-eof() );
    ctx = ctx.bind( c"field-name", ta, ta, mk-lit(mangled-field-name) );
    ctx = ctx.bind( c"primitive::field-get", ta, ta, mk-var(c"."+to-string(field-ordinal)) );
-   let field-ordinal-get = substitute(ctx, find-global-callable(c"primitive::field-get", base-type, blame));
+   let field-ordinal-get = substitute(ctx, global-tctx.find-callable(c"primitive::field-get", base-type, blame));
 
    type-ast-inserts = type-ast-inserts.push(field-get);
    type-ast-inserts = type-ast-inserts.push(field-set);

--- a/SRC/infer-type-definition.lsts
+++ b/SRC/infer-type-definition.lsts
@@ -13,17 +13,17 @@ let visit-field-template(field-name: CString, base-type: Type, field-type: Type,
    ctx = ctx.bind( c"primitive::field-get-indirect", ta, ta, mk-var(c"."+field-name) );
    ctx = ctx.bind( c"primitive::field-set-indirect", ta, ta, mk-var(c"set."+field-name) );
    let global-tctx = Some(mk-tctx());
-   let field-get = substitute(ctx, global-tctx.find-callable(c"primitive::field-get", base-type, blame));
-   let field-set = substitute(ctx, global-tctx.find-callable(c"primitive::field-set", t2(c"Cons", base-type, field-type), blame));
-   let field-get-indirect = substitute(ctx, global-tctx.find-callable(c"primitive::field-get-indirect", t2(c"Array",base-type,ta), blame));
-   let field-set-indirect = substitute(ctx, global-tctx.find-callable(c"primitive::field-set-indirect", t2(c"Cons", t2(c"Array",base-type,ta), field-type), blame));
+   let field-get = substitute(ctx, global-tctx.find-callable(c"primitive::field-get", base-type, blame).blame);
+   let field-set = substitute(ctx, global-tctx.find-callable(c"primitive::field-set", t2(c"Cons", base-type, field-type), blame).blame);
+   let field-get-indirect = substitute(ctx, global-tctx.find-callable(c"primitive::field-get-indirect", t2(c"Array",base-type,ta), blame).blame);
+   let field-set-indirect = substitute(ctx, global-tctx.find-callable(c"primitive::field-set-indirect", t2(c"Cons", t2(c"Array",base-type,ta), field-type), blame).blame);
 
    ctx = (None : Maybe<TypeContext>)();
    ctx = ctx.bind( c"base-type", base-type, denormalize(base-type), mk-eof() );
    ctx = ctx.bind( c"field-type", field-type, denormalize(field-type), mk-eof() );
    ctx = ctx.bind( c"field-name", ta, ta, mk-lit(mangled-field-name) );
    ctx = ctx.bind( c"primitive::field-get", ta, ta, mk-var(c"."+to-string(field-ordinal)) );
-   let field-ordinal-get = substitute(ctx, global-tctx.find-callable(c"primitive::field-get", base-type, blame));
+   let field-ordinal-get = substitute(ctx, global-tctx.find-callable(c"primitive::field-get", base-type, blame).blame);
 
    type-ast-inserts = type-ast-inserts.push(field-get);
    type-ast-inserts = type-ast-inserts.push(field-set);

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -283,7 +283,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                   then t0(c"MustNotRetain") else ta;
                   let pre-retain-tctx = tctx;
                   (tctx, let new-r) = std-infer-expr(tctx, r, false, Call(var-name-if-var-or-lit(l)), rr-args-hint);
-                  let ftype = typeof-term(find-global-callable( var-name-if-var-or-lit(l), typeof-term(new-r), term ));
+                  let ftype = typeof-term(tctx.find-callable( var-name-if-var-or-lit(l), typeof-term(new-r), term ));
                   if ftype.domain.is-any-arg-t(c"MustNotRetain",0) {
                      (tctx, new-r) = std-infer-expr(pre-retain-tctx, r, false, Call(var-name-if-var-or-lit(l)), ftype.domain && rr-args-hint);
                   };
@@ -313,7 +313,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                rt = phi-state(tctx, rt, term);
                ascript(term, rt);
                if not(rt.is-t(c"Cons",2)) {
-                  let function-type = typeof-term(find-global-callable(var-name-if-var-or-lit(l), typeof-term(r), term));
+                  let function-type = typeof-term(tctx.find-callable(var-name-if-var-or-lit(l), typeof-term(r), term));
                   if function-type.is-t(c"MustRetainOnCall",0) && not(hint.is-t(c"MustNotRetain",0)) && not(tctx.get-or(mk-tctx()).is-blob) {
                     (tctx, term) = maybe-retain(tctx, term);
                   }
@@ -335,7 +335,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
 
 let wrap-call(tctx: TypeContext?, fname: CString, term: AST): (TypeContext?, AST) = (
    let args-type = typeof-term(term);
-   let function-type = typeof-term(find-global-callable(fname, args-type, term));
+   let function-type = typeof-term(tctx.find-callable(fname, args-type, term));
    let function-term = mk-var(fname); ascript(function-term, function-type);
    let result = mk-app(function-term, term);
    (tctx, let result-type) = apply-global-callable(tctx, fname, args-type, term);

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -283,7 +283,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                   then t0(c"MustNotRetain") else ta;
                   let pre-retain-tctx = tctx;
                   (tctx, let new-r) = std-infer-expr(tctx, r, false, Call(var-name-if-var-or-lit(l)), rr-args-hint);
-                  let ftype = typeof-term(tctx.find-callable( var-name-if-var-or-lit(l), typeof-term(new-r), term ));
+                  let ftype = typeof-term(tctx.find-callable( var-name-if-var-or-lit(l), typeof-term(new-r), term ).blame);
                   if ftype.domain.is-any-arg-t(c"MustNotRetain",0) {
                      (tctx, new-r) = std-infer-expr(pre-retain-tctx, r, false, Call(var-name-if-var-or-lit(l)), ftype.domain && rr-args-hint);
                   };
@@ -313,7 +313,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                rt = phi-state(tctx, rt, term);
                ascript(term, rt);
                if not(rt.is-t(c"Cons",2)) {
-                  let function-type = typeof-term(tctx.find-callable(var-name-if-var-or-lit(l), typeof-term(r), term));
+                  let function-type = typeof-term(tctx.find-callable(var-name-if-var-or-lit(l), typeof-term(r), term).blame);
                   if function-type.is-t(c"MustRetainOnCall",0) && not(hint.is-t(c"MustNotRetain",0)) && not(tctx.get-or(mk-tctx()).is-blob) {
                     (tctx, term) = maybe-retain(tctx, term);
                   }
@@ -335,7 +335,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
 
 let wrap-call(tctx: TypeContext?, fname: CString, term: AST): (TypeContext?, AST) = (
    let args-type = typeof-term(term);
-   let function-type = typeof-term(tctx.find-callable(fname, args-type, term));
+   let function-type = typeof-term(tctx.find-callable(fname, args-type, term).blame);
    let function-term = mk-var(fname); ascript(function-term, function-type);
    let result = mk-app(function-term, term);
    (tctx, let result-type) = apply-global-callable(tctx, fname, args-type, term);

--- a/SRC/unit-inference.lsts
+++ b/SRC/unit-inference.lsts
@@ -10,7 +10,6 @@ import SRC/inference-definitions.lsts;
 # unification
 import SRC/tctx-bind.lsts;
 import SRC/reduce-plural.lsts;
-import SRC/most-special.lsts;
 
 # corollaries
 import SRC/class-info-index.lsts;

--- a/tests/promises/lm-tctx/find-callable.lsts
+++ b/tests/promises/lm-tctx/find-callable.lsts
@@ -1,0 +1,19 @@
+
+import LM23COMMON/unit-prop-core.lsts;
+
+let tctx = Some(mk-tctx());
+tctx = tctx.bind-global(c"f", t2(c"Arrow", t0(c"A"), t0(c"B")), mk-var(c"a"));
+tctx = tctx.bind-global(c"f", t2(c"Arrow", t0(c"B"), t0(c"B")), mk-var(c"b"));
+tctx = tctx.bind-global(c"f", t2(c"Arrow", t0(c"A") && t0(c"B"), t0(c"B")), mk-var(c"ab"));
+
+assert( tctx.find-callable(c"f", t0(c"A"), mk-eof()).nt == t2(c"Arrow", t0(c"A"), t0(c"B")) );
+assert( tctx.find-callable(c"f", t0(c"A"), mk-eof()).dt == t2(c"Arrow", t0(c"A"), t0(c"B")) );
+assert( tctx.find-callable(c"f", t0(c"A"), mk-eof()).blame == mk-var(c"a") );
+
+assert( tctx.find-callable(c"f", t0(c"B"), mk-eof()).nt == t2(c"Arrow", t0(c"B"), t0(c"B")) );
+assert( tctx.find-callable(c"f", t0(c"B"), mk-eof()).dt == t2(c"Arrow", t0(c"B"), t0(c"B")) );
+assert( tctx.find-callable(c"f", t0(c"B"), mk-eof()).blame == mk-var(c"b") );
+
+assert( tctx.find-callable(c"f", t0(c"A") && t0(c"B"), mk-eof()).nt == t2(c"Arrow", t0(c"A") && t0(c"B"), t0(c"B")) );
+assert( tctx.find-callable(c"f", t0(c"A") && t0(c"B"), mk-eof()).dt == t2(c"Arrow", t0(c"A") && t0(c"B"), t0(c"B")) );
+assert( tctx.find-callable(c"f", t0(c"A") && t0(c"B"), mk-eof()).blame == mk-var(c"ab") );


### PR DESCRIPTION
## Describe your changes
Features:
* `tctx.find-callable` is stable and always returns a full `TypeContextRow`
* add basic tests for find callable, including specialization

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
