### PR TITLE
Tctx apply callable fsdfss

### DIFF
--- a/LM23COMMON/index.lsts
+++ b/LM23COMMON/index.lsts
@@ -5,3 +5,5 @@ import LM23COMMON/unit-ast-core.lsts;
 import LM23COMMON/unit-tctx-core.lsts;
 import LM23COMMON/unit-prop-core.lsts;
 
+# orphans
+import LM23COMMON/prop-tctx-apply-callable.lsts;

--- a/LM23COMMON/prop-stack-to-specialize.lsts
+++ b/LM23COMMON/prop-stack-to-specialize.lsts
@@ -1,0 +1,4 @@
+
+type StackToSpecialize = { key:CString, ctx:Maybe<TypeContext>, result-type:Type, term: AST };
+
+let stack-to-specialize = [] : List<StackToSpecialize>;

--- a/LM23COMMON/prop-tctx-apply-callable.lsts
+++ b/LM23COMMON/prop-tctx-apply-callable.lsts
@@ -1,0 +1,18 @@
+
+let .apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type): (TypeContext?, Type) = (
+   # Coerce types into denormalized format
+   # TODO: replace with Into<Type::Format::Denormal> parameter types
+   arg-types = denormalize-strong(arg-types);
+   return-type-hint = denormalize-strong(return-type-hint);
+
+   # Find the appropriate function
+   let f-row = tctx.find-callable(fname, arg-types, blame, return-type-hint);
+
+   # Apply function
+   (tctx, let apply-tctx, let closed-type, let return-type) = tctx.apply(fname, f-row.dt, arg-types, blame, return-type-hint);
+
+   # Specialize function if necessary
+   if f-row.dt.is-open then try-specialize(fname, f-row.dt, apply-tctx, closed-type);
+
+   (tctx, return-type)
+);

--- a/LM23COMMON/prop-tctx-apply-callable.lsts
+++ b/LM23COMMON/prop-tctx-apply-callable.lsts
@@ -1,18 +1,38 @@
 
+let .apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST): (TypeContext?, Type) = (
+   tctx.apply-callable(fname, arg-types, blame, ta, true);
+);
+
+let .maybe-apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST): (TypeContext?, Type) = (
+   tctx.apply-callable(fname, arg-types, blame, ta, false);
+);
+
 let .apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type): (TypeContext?, Type) = (
+   tctx.apply-callable(fname, arg-types, blame, return-type-hint, true);
+);
+
+let .maybe-apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type): (TypeContext?, Type) = (
+   tctx.apply-callable(fname, arg-types, blame, return-type-hint, false);
+);
+
+let .apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type, failable: U64): (TypeContext?, Type) = (
    # Coerce types into denormalized format
    # TODO: replace with Into<Type::Format::Denormal> parameter types
    arg-types = denormalize-strong(arg-types);
    return-type-hint = denormalize-strong(return-type-hint);
 
    # Find the appropriate function
-   let f-row = tctx.find-callable(fname, arg-types, blame, return-type-hint);
+   let f-row = tctx.find-callable(fname, arg-types, blame, return-type-hint, failable);
 
-   # Apply function
-   (tctx, let apply-tctx, let closed-type, let return-type) = tctx.apply(fname, f-row.dt, arg-types, blame, return-type-hint);
+   let return-type = ta;
 
-   # Specialize function if necessary
-   if f-row.dt.is-open then try-specialize(fname, f-row.dt, apply-tctx, closed-type);
+   if non-zero(f-row) {
+      # Apply function
+      (tctx, let apply-tctx, let closed-type, return-type) = tctx.apply(fname, f-row.get-or-panic.dt, arg-types, blame, return-type-hint);
+
+      # Specialize function if necessary
+      if f-row.get-or-panic.dt.is-open then try-specialize(fname, f-row.get-or-panic.dt, apply-tctx, closed-type);
+   };
 
    (tctx, return-type)
 );

--- a/LM23COMMON/prop-tctx-apply-callable.lsts
+++ b/LM23COMMON/prop-tctx-apply-callable.lsts
@@ -32,7 +32,7 @@ let .apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: 
    
       # Specialize function if necessary
       if f-row.get-or-panic.dt.is-open {
-         let special-type = closed-type.normalize;
+         let special-type = apply-tctx.substitute(f-row.get-or-panic.nt);
          if not(is-special(fname,special-type)) {
             stack-to-specialize = cons( StackToSpecialize(fname,apply-tctx,special-type,f-row.get-or-panic.blame), stack-to-specialize );
          }

--- a/LM23COMMON/prop-tctx-apply-callable.lsts
+++ b/LM23COMMON/prop-tctx-apply-callable.lsts
@@ -29,11 +29,13 @@ let .apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: 
    if non-zero(f-row) {
       # Apply function
       (tctx, let apply-tctx, let closed-type, return-type) = tctx.apply(fname, f-row.get-or-panic.dt, arg-types, blame, return-type-hint);
-      let special-type = closed-type.normalize;
    
       # Specialize function if necessary
-      if not(is-special(fname,special-type)) {
-         stack-to-specialize = cons( StackToSpecialize(fname,apply-tctx,special-type,f-row.get-or-panic.blame), stack-to-specialize );
+      if f-row.get-or-panic.dt.is-open {
+         let special-type = closed-type.normalize;
+         if not(is-special(fname,special-type)) {
+            stack-to-specialize = cons( StackToSpecialize(fname,apply-tctx,special-type,f-row.get-or-panic.blame), stack-to-specialize );
+         }
       }
    };
 

--- a/LM23COMMON/prop-tctx-apply-callable.lsts
+++ b/LM23COMMON/prop-tctx-apply-callable.lsts
@@ -31,7 +31,9 @@ let .apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: 
       (tctx, let apply-tctx, let closed-type, return-type) = tctx.apply(fname, f-row.get-or-panic.dt, arg-types, blame, return-type-hint);
 
       # Specialize function if necessary
-      if f-row.get-or-panic.dt.is-open then try-specialize(fname, f-row.get-or-panic.dt, apply-tctx, closed-type);
+      if not(is-special(fname,closed-type)) {
+         stack-to-specialize = cons( StackToSpecialize(function-name,f-row,unify-ctx,result-type), stack-to-specialize );
+      }
    };
 
    (tctx, return-type)

--- a/LM23COMMON/prop-tctx-apply-callable.lsts
+++ b/LM23COMMON/prop-tctx-apply-callable.lsts
@@ -29,10 +29,11 @@ let .apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: 
    if non-zero(f-row) {
       # Apply function
       (tctx, let apply-tctx, let closed-type, return-type) = tctx.apply(fname, f-row.get-or-panic.dt, arg-types, blame, return-type-hint);
-
+      let special-type = closed-type.normalize;
+   
       # Specialize function if necessary
-      if not(is-special(fname,closed-type)) {
-         stack-to-specialize = cons( StackToSpecialize(function-name,f-row,unify-ctx,result-type), stack-to-specialize );
+      if not(is-special(fname,special-type)) {
+         stack-to-specialize = cons( StackToSpecialize(fname,apply-tctx,special-type,f-row.get-or-panic.blame), stack-to-specialize );
       }
    };
 

--- a/LM23COMMON/prop-tctx-apply.lsts
+++ b/LM23COMMON/prop-tctx-apply.lsts
@@ -31,8 +31,6 @@ let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST, r
    # Specialize the function type
    let closed-type = apply-tctx.substitute(ft).without-phi-keep-state;
 
-   if fname==c"LEOF" then print("LEOF Apply ctx \{apply-tctx}\n");
-
    # Fail if specialized function is still open
    if closed-type.is-open
    then exit-error("Unification did not close all open type variables in call to \{fname}\nFunction: \{ft}\nArguments: \{at}", blame);

--- a/LM23COMMON/prop-tctx-apply.lsts
+++ b/LM23COMMON/prop-tctx-apply.lsts
@@ -31,6 +31,8 @@ let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST, r
    # Specialize the function type
    let closed-type = apply-tctx.substitute(ft).without-phi-keep-state;
 
+   if fname==c"LEOF" then print("LEOF Apply ctx \{apply-tctx}\n");
+
    # Fail if specialized function is still open
    if closed-type.is-open
    then exit-error("Unification did not close all open type variables in call to \{fname}\nFunction: \{ft}\nArguments: \{at}", blame);

--- a/LM23COMMON/prop-tctx-apply.lsts
+++ b/LM23COMMON/prop-tctx-apply.lsts
@@ -8,7 +8,6 @@ let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST, r
    if not(can-apply(ft, at)) then exit-error("Unable to apply function \{fname}\nFunction: \{ft}\nArguments: \{at}", blame);
 
    # Apply function, then normalize the unification context
-   # If we could remove the normalization here then this whole function would be stateless
    let apply-tctx = if non-zero(return-type-hint)
    then unify(ft.range, return-type-hint, blame).normalize.without-phi-keep-state
    else unify(ft.domain, at, blame).normalize.without-phi-keep-state;

--- a/LM23COMMON/prop-tctx-apply.lsts
+++ b/LM23COMMON/prop-tctx-apply.lsts
@@ -1,11 +1,17 @@
 
 let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST): (TypeContext?, TypeContext?, Type, Type) = (
+   tctx.apply(fname, ft, at, blame, ta);
+);
+
+let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST, return-type-hint: Type): (TypeContext?, TypeContext?, Type, Type) = (
    # Fail if arguments are not accepted by function (<:)
    if not(can-apply(ft, at)) then exit-error("Unable to apply function \{fname}\nFunction: \{ft}\nArguments: \{at}", blame);
 
    # Apply function, then normalize the unification context
    # If we could remove the normalization here then this whole function would be stateless
-   let apply-tctx = unify(ft.domain, at, blame).normalize.without-phi-keep-state;
+   let apply-tctx = if non-zero(return-type-hint)
+   then unify(ft.range, return-type-hint, blame).normalize.without-phi-keep-state
+   else unify(ft.domain, at, blame).normalize.without-phi-keep-state;
 
    # Fail if arguments are not accepted by function (unify)
    if apply-tctx.is-none then exit-error("Unable to apply (unify) function \{fname}\nFunction: \{ft}\nArguments: \{at}", blame);

--- a/LM23COMMON/prop-tctx-find-callable.lsts
+++ b/LM23COMMON/prop-tctx-find-callable.lsts
@@ -46,7 +46,7 @@ let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: A
    }};
 
    # Fail if function needs to be in an unsafe block
-   if non-zero(result) && result.get-or-panic.is-t(c"Unsafe",0) && not(tctx.get-or(mk-tctx()).is-unsafe)
+   if non-zero(result) && result.get-or-panic.dt.is-t(c"Unsafe",0) && not(tctx.get-or(mk-tctx()).is-unsafe)
    then exit-error("Call to unsafe function outside of unsafe block", blame);
 
    # Fail if function call is ambiguous

--- a/LM23COMMON/prop-tctx-find-callable.lsts
+++ b/LM23COMMON/prop-tctx-find-callable.lsts
@@ -1,13 +1,30 @@
 
 # .find-callable is the central hub for all function and constructor calls
 let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST): TypeContextRow = (
-   tctx.find-callable(fname, arg-types, blame, ta);
+   tctx.find-callable(fname, arg-types, blame, ta, true).get-or-panic;
+);
+
+let .maybe-find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST): TypeContextRow? = (
+   tctx.find-callable(fname, arg-types, blame, ta, false);
 );
 
 let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type): TypeContextRow = (
+   tctx.find-callable(fname, arg-types, blame, return-type-hint, true).get-or-panic;
+);
+
+let .maybe-find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type): TypeContextRow? = (
+   tctx.find-callable(fname, arg-types, blame, return-type-hint, false);
+);
+
+let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type, failable: U64): TypeContextRow? = (
+   # Coerce argument types into Type::Format::Denormal
+   # TODO: replace with Into<Type::Format::Denormal>
    arg-types = denormalize-strong(arg-types);
    return-type-hint = denormalize-strong(return-type-hint);
+
    let match-set = mk-vector(type(TypeContextRow));
+
+   # Find all accepting function candidates
    for tr in tctx.lookups(fname) {
       # can-receive is an additional refinement on top of argument satisfaction
       # it is necessary for nullary or partial constructors that need a full type
@@ -16,6 +33,8 @@ let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: A
          match-set = match-set.push(tr);
       }
    };
+
+   # Apply specialization to reduce function candidates down to one
    let result = None : TypeContextRow?;
    for tr1 in match-set { if not(non-zero(result)) {
       let all-accept = true;
@@ -25,19 +44,28 @@ let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: A
       };
       if all-accept { result = Some(tr1) };
    }};
-   if not(non-zero(result)) && match-set.length > 0 {
+
+   # Fail if function needs to be in an unsafe block
+   if non-zero(result) && result.get-or-panic.is-t(c"Unsafe",0) && not(tctx.get-or(mk-tctx()).is-unsafe)
+   then exit-error("Call to unsafe function outside of unsafe block", blame);
+
+   # Fail if function call is ambiguous
+   if failable && not(non-zero(result)) && match-set.length > 0 {
       eprint("Unable to find unambiguous callable: \{fname} \{arg-types}\nAt: \{blame.location}\n");
       for tr in match-set {
          eprint("\{tr.dt}\n");
       };
       exit(1);
    };
-   if not(non-zero(result)) then {
+
+   # Fail if function call is ambiguous
+   if failable && not(non-zero(result)) then {
       print("Unable to find appropriate callable: \{fname} \{arg-types}\nAt: \{blame.location}\n");
       for tr in tctx.lookups(fname) {
          print("Candidate: \{tr.dt}\n");
       };
       exit(1);
    };
-   result.get-or-panic
+
+   result
 );

--- a/LM23COMMON/tctx-lookup.lsts
+++ b/LM23COMMON/tctx-lookup.lsts
@@ -24,6 +24,7 @@ let .lookup(trs: List<TypeContextRow>, key: CString): TypeContextRow = (
    };
    default
 );
+
 let .lookups(tctx: TypeContext?, key: CString): List<TypeContextRow> = tctx.get-or(mk-tctx()).tctx.lookups(key);
 let .lookups(trs: List<TypeContextRow>, key: CString): List<TypeContextRow> = (
    let default = [] : List<TypeContextRow>;

--- a/LM23COMMON/unit-prop-core.lsts
+++ b/LM23COMMON/unit-prop-core.lsts
@@ -7,3 +7,4 @@ import LM23COMMON/prop-denormalize.lsts;
 import LM23COMMON/prop-tctx-apply.lsts;
 import LM23COMMON/prop-tctx-normalize.lsts;
 import LM23COMMON/prop-tctx-find-callable.lsts;
+import LM23COMMON/prop-stack-to-specialize.lsts;

--- a/LM23COMMON/unit-prop-core.lsts
+++ b/LM23COMMON/unit-prop-core.lsts
@@ -7,4 +7,3 @@ import LM23COMMON/prop-denormalize.lsts;
 import LM23COMMON/prop-tctx-apply.lsts;
 import LM23COMMON/prop-tctx-normalize.lsts;
 import LM23COMMON/prop-tctx-find-callable.lsts;
-import LM23COMMON/prop-tctx-apply-callable.lsts;

--- a/LM23COMMON/unit-prop-core.lsts
+++ b/LM23COMMON/unit-prop-core.lsts
@@ -7,3 +7,4 @@ import LM23COMMON/prop-denormalize.lsts;
 import LM23COMMON/prop-tctx-apply.lsts;
 import LM23COMMON/prop-tctx-normalize.lsts;
 import LM23COMMON/prop-tctx-find-callable.lsts;
+import LM23COMMON/prop-tctx-apply-callable.lsts;

--- a/PLUGINS/BACKEND/C/blob-render.lsts
+++ b/PLUGINS/BACKEND/C/blob-render.lsts
@@ -1,5 +1,6 @@
 
 let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContext, S) = (
+   print("Render \{term}\n");
    let r = SNil;
    match term {
       ASTNil{} => ();
@@ -60,7 +61,7 @@ let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContex
       App{ left:Var{key:c"mangle"}, right:App{ left:Lit{key:c":"}, right:App{ left:Lit{id=key}, right:AType{} } } } => r = mangle-identifier(id);
       App{ left:Var{key:c"mangle-pre"}, right:AType{tt=tt} } => (
          r = std-c-mangle-declaration-internal(tt.l1.normalize.rewrite-opaque-type-alias.without-any-phi, term).first;
-         if clone-rope(r)==c"LM_ListLM__LT_LM__GT_" then exit-error("mangle-pre bad \{tt.l1.normalize.rewrite-opaque-type-alias.without-any-phi}\n\{term}\n", term);
+         if clone-rope(r)==c"LM_ListLM__LT_LM__GT_" then exit-error("Bad\n", term);
       );
       App{ left:Var{key:c"mangle-post"}, right:AType{tt=tt} } => r = std-c-mangle-declaration-internal(tt.l1.normalize.rewrite-opaque-type-alias.without-any-phi, term).second;
       App{ left:Abs{ lhs-t=lhs:Var{lhs=key}, rhs:ASTNil{}, tlt=tt }, rhs=right } => (

--- a/PLUGINS/BACKEND/C/blob-render.lsts
+++ b/PLUGINS/BACKEND/C/blob-render.lsts
@@ -58,7 +58,10 @@ let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContex
       );
       App{ left:Var{key:c"uuid"} } => r = SAtom(uuid());
       App{ left:Var{key:c"mangle"}, right:App{ left:Lit{key:c":"}, right:App{ left:Lit{id=key}, right:AType{} } } } => r = mangle-identifier(id);
-      App{ left:Var{key:c"mangle-pre"}, right:AType{tt=tt} } => r = std-c-mangle-declaration-internal(tt.l1.normalize.rewrite-opaque-type-alias.without-any-phi, term).first;
+      App{ left:Var{key:c"mangle-pre"}, right:AType{tt=tt} } => (
+         r = std-c-mangle-declaration-internal(tt.l1.normalize.rewrite-opaque-type-alias.without-any-phi, term).first;
+         if clone-rope(r)==c"LM_ListLM__LT_LM__GT_" then exit-error("mangle-pre bad \{tt.l1.normalize.rewrite-opaque-type-alias.without-any-phi}\n\{term}\n", term);
+      );
       App{ left:Var{key:c"mangle-post"}, right:AType{tt=tt} } => r = std-c-mangle-declaration-internal(tt.l1.normalize.rewrite-opaque-type-alias.without-any-phi, term).second;
       App{ left:Abs{ lhs-t=lhs:Var{lhs=key}, rhs:ASTNil{}, tlt=tt }, rhs=right } => (
          let s = blob-render-simple(ctx, context-key, rhs).second;

--- a/PLUGINS/BACKEND/C/blob-render.lsts
+++ b/PLUGINS/BACKEND/C/blob-render.lsts
@@ -1,6 +1,5 @@
 
 let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContext, S) = (
-   print("Render \{term}\n");
    let r = SNil;
    match term {
       ASTNil{} => ();
@@ -61,7 +60,6 @@ let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContex
       App{ left:Var{key:c"mangle"}, right:App{ left:Lit{key:c":"}, right:App{ left:Lit{id=key}, right:AType{} } } } => r = mangle-identifier(id);
       App{ left:Var{key:c"mangle-pre"}, right:AType{tt=tt} } => (
          r = std-c-mangle-declaration-internal(tt.l1.normalize.rewrite-opaque-type-alias.without-any-phi, term).first;
-         if clone-rope(r)==c"LM_ListLM__LT_LM__GT_" then exit-error("Bad\n", term);
       );
       App{ left:Var{key:c"mangle-post"}, right:AType{tt=tt} } => r = std-c-mangle-declaration-internal(tt.l1.normalize.rewrite-opaque-type-alias.without-any-phi, term).second;
       App{ left:Abs{ lhs-t=lhs:Var{lhs=key}, rhs:ASTNil{}, tlt=tt }, rhs=right } => (

--- a/PLUGINS/BACKEND/C/cc-blob.lsts
+++ b/PLUGINS/BACKEND/C/cc-blob.lsts
@@ -1,6 +1,7 @@
 
 let cc-blob(callee-ctx: FContext, function-name: CString, args-tt: Type, blame: AST): Fragment = (
    let f = Some(mk-tctx()).find-callable(function-name, args-tt, blame).blame;
+   if typeof-term(f).is-open then exit-error("STD C cc-blob is open \{function-name} (\{args-tt})\n", blame);
    match f {
       Glb{val:Abs{rhs=rhs}} => (
          let r = blob-render(callee-ctx, rhs, mk-fragment());

--- a/PLUGINS/BACKEND/C/std-c-compile-call.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-call.lsts
@@ -16,6 +16,7 @@ let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor
       }; r
    } else if typeof-term(fterm).is-t(c"Prop",0) { std-c-compile-expr(ctx, args, false)
    } else {
+      if typeof-term(fterm).is-open then exit-error("STD C Compile Call is open \{fname} (\{typeof-term(args)}) : \{return-hint-if-constructor}\n", args);
       let push-args = std-c-compile-push-args(ctx, args);
       let function-id = if typeof-term(fterm).is-t(c"FFI",0) || typeof-term(fterm).is-t(c"C-FFI",0)
                         then fname else mangle-identifier-function(fname, typeof-term(fterm));

--- a/PLUGINS/BACKEND/C/std-c-compile-call.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-call.lsts
@@ -5,6 +5,7 @@ let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor
    let fterm = Some(mk-tctx()).find-callable(fname, typeof-term(args), args, return-hint-if-constructor).blame;
    if not(non-zero(fterm)) then fail("std-c-compile-call Function was null: \{fterm}\nArguments: \{typeof-term(args)}\n");
    if typeof-term(fterm).is-t(c"Blob",0) {
+      if typeof-term(fterm).is-open then exit-error("STD C compile call is open \{fname} (\{typeof-term(args)})\n\{typeof-term(fterm)}\n", args);
       let r = mk-fragment();
       match fterm {
          Glb{val:Abs{lhs=lhs, rhs=rhs}} => (
@@ -16,6 +17,7 @@ let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor
       }; r
    } else if typeof-term(fterm).is-t(c"Prop",0) { std-c-compile-expr(ctx, args, false)
    } else {
+      if typeof-term(fterm).is-open then exit-error("STD C compile call is open \{fname} (\{typeof-term(args)})\n\{typeof-term(fterm)}\n", args);
       let push-args = std-c-compile-push-args(ctx, args);
       let function-id = if typeof-term(fterm).is-t(c"FFI",0) || typeof-term(fterm).is-t(c"C-FFI",0)
                         then fname else mangle-identifier-function(fname, typeof-term(fterm));

--- a/PLUGINS/BACKEND/C/std-c-compile-call.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-call.lsts
@@ -3,8 +3,10 @@ let std-c-compile-call(ctx: FContext, fname: CString, args: AST): Fragment = std
 
 let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor: Type, args: AST): Fragment = (
    let fterm = Some(mk-tctx()).find-callable(fname, typeof-term(args), args, return-hint-if-constructor).blame;
+   if fname=="LEOF" then print("LEOF (\{typeof-term(args)}) : \{return-hint-if-constructor} = \{typeof-term(fterm)}\n\{fterm}\n");
    if not(non-zero(fterm)) then fail("std-c-compile-call Function was null: \{fterm}\nArguments: \{typeof-term(args)}\n");
    if typeof-term(fterm).is-t(c"Blob",0) {
+      if typeof-term(fterm).is-open then exit-error("STD C Compile Call is open \{fname} (\{typeof-term(args)}) : \{return-hint-if-constructor}\n", args);
       let r = mk-fragment();
       match fterm {
          Glb{val:Abs{lhs=lhs, rhs=rhs}} => (

--- a/PLUGINS/BACKEND/C/std-c-compile-call.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-call.lsts
@@ -3,10 +3,9 @@ let std-c-compile-call(ctx: FContext, fname: CString, args: AST): Fragment = std
 
 let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor: Type, args: AST): Fragment = (
    let fterm = Some(mk-tctx()).find-callable(fname, typeof-term(args), args, return-hint-if-constructor).blame;
-   if fname=="LEOF" then print("LEOF (\{typeof-term(args)}) : \{return-hint-if-constructor} = \{typeof-term(fterm)}\n\{fterm}\n");
    if not(non-zero(fterm)) then fail("std-c-compile-call Function was null: \{fterm}\nArguments: \{typeof-term(args)}\n");
    if typeof-term(fterm).is-t(c"Blob",0) {
-      if typeof-term(fterm).is-open then exit-error("STD C Compile Call is open \{fname} (\{typeof-term(args)}) : \{return-hint-if-constructor}\n", args);
+      if typeof-term(fterm).is-open then exit-error("STD C Compile Call is open \{fname} (\{typeof-term(args)}) : \{return-hint-if-constructor}\n\{typeof-term(fterm)}", args);
       let r = mk-fragment();
       match fterm {
          Glb{val:Abs{lhs=lhs, rhs=rhs}} => (
@@ -18,7 +17,7 @@ let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor
       }; r
    } else if typeof-term(fterm).is-t(c"Prop",0) { std-c-compile-expr(ctx, args, false)
    } else {
-      if typeof-term(fterm).is-open then exit-error("STD C Compile Call is open \{fname} (\{typeof-term(args)}) : \{return-hint-if-constructor}\n", args);
+      if typeof-term(fterm).is-open then exit-error("STD C Compile Call is open \{fname} (\{typeof-term(args)}) : \{return-hint-if-constructor}\n\{typeof-term(fterm)}", args);
       let push-args = std-c-compile-push-args(ctx, args);
       let function-id = if typeof-term(fterm).is-t(c"FFI",0) || typeof-term(fterm).is-t(c"C-FFI",0)
                         then fname else mangle-identifier-function(fname, typeof-term(fterm));

--- a/PLUGINS/BACKEND/C/std-c-compile-call.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-call.lsts
@@ -5,7 +5,6 @@ let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor
    let fterm = Some(mk-tctx()).find-callable(fname, typeof-term(args), args, return-hint-if-constructor).blame;
    if not(non-zero(fterm)) then fail("std-c-compile-call Function was null: \{fterm}\nArguments: \{typeof-term(args)}\n");
    if typeof-term(fterm).is-t(c"Blob",0) {
-      if typeof-term(fterm).is-open then exit-error("STD C Compile Call is open \{fname} (\{typeof-term(args)}) : \{return-hint-if-constructor}\n\{typeof-term(fterm)}", args);
       let r = mk-fragment();
       match fterm {
          Glb{val:Abs{lhs=lhs, rhs=rhs}} => (
@@ -17,7 +16,6 @@ let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor
       }; r
    } else if typeof-term(fterm).is-t(c"Prop",0) { std-c-compile-expr(ctx, args, false)
    } else {
-      if typeof-term(fterm).is-open then exit-error("STD C Compile Call is open \{fname} (\{typeof-term(args)}) : \{return-hint-if-constructor}\n\{typeof-term(fterm)}", args);
       let push-args = std-c-compile-push-args(ctx, args);
       let function-id = if typeof-term(fterm).is-t(c"FFI",0) || typeof-term(fterm).is-t(c"C-FFI",0)
                         then fname else mangle-identifier-function(fname, typeof-term(fterm));

--- a/PLUGINS/BACKEND/C/std-c-mangle-declaration.lsts
+++ b/PLUGINS/BACKEND/C/std-c-mangle-declaration.lsts
@@ -1,7 +1,7 @@
 
 let std-c-mangle-declaration(tt: Type, blame: AST): Tuple<S,S> = (
    let is-flexible-array-member = tt.is-t(c"FlexibleArrayMember",0);
-   std-c-mangle-declaration-internal(tt.normalize.rewrite-opaque-type-alias.without-phi, is-flexible-array-member, blame)
+   std-c-mangle-declaration-internal(tt.normalize.rewrite-opaque-type-alias.without-phi, is-flexible-array-member, blame);
 );
 
 let std-c-mangle-declaration-internal(tt: Type, blame: AST): Tuple<S,S> = std-c-mangle-declaration-internal(tt, false, blame);

--- a/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
+++ b/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
@@ -576,12 +576,12 @@ let std-c-expr-of-statement(t: CTerm): AST = (
             (preamble, let arg1-rhs) = std-c-lift-lhs(std-c-expr-of-statement(arg1.get-or-panic));
             if non-zero(arg1-rhs)
             then arg1-rhs
-            else mk-lit(c"").ascript(t0(c"L"))
-         } else { mk-lit(c"").ascript(t0(c"L")) };
+            else mk-lit(c"").ascript(t0(c"L") && t0(c"Literal"))
+         } else { mk-lit(c"").ascript(t0(c"L") && t0(c"Literal")) };
          if arg2.is-some then { args = mk-cons(args, std-c-expr-of-statement(arg2.get-or-panic)); }
-         else { args = mk-cons(args, mk-lit(c"").ascript(t0(c"L"))); };
+         else { args = mk-cons(args, mk-lit(c"").ascript(t0(c"L") && t0(c"Literal"))); };
          if arg3.is-some then { args = mk-cons(args, std-c-expr-of-statement(arg3.get-or-panic)); }
-         else { args = mk-cons(args, mk-lit(c"").ascript(t0(c"L"))); };
+         else { args = mk-cons(args, mk-lit(c"").ascript(t0(c"L") && t0(c"Literal"))); };
          args = mk-cons(args, std-c-expr-of-statement(stmt));
          let for-expr = mk-app(
             Var( c"c::for", with-location(mk-token("c::for"),op.location) ),

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -605,6 +605,7 @@ let lsts-parse-ascript(tokens: List<Token>): Tuple<AST,List<Token>> = (
    while lsts-parse-head(tokens)==c":" && non-zero(tokens) && lsts-parse-head(tail(tokens)) != c":" {
       tokens = tail(tokens);
       (let tt, tokens) = lsts-parse-type(tokens);
+      if tt.is-t(c"L",0) then tt = tt && t0(c"Literal");
       tt = phi-as-state(tt).expand-implied-phi;
       match term {
          App{ constructor=left:Lit{}, right:ASTNil{} } => (

--- a/SRC/apply-and-specialize.lsts
+++ b/SRC/apply-and-specialize.lsts
@@ -4,7 +4,7 @@ let apply-and-specialize(tctx: TypeContext?, fname: CString, ft: Type, ft-denorm
    (tctx, let apply-tctx, let closed-type, let return-type) = tctx.apply(fname, ft-denormal, at, blame);
    if ft.is-open then {
       let special-tctx = apply-tctx.with-pctx( original-tctx.get-or(mk-tctx()).pctx );
-      try-specialize(fname, ft-denormal, special-tctx, closed-type);
+      try-specialize(fname, ft, special-tctx, closed-type);
    };
    if fname==c"mark-as-released" then tctx = phi-move(tctx,at,blame); 
    (tctx, return-type)

--- a/SRC/apply-and-specialize.lsts
+++ b/SRC/apply-and-specialize.lsts
@@ -4,7 +4,7 @@ let apply-and-specialize(tctx: TypeContext?, fname: CString, ft: Type, ft-denorm
    (tctx, let apply-tctx, let closed-type, let return-type) = tctx.apply(fname, ft-denormal, at, blame);
    if ft.is-open then {
       let special-tctx = apply-tctx.with-pctx( original-tctx.get-or(mk-tctx()).pctx );
-      try-specialize(fname, ft, special-tctx, closed-type);
+      try-specialize(fname, ft-denormal, special-tctx, closed-type);
    };
    if fname==c"mark-as-released" then tctx = phi-move(tctx,at,blame); 
    (tctx, return-type)

--- a/SRC/ast-definitions.lsts
+++ b/SRC/ast-definitions.lsts
@@ -28,8 +28,6 @@ let .into(tr: TypeContextRow, tt: Type<String>): String = "TypeContextRow{ key: 
 
 type alias AContext = List<(CString,AST)>;
 
-type StackToSpecialize = { key:CString, pre-type:Type, ctx:Maybe<TypeContext>, post-type:Type };
-
 type ParsePartial = PME{ term:AST , remainder:List<Token> };
 
 type ApplyResult = { function-type:Type , return-type:Type };

--- a/SRC/find-global-callable.lsts
+++ b/SRC/find-global-callable.lsts
@@ -1,46 +1,4 @@
 
-let apply-global-constructor(tctx: TypeContext?, fname: CString, hint: Type, arg-types: Type, blame: AST): (TypeContext?, Type) = (
-   hint = hint.rewrite-type-alias;
-   let result = ta;
-   let simple = ta;
-   if non-zero(hint) && hint.is-type {
-      for Tuple{ot=first, kt=second, t=third} in global-type-context-denormal.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
-         if (not(non-zero(hint)) || can-receive(ot, hint)) && (not(non-zero(arg-types)) || can-apply(ot, arg-types)) {
-            let next = if non-zero(hint)
-            then unify(ot.range,hint,blame).normalize.substitute(kt)
-            else kt;
-            simple = ot;
-            if non-zero(result) then result = result && next else result = next;
-         }
-      };
-   } else {
-      for Tuple{ot=first, kt=second, t=third} in global-type-context-denormal.lookup(fname, [] : List<Tuple<Type,Type,AST>>) {
-         if not(non-zero(arg-types)) || can-apply(ot, arg-types) {
-            let next = if non-zero(hint)
-            then hint
-            else kt;
-            simple = ot;
-            if non-zero(result) then result = result && next else result = next;
-         }
-      };
-   };
-   if not(non-zero(result)) && non-zero(hint) && not(hint.is-type) then result = hint
-   else if not(non-zero(result)) then exit-error("Unable to apply appropriate global constructor: \{fname} :: \{hint} (\{arg-types})", blame);
-   if result.is-arrow && non-zero(arg-types) {
-      let inner-tctx = if non-zero(hint)
-      then unify(simple.range, hint, blame).normalize
-      else unify(simple.domain, arg-types, blame).normalize;
-      let closed-type = inner-tctx.substitute(simple);
-      if simple.is-open then try-specialize(fname, simple, inner-tctx, closed-type);
-      result = inner-tctx.substitute(simple.range);
-      for prow in inner-tctx.get-or(mk-tctx()).pctx {
-         tctx = tctx.bind-phi(prow.phi-id, prow.phi-tt, blame);
-      };
-   };
-   tctx = tctx.apply-move-args(simple, arg-types, blame);
-   (tctx, result)
-);
-
 let apply-global-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST): (TypeContext?, Type) = apply-global-callable(tctx,fname,arg-types,blame,true);
 let maybe-apply-global-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST): (TypeContext?, Type) = apply-global-callable(tctx,fname,arg-types,blame,false);
 

--- a/SRC/index-globals.lsts
+++ b/SRC/index-globals.lsts
@@ -28,6 +28,4 @@ let global-ctx = FCtxEOF;
 
 let parse-suffixes = [] : List<(CString,Type)>;
 
-let stack-to-specialize = [] : List<StackToSpecialize>;
-
 let config-v3 = true;

--- a/SRC/infer-global-terms.lsts
+++ b/SRC/infer-global-terms.lsts
@@ -41,11 +41,10 @@ let infer-global-terms(tctx: TypeContext?, term: AST): (TypeContext?, AST) = (
                kto = new-kto;
             );
          };
-         let ktn = kto.normalize;
          let ktd = kto && t0(c"GlobalVariable");
-         global-type-context-normal = global-type-context-normal.bind(k.key, ktn, term);
+         global-type-context-normal = global-type-context-normal.bind(k.key, kto, term);
          global-type-context-denormal = global-type-context-denormal.bind(k.key, ktd, term);
-         tctx = tctx.bind-global(k.key, ktn, ktd, term);
+         tctx = tctx.bind-global(k.key, kto, ktd, term);
          mark-global-as-seen(k.key, ktd, ta);
          ascript(term, ktd);
          (tctx, _) = maybe-apply-global-callable(tctx,c"mov", t2(c"Cons",ktd,ktd), term);

--- a/SRC/infer-type-definition.lsts
+++ b/SRC/infer-type-definition.lsts
@@ -174,47 +174,47 @@ let infer-type-yield-constructor(base-type: Type, case-tag: CString, case-number
 
    let return-id = uuid();
  
-   let body = mk-lit(c"({").ascript(t0(c"L"));
+   let body = mk-lit(c"({").ascript(t0(c"L") && t0(c"Literal"));
    body = mk-cons(body, mk-app(mk-var(c"mangle-pre"),mk-atype(t1(c"Type",base-type))) );
-   body = mk-cons(body, mk-lit(c" ").ascript(t0(c"L")));
-   body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L")));
+   body = mk-cons(body, mk-lit(c" ").ascript(t0(c"L") && t0(c"Literal")));
+   body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L") && t0(c"Literal")));
    body = mk-cons(body, mk-app(mk-var(c"mangle-post"),mk-atype(t1(c"Type",base-type))) );
-   body = mk-cons(body, mk-lit(c";").ascript(t0(c"L")));
-   body = mk-cons(body, mk-lit(c"memset(&").ascript(t0(c"L")));
-   body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L")));
-   body = mk-cons(body, mk-lit(c",0,sizeof ").ascript(t0(c"L")));
-   body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L")));
-   body = mk-cons(body, mk-lit(c");").ascript(t0(c"L")));
+   body = mk-cons(body, mk-lit(c";").ascript(t0(c"L") && t0(c"Literal")));
+   body = mk-cons(body, mk-lit(c"memset(&").ascript(t0(c"L") && t0(c"Literal")));
+   body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L") && t0(c"Literal")));
+   body = mk-cons(body, mk-lit(c",0,sizeof ").ascript(t0(c"L") && t0(c"Literal")));
+   body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L") && t0(c"Literal")));
+   body = mk-cons(body, mk-lit(c");").ascript(t0(c"L") && t0(c"Literal")));
 
    if has-tag-case {
-      body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L")) );
-      body = mk-cons(body, mk-lit(c".discriminator_case_tag=").ascript(t0(c"L")));
-      body = mk-cons(body, mk-lit(to-string(case-number)).ascript(t0(c"L")) );
-      body = mk-cons(body, mk-lit(c";").ascript(t0(c"L")));
+      body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L") && t0(c"Literal")) );
+      body = mk-cons(body, mk-lit(c".discriminator_case_tag=").ascript(t0(c"L") && t0(c"Literal")));
+      body = mk-cons(body, mk-lit(to-string(case-number)).ascript(t0(c"L") && t0(c"Literal")) );
+      body = mk-cons(body, mk-lit(c";").ascript(t0(c"L") && t0(c"Literal")));
    };
 
    for Tuple{field-name=first, field-type=second} in common-fields.reverse {
       let mangled-field-name = c"0_" + field-name;
-      body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L")) );
-      body = mk-cons(body, mk-lit(c".").ascript(t0(c"L")));
-      body = mk-cons(body, mk-app(mk-var(c"mangle"),mk-lit(mangled-field-name).ascript(t0(c"L"))) );
-      body = mk-cons(body, mk-lit(c"=").ascript(t0(c"L")));
+      body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L") && t0(c"Literal")) );
+      body = mk-cons(body, mk-lit(c".").ascript(t0(c"L") && t0(c"Literal")));
+      body = mk-cons(body, mk-app(mk-var(c"mangle"),mk-lit(mangled-field-name).ascript(t0(c"L") && t0(c"Literal"))) );
+      body = mk-cons(body, mk-lit(c"=").ascript(t0(c"L") && t0(c"Literal")));
       body = mk-cons(body, mk-var(mangled-field-name) );
-      body = mk-cons(body, mk-lit(c";").ascript(t0(c"L")));
+      body = mk-cons(body, mk-lit(c";").ascript(t0(c"L") && t0(c"Literal")));
    };
 
    for Tuple{field-name=first, field-type=second} in case-fields.reverse {
       let mangled-field-name = to-string(case-number) + c"_" + field-name;
-      body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L")) );
-      body = mk-cons(body, mk-lit(c".").ascript(t0(c"L")));
-      body = mk-cons(body, mk-app(mk-var(c"mangle"),mk-lit(mangled-field-name).ascript(t0(c"L"))) );
-      body = mk-cons(body, mk-lit(c"=").ascript(t0(c"L")));
+      body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L") && t0(c"Literal")) );
+      body = mk-cons(body, mk-lit(c".").ascript(t0(c"L") && t0(c"Literal")));
+      body = mk-cons(body, mk-app(mk-var(c"mangle"),mk-lit(mangled-field-name).ascript(t0(c"L") && t0(c"Literal"))) );
+      body = mk-cons(body, mk-lit(c"=").ascript(t0(c"L") && t0(c"Literal")));
       body = mk-cons(body, mk-var(mangled-field-name) );
-      body = mk-cons(body, mk-lit(c";").ascript(t0(c"L")));
+      body = mk-cons(body, mk-lit(c";").ascript(t0(c"L") && t0(c"Literal")));
    };
 
-   body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L")));
-   body = mk-cons(body, mk-lit(c";})").ascript(t0(c"L")));
+   body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L") && t0(c"Literal")));
+   body = mk-cons(body, mk-lit(c";})").ascript(t0(c"L") && t0(c"Literal")));
 
    let constructor = mk-glb( mk-token(case-tag).with-location(blame.location), mk-abs(args, body.ascript(base-type.expand-implied-phi), t0(c"Blob") ) );
 

--- a/SRC/specialize.lsts
+++ b/SRC/specialize.lsts
@@ -6,6 +6,5 @@ let specialize(key: CString, unify-ctx: TypeContext?, result-type: Type, term: A
       infer-global-context(special-term);
       (_, special-term) = std-infer-expr(global-flow-tctx, special-term, false, Used, ta);
       ast-parsed-program = ast-parsed-program + special-term;
-      if key=="LEOF" then print("specialize LEOF : \{result-type}\n\{special-term}\n");
    }
 );

--- a/SRC/specialize.lsts
+++ b/SRC/specialize.lsts
@@ -1,7 +1,7 @@
 
 let specialize(key: CString, unify-ctx: TypeContext?, result-type: Type, term: AST): Nil = (
    if not(is-special(key, result-type)) {
-      if key==c"Equal" then print("Specialize \{key} : \{result-type}\n");
+      if key==c".discriminator-case-tag" then print("try specialize \{key} \{typeof-term(term)} = \{result-type}\n");
       mark-as-special(key, result-type);
       let special-term = substitute(unify-ctx, term);
       infer-global-context(special-term);

--- a/SRC/specialize.lsts
+++ b/SRC/specialize.lsts
@@ -1,21 +1,11 @@
 
-let specialize(key: CString, ft: Type, unify-ctx: TypeContext?, result-type: Type): Nil = (
-   let result-type-without-phi = result-type.without-any-phi;
-   if not(is-special(key, result-type-without-phi)) {
-      let term = mk-eof();
-      for Tuple{kt=first, t=third} in global-type-context-normal.lookup(key, [] : List<(Type,Type,AST)>) {
-         if ft == kt { match t {
-            Glb{val:Abs{}} => term = t;
-            _ => ();
-         }}
-      };
-      if non-zero(term) {
-         mark-as-special(key, result-type-without-phi);
-         let special-term = substitute(unify-ctx, term);
-         infer-global-context(special-term);
-         (_, special-term) = std-infer-expr(global-flow-tctx, special-term, false, Used, ta);
-         ast-parsed-program = ast-parsed-program + special-term;
-         if key=="LEOF" then print("specialize LEOF : \{result-type}\n\{special-term}\n");
-      }
+let specialize(key: CString, unify-ctx: TypeContext?, result-type: Type, term: AST): Nil = (
+   if not(is-special(key, result-type)) {
+      mark-as-special(key, result-type);
+      let special-term = substitute(unify-ctx, term);
+      infer-global-context(special-term);
+      (_, special-term) = std-infer-expr(global-flow-tctx, special-term, false, Used, ta);
+      ast-parsed-program = ast-parsed-program + special-term;
+      if key=="LEOF" then print("specialize LEOF : \{result-type}\n\{special-term}\n");
    }
 );

--- a/SRC/specialize.lsts
+++ b/SRC/specialize.lsts
@@ -15,6 +15,7 @@ let specialize(key: CString, ft: Type, unify-ctx: TypeContext?, result-type: Typ
          infer-global-context(special-term);
          (_, special-term) = std-infer-expr(global-flow-tctx, special-term, false, Used, ta);
          ast-parsed-program = ast-parsed-program + special-term;
+         if key=="LEOF" then print("specialize LEOF : \{result-type}\n\{special-term}\n");
       }
    }
 );

--- a/SRC/specialize.lsts
+++ b/SRC/specialize.lsts
@@ -1,6 +1,7 @@
 
 let specialize(key: CString, unify-ctx: TypeContext?, result-type: Type, term: AST): Nil = (
    if not(is-special(key, result-type)) {
+      if key==c"Equal" then print("Specialize \{key} : \{result-type}\n");
       mark-as-special(key, result-type);
       let special-term = substitute(unify-ctx, term);
       infer-global-context(special-term);

--- a/SRC/specialize.lsts
+++ b/SRC/specialize.lsts
@@ -1,7 +1,6 @@
 
 let specialize(key: CString, unify-ctx: TypeContext?, result-type: Type, term: AST): Nil = (
    if not(is-special(key, result-type)) {
-      if key==c".discriminator-case-tag" then print("try specialize \{key} \{typeof-term(term)} = \{result-type}\n");
       mark-as-special(key, result-type);
       let special-term = substitute(unify-ctx, term);
       infer-global-context(special-term);

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -67,7 +67,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
       );
       App{asc=left:Lit{key:c":"}, right:App{t=left,right:AType{tt=tt}}} => (
          if tt.is-t(c"String",0) {
-            term = t.ascript(t0(c"CString"));
+            term = t.ascript(t0(c"CString") && t0(c"Literal"));
             term = mk-app(mk-var(c"intern"),term);
             (tctx, term) = std-infer-expr(tctx, term, false, Tail, ta);
          } else {
@@ -208,15 +208,14 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          } else if not(non-zero(typeof-term(term))) {
             if hint.is-t(c"List",1) && hint.is-type && key==c"LEOF"
             then {
-               (tctx, let lit-tt) = apply-global-constructor(tctx, key, hint, t0(c"Nil"), term);
-               ascript(term,lit-tt);
+               (tctx, let lit-tt) = tctx.apply-callable(key, t0(c"Nil"), term, hint);
+               ascript(term, lit-tt);
             } else if hint.is-t(c"HashtableEq",2) && hint.is-type && key==c"HashtableEqEOF"
             then {
-               (tctx, let lit-tt) = apply-global-constructor(tctx, key, hint, t0(c"Nil"), term);
-               ascript(term,lit-tt);
+               (tctx, let lit-tt) = tctx.apply-callable(key, t0(c"Nil"), term, hint);
+               ascript(term, lit-tt);
             } else {
-               (tctx, let lit-tt) = apply-global-constructor(tctx, key, hint, ta, term);
-               ascript(term,lit-tt);
+               ascript(term, t2(c"Arrow",t0(c"Any"),t0(c"Any")));
             }
          }
       );
@@ -294,7 +293,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                };
                (tctx, rt) = if typeof-term(l).is-arrow && non-zero(lit-name-if-lit(l)) {
                   let direct-hint = hint-if-hint(l);
-                  (tctx, rt) = apply-global-constructor(tctx, lit-name-if-lit(l), direct-hint, typeof-term(r), term);
+                  (tctx, rt) = tctx.apply-callable(lit-name-if-lit(l), typeof-term(r), term, direct-hint);
                   (tctx, rt)
                } else if typeof-term(l).is-arrow && non-zero(var-name-if-var-or-lit(l)) {
                   (tctx, rt) = apply-global-callable(tctx, var-name-if-var-or-lit(l), typeof-term(r), term); (tctx, rt)
@@ -330,6 +329,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
    if used.is-unused && typeof-term(term).slot(c"Phi::State",1).l1.slot(c"MustRelease::ToRelease",1).l1.is-t(c"Linear",1) {
       (tctx, term) = wrap-call(tctx, c".release", term);
    };
+   print("\{term} : \{typeof-term(term)}\n");
    (tctx, term);
 );
 

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -329,7 +329,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
    if used.is-unused && typeof-term(term).slot(c"Phi::State",1).l1.slot(c"MustRelease::ToRelease",1).l1.is-t(c"Linear",1) {
       (tctx, term) = wrap-call(tctx, c".release", term);
    };
-   print("\{term} : \{typeof-term(term)}\n");
    (tctx, term);
 );
 

--- a/SRC/try-specialize.lsts
+++ b/SRC/try-specialize.lsts
@@ -1,6 +1,6 @@
 
 let try-specialize(function-name: CString, ft: Type, unify-ctx: TypeContext?, result-type: Type): Nil = (
-   result-type = result-type.normalize;
+   result-type = unify-ctx.substitute(ft);
    for Tuple{ kt=first, t=third } in global-type-context-normal.lookup(function-name, [] : List<(Type,Type,AST)>) {
       if kt==ft && not(is-special(function-name,result-type)) { match t {
          Glb{val:Abs{}} => stack-to-specialize = cons( StackToSpecialize(function-name,unify-ctx,result-type,t), stack-to-specialize );

--- a/SRC/try-specialize.lsts
+++ b/SRC/try-specialize.lsts
@@ -1,5 +1,6 @@
 
 let try-specialize(function-name: CString, ft: Type, unify-ctx: TypeContext?, result-type: Type): Nil = (
+   result-type = result-type.normalize;
    for Tuple{ kt=first, t=third } in global-type-context-normal.lookup(function-name, [] : List<(Type,Type,AST)>) {
       if kt==ft && not(is-special(function-name,result-type)) { match t {
          Glb{val:Abs{}} => stack-to-specialize = cons( StackToSpecialize(function-name,unify-ctx,result-type,t), stack-to-specialize );

--- a/SRC/try-specialize.lsts
+++ b/SRC/try-specialize.lsts
@@ -2,7 +2,7 @@
 let try-specialize(function-name: CString, ft: Type, unify-ctx: TypeContext?, result-type: Type): Nil = (
    for Tuple{ kt=first, t=third } in global-type-context-normal.lookup(function-name, [] : List<(Type,Type,AST)>) {
       if kt==ft && not(is-special(function-name,result-type)) { match t {
-         Glb{val:Abs{}} => stack-to-specialize = cons( StackToSpecialize(function-name,ft,unify-ctx,result-type), stack-to-specialize );
+         Glb{val:Abs{}} => stack-to-specialize = cons( StackToSpecialize(function-name,unify-ctx,result-type,t), stack-to-specialize );
          _ => ();
       }}
    }

--- a/SRC/typecheck.lsts
+++ b/SRC/typecheck.lsts
@@ -12,7 +12,7 @@ let typecheck(): Nil = (
       # this can't be a normal for-loop because it gets extended during iteration
       [StackToSpecialize{ key=key, ctx=ctx, result-type=result-type, term=term }.. rst] => (
          stack-to-specialize = rst;
-         specialize(key, ctx, post-type, term);
+         specialize(key, ctx, result-type, term);
       );
    }};
    validate-interfaces();

--- a/SRC/typecheck.lsts
+++ b/SRC/typecheck.lsts
@@ -10,9 +10,9 @@ let typecheck(): Nil = (
    (global-flow-tctx, ast-parsed-program) = std-infer-expr(global-flow-tctx, ast-parsed-program, false, Used, ta);
    while non-zero(stack-to-specialize) { match stack-to-specialize {
       # this can't be a normal for-loop because it gets extended during iteration
-      [StackToSpecialize{ key=key, pre-type=pre-type, ctx=ctx, post-type=post-type }.. rst] => (
+      [StackToSpecialize{ key=key, ctx=ctx, result-type=result-type, term=term }.. rst] => (
          stack-to-specialize = rst;
-         specialize(key, pre-type, ctx, post-type);
+         specialize(key, ctx, post-type, term);
       );
    }};
    validate-interfaces();


### PR DESCRIPTION
## Describe your changes
Features:
* `tctx.apply-callable` for constructors
* putting information into the stack-to-specialize is stable
* this is the core function logic loop, and it is almost fully stable
* started with the constructor case, which is more complicated
* normal function application should fold easily next turn
* no tests yet though

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
