### PR TITLE
Finish find apply callable helpers fspsdi

### DIFF
--- a/LM23COMMON/prop-tctx-find-callable.lsts
+++ b/LM23COMMON/prop-tctx-find-callable.lsts
@@ -1,10 +1,18 @@
 
 # .find-callable is the central hub for all function and constructor calls
 let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST): TypeContextRow = (
+   tctx.find-callable(fname, arg-types, blame, ta);
+);
+
+let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type): TypeContextRow = (
    arg-types = denormalize-strong(arg-types);
+   return-type-hint = denormalize-strong(return-type-hint);
    let match-set = mk-vector(type(TypeContextRow));
    for tr in tctx.lookups(fname) {
-      if can-apply(tr.dt, arg-types) {
+      # can-receive is an additional refinement on top of argument satisfaction
+      # it is necessary for nullary or partial constructors that need a full type
+      # like, None : TypeContext?
+      if can-apply(tr.dt, arg-types) && (not(non-zero(return-type-hint)) || can-receive(tr.dt, return-type-hint)) {
          match-set = match-set.push(tr);
       }
    };

--- a/LM23COMMON/type-most-special.lsts
+++ b/LM23COMMON/type-most-special.lsts
@@ -7,13 +7,21 @@
 # Theoretically this is justified by flow-of-information during disambiguation
 #    f(x) is interpreted as "f informed by x"
 #    rather than as simply "f of x"
+# This check also includes return-type specialization
+# None : Nil -> x?
+# None : Nil -> U64?  (most special)
 
 let most-special(t0: Type, t1: Type): Type = (
    if t0.is-arrow && t1.is-arrow {
-      if can-unify(t0.domain, t1.domain) then t1
-      else if can-unify(t1.domain, t0.domain) then t0
+      if t0.domain <: t1.domain && t1.domain <: t0.domain {
+         if t0.range <: t1.range then t0
+         else if t1.range <: t0.range then t1
+         else ta
+      }
+      else if t1.domain <: t0.domain then t1
+      else if t0.domain <: t1.domain then t0
       else ta
-   } else if can-unify(t0, t1) then t1
-     else if can-unify(t1, t0) then t0
+   } else if t0 <: t1 then t0
+     else if t1 <: t0 then t1
      else ta
 );

--- a/PLUGINS/BACKEND/C/std-c-compile-call.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-call.lsts
@@ -2,11 +2,7 @@
 let std-c-compile-call(ctx: FContext, fname: CString, args: AST): Fragment = std-c-compile-call(ctx, fname, ta, args);
 
 let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor: Type, args: AST): Fragment = (
-   let fterm = if non-zero(return-hint-if-constructor) {
-      find-global-constructor(fname, return-hint-if-constructor, typeof-term(args), args);
-   } else {
-      Some(mk-tctx()).find-callable(fname, typeof-term(args), args).blame;
-   };
+   let fterm = Some(mk-tctx()).find-callable(fname, typeof-term(args), args, return-hint-if-constructor).blame;
    if not(non-zero(fterm)) then fail("std-c-compile-call Function was null: \{fterm}\nArguments: \{typeof-term(args)}\n");
    if typeof-term(fterm).is-t(c"Blob",0) {
       let r = mk-fragment();

--- a/SRC/find-global-callable.lsts
+++ b/SRC/find-global-callable.lsts
@@ -1,22 +1,4 @@
 
-let find-global-constructor(fname: CString, hint: Type, arg-types: Type, blame: AST): AST = (
-   hint = hint.rewrite-type-alias.without-phi;
-   let result = ASTEOF();
-   for Tuple{ot=first, kt=second, t=third} in global-type-context-denormal.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
-      if not(ot.is-open) && (not(non-zero(hint)) || can-receive(ot, hint)) && can-apply(ot, arg-types) {
-         if non-zero(result) then fail("Duplicate global constructor: \{fname} :: \{hint} (\{arg-types})At: \{blame.location}\n1: \{result}\n2: \{t}\n");
-         result = t;
-      }
-   };
-   if not(non-zero(result)) then {
-      for Tuple{ot=first, kt=second, t=third} in global-type-context-denormal.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
-         print("Candidate \{fname} : \{kt}\n");
-      };
-      exit-error("Unable to find appropriate global constructor: \{fname} :: \{hint} (\{arg-types})", blame);
-   };
-   result
-);
-
 let apply-global-constructor(tctx: TypeContext?, fname: CString, hint: Type, arg-types: Type, blame: AST): (TypeContext?, Type) = (
    hint = hint.rewrite-type-alias;
    let result = ta;

--- a/tests/promises/lm-tctx/find-callable.lsts
+++ b/tests/promises/lm-tctx/find-callable.lsts
@@ -17,3 +17,10 @@ assert( tctx.find-callable(c"f", t0(c"B"), mk-eof()).blame == mk-var(c"b") );
 assert( tctx.find-callable(c"f", t0(c"A") && t0(c"B"), mk-eof()).nt == t2(c"Arrow", t0(c"A") && t0(c"B"), t0(c"B")) );
 assert( tctx.find-callable(c"f", t0(c"A") && t0(c"B"), mk-eof()).dt == t2(c"Arrow", t0(c"A") && t0(c"B"), t0(c"B")) );
 assert( tctx.find-callable(c"f", t0(c"A") && t0(c"B"), mk-eof()).blame == mk-var(c"ab") );
+
+tctx = tctx.bind-global(c"g", t2(c"Arrow", t0(c"A"), t1(c"B",tv(c"x"))), mk-var(c"abx"));
+tctx = tctx.bind-global(c"g", t2(c"Arrow", t0(c"A"), t1(c"B",t0(c"A"))), mk-var(c"aba"));
+
+assert( tctx.find-callable(c"g", t0(c"A"), mk-eof()).nt == t2(c"Arrow", t0(c"A"), t1(c"B",t0(c"A"))) );
+assert( tctx.find-callable(c"g", t0(c"A"), mk-eof()).dt == t2(c"Arrow", t0(c"A"), t1(c"B",t0(c"A"))) );
+assert( tctx.find-callable(c"g", t0(c"A"), mk-eof()).blame == mk-var(c"aba") );

--- a/tests/promises/lm-type/destructor.lsts
+++ b/tests/promises/lm-type/destructor.lsts
@@ -95,3 +95,13 @@ assert( tv(c"a").move-linear == tv(c"a") );
 assert( t0(c"A").move-linear == t0(c"A") );
 assert( (t0(c"A") && t1(c"Linear",t0(c"A"))).move-linear == (t0(c"A") && t1(c"Linear",t0(c"Phi::Moved"))) );
 assert( safe-alloc-block-count == 0 );
+
+assert( most-special( t0(c"A") && t0(c"B"), t0(c"A") ) == (t0(c"A") && t0(c"B")) );
+assert( most-special( t0(c"A"), t0(c"A") && t0(c"B") ) == (t0(c"A") && t0(c"B")) );
+assert( most-special( tv(c"a"), t0(c"A") ) == t0(c"A") );
+assert( most-special( t0(c"A"), tv(c"a") ) == t0(c"A") );
+assert( most-special( ta, t0(c"A") ) == t0(c"A") );
+assert( most-special( t0(c"A"), ta ) == t0(c"A") );
+assert( most-special( t2(c"Arrow",tv(c"a"),tv(c"a")), t2(c"Arrow",t0(c"A"),t0(c"A")) ) == t2(c"Arrow",t0(c"A"),t0(c"A")) );
+assert( most-special( t2(c"Arrow",t0(c"A"),tv(c"a")), t2(c"Arrow",t0(c"A"),t0(c"A")) ) == t2(c"Arrow",t0(c"A"),t0(c"A")) );
+assert( safe-alloc-block-count == 0 );


### PR DESCRIPTION
## Describe your changes
* eliminate `find-global-constructor` in favor of just `tctx.find-callable`
* constructors need return-type specialization:
   * `None : Nil -> x?`
   * `None : Nil -> TypeContext?` (most special)
* added test cases for return-type specialization
* so far the V2/3 Common project has eliminated at least 30 bugs
* this foundation is hopefully sound (i.e. no failing edge cases)
* I am finally getting more confident in the overall project health
* will be ready to introduce LSTS programming to a wider audience soon (after full V3 release)

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
