### PR TITLE
Gc enabled hashtable fsduif

### DIFF
--- a/LM23COMMON/type-as-return-hint.lsts
+++ b/LM23COMMON/type-as-return-hint.lsts
@@ -1,0 +1,18 @@
+
+let .as-return-hint(tt: Type): Type = (
+   match tt {
+      TAnd { conjugate=conjugate } => (
+         let result = mk-vector(type(Type), 0_u64);
+         for c in conjugate {
+            c = c.as-return-hint;
+            if non-zero(c) then result = result.push(c);
+         };
+         if result.length==0 then ta
+         else if result.length==1 then result[0]
+         else tand(result)
+      );
+      TGround { tag:c"TailPosition", parameters:[] } => ta;
+      TVar {} => ta;
+      _ => tt;
+   }
+);

--- a/LM23COMMON/unit-type-core.lsts
+++ b/LM23COMMON/unit-type-core.lsts
@@ -36,3 +36,4 @@ import LM23COMMON/type-can-receive.lsts;
 import LM23COMMON/type-without-phi-keep-state.lsts;
 import LM23COMMON/type-without-phi-keep-id.lsts;
 import LM23COMMON/type-most-special.lsts;
+import LM23COMMON/type-as-return-hint.lsts;

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -652,7 +652,9 @@ let lsts-parse-mul(tokens: List<Token>): Tuple<AST,List<Token>> = (
 
 let lsts-parse-map(tokens: List<Token>): Tuple<AST,List<Token>> = (
    lsts-parse-expect(c"{", tokens); let loc = head(tokens).location; tokens = tail(tokens);
-   let term = Lit( c"HashtableEqEOF", with-location(mk-token("HashtableEqEOF"),loc) );
+   let term = if config-v3
+   then mk-app( Var( c"mk-hashtable", with-location(mk-token("mk-hashtable"),loc) ), mk-nil() )
+   else Lit( c"HashtableEqEOF", with-location(mk-token("HashtableEqEOF"),loc) );
    if lsts-parse-head(tokens)==c"for" {
       fail("TODO map comprehension at \{loc}\n")
    } else {

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -272,12 +272,15 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                };
                (tctx, let function-type, rt) = if typeof-term(l).is-arrow && non-zero(lit-name-if-lit(l)) {
                   let direct-hint = hint-if-hint(l);
-                  let function-type = tctx.find-callable(var-name-if-var-or-lit(l), typeof-term(r), term, hint).nt;
-                  (tctx, rt) = tctx.apply-callable(lit-name-if-lit(l), typeof-term(r), term, direct-hint && hint);
+                  if hint.is-t(c"ReturnHint",0) then direct-hint = direct-hint && hint;
+                  let function-type = tctx.find-callable(var-name-if-var-or-lit(l), typeof-term(r), term, direct-hint.as-return-hint).nt;
+                  (tctx, rt) = tctx.apply-callable(lit-name-if-lit(l), typeof-term(r), term, direct-hint.as-return-hint);
                   (tctx, function-type, rt)
                } else if typeof-term(l).is-arrow && non-zero(var-name-if-var-or-lit(l)) {
-                  let function-type = tctx.find-callable(var-name-if-var-or-lit(l), typeof-term(r), term, hint).nt;
-                  (tctx, rt) = tctx.apply-callable(var-name-if-var-or-lit(l), typeof-term(r), term, hint);
+                  let direct-hint = ta;
+                  if hint.is-t(c"ReturnHint",0) then direct-hint = direct-hint && hint;
+                  let function-type = tctx.find-callable(var-name-if-var-or-lit(l), typeof-term(r), term, direct-hint.as-return-hint).nt;
+                  (tctx, rt) = tctx.apply-callable(var-name-if-var-or-lit(l), typeof-term(r), term, direct-hint.as-return-hint);
                   (tctx, function-type, rt)
                } else {
                   (tctx, ta, t2(c"Cons", typeof-term(l), typeof-term(r)))
@@ -310,7 +313,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
    if used.is-unused && typeof-term(term).slot(c"Phi::State",1).l1.slot(c"MustRelease::ToRelease",1).l1.is-t(c"Linear",1) {
       (tctx, term) = wrap-call(tctx, c".release", term);
    };
-   print("\{term} : \{typeof-term(term)}\n");
    (tctx, term);
 );
 
@@ -337,7 +339,10 @@ let std-infer-call-arg(tctx: TypeContext?, term: AST, function-name: CString, hi
    }} else if function-name==c"map::cons" { match term {
       App{k=left, m=right} => (
          (tctx, let new-k) = std-infer-expr(tctx, k, false, Call(function-name), ta);
-         (tctx, let new-m) = std-infer-expr(tctx, m, false, Used(), t2(c"HashtableEq",typeof-term(new-k).normalize.slot(c"Cons",2).l1,typeof-term(new-k).normalize.slot(c"Cons",2).l2));
+         let direct-hint = if config-v3
+         then t2(c"Hashtable",typeof-term(new-k).normalize.slot(c"Cons",2).l1,typeof-term(new-k).normalize.slot(c"Cons",2).l2) && t0(c"ReturnHint")
+         else t2(c"HashtableEq",typeof-term(new-k).normalize.slot(c"Cons",2).l1,typeof-term(new-k).normalize.slot(c"Cons",2).l2);
+         (tctx, let new-m) = std-infer-expr(tctx, m, false, Used(), direct-hint);
          if not(is(k,new-k)) || not(is(m,new-m)) then { k = new-k; m = new-m; term = mk-cons(k, m); };
          tctx = tctx.ascript(term, t2(c"Cons",typeof-term(k),typeof-term(m)));
          (tctx, term)

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -61,6 +61,11 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          tctx = Some(direct-tctx);
       );
       App{asc=left:Lit{key:c":"}, right:App{t=left,right:AType{tt=tt}}} => (
+         if tt.is-t(c"Hashtable",2) { match t {
+            App{ left:Var{key:c"map::cons"} } => tt = tt && t0(c"ReturnHint");
+            App{ left:Var{key:c"mk-hashtable"} } => tt = tt && t0(c"ReturnHint");
+            _ => ();
+         }};
          if tt.is-t(c"String",0) {
             term = t.ascript(t0(c"CString") && t0(c"Literal"));
             term = mk-app(mk-var(c"intern"),term);

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -272,12 +272,12 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                };
                (tctx, let function-type, rt) = if typeof-term(l).is-arrow && non-zero(lit-name-if-lit(l)) {
                   let direct-hint = hint-if-hint(l);
-                  let function-type = tctx.find-callable(var-name-if-var-or-lit(l), typeof-term(r), term).nt;
-                  (tctx, rt) = tctx.apply-callable(lit-name-if-lit(l), typeof-term(r), term, direct-hint);
+                  let function-type = tctx.find-callable(var-name-if-var-or-lit(l), typeof-term(r), term, hint).nt;
+                  (tctx, rt) = tctx.apply-callable(lit-name-if-lit(l), typeof-term(r), term, direct-hint && hint);
                   (tctx, function-type, rt)
                } else if typeof-term(l).is-arrow && non-zero(var-name-if-var-or-lit(l)) {
-                  let function-type = tctx.find-callable(var-name-if-var-or-lit(l), typeof-term(r), term).nt;
-                  (tctx, rt) = tctx.apply-callable(var-name-if-var-or-lit(l), typeof-term(r), term);
+                  let function-type = tctx.find-callable(var-name-if-var-or-lit(l), typeof-term(r), term, hint).nt;
+                  (tctx, rt) = tctx.apply-callable(var-name-if-var-or-lit(l), typeof-term(r), term, hint);
                   (tctx, function-type, rt)
                } else {
                   (tctx, ta, t2(c"Cons", typeof-term(l), typeof-term(r)))
@@ -310,6 +310,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
    if used.is-unused && typeof-term(term).slot(c"Phi::State",1).l1.slot(c"MustRelease::ToRelease",1).l1.is-t(c"Linear",1) {
       (tctx, term) = wrap-call(tctx, c".release", term);
    };
+   print("\{term} : \{typeof-term(term)}\n");
    (tctx, term);
 );
 

--- a/lib2/core/hashtable.lsts
+++ b/lib2/core/hashtable.lsts
@@ -1,12 +1,34 @@
 
 type Hashtable<k,v> implies MustRetain, MustRelease
-   = { data: OwnedData<(Bool,k,v)>[], occupied: USize, capacity: USize };
+   = { data: OwnedData<(Bool,k,v)>[] };
+
+let .release(x: Hashtable<k,v>): Nil = (
+   if (x.data as USize) != 0 {
+      x.data.release;
+   };
+   mark-as-released(x);
+);
+
+let .retain(x: Hashtable<k,v>): Hashtable<k,v> = (
+   if (x.data as USize) != 0 {
+      x.data.retain;
+   };
+   x
+);
 
 let mk-hashtable(tyk: Type<k>, tyv: Type<v>, capacity: USize): Hashtable<k,v> = (
-   let ptr = mk-owned-data(type((Bool,k,v)), capacity);
-   Vector( ptr, 0_sz, 0_sz )
+   Hashtable( mk-owned-data(type((Bool,k,v)), capacity) )
 );
 
 let mk-hashtable(tyk: Type<k>, tyv: Type<v>): Hashtable<k,v> = (
-   mk-hashtable(type(k), type(v), 0)
+   Hashtable( mk-owned-data(type((Bool,k,v)), 0) )
 );
+
+let mk-hashtable(capacity: USize): Hashtable<k,v> = (
+   Hashtable( mk-owned-data(type((Bool,k,v)), capacity) )
+);
+
+let mk-hashtable(): Hashtable<k,v> = (
+   Hashtable( mk-owned-data(type((Bool,k,v)), 0) )
+);
+

--- a/lib2/core/l.lsts
+++ b/lib2/core/l.lsts
@@ -1,8 +1,8 @@
 
 type L suffix _l;
 
-let :Blob $":expression"(x: Any): L;
-let :Blob $":frame"(x: Any): L;
+let :Blob $":expression"(x0: Any): L;
+let :Blob $":frame"(x0: Any): L;
 
 let :Blob $":function-id"(x: ImplicitContext): L;
 

--- a/lib2/core/vector.lsts
+++ b/lib2/core/vector.lsts
@@ -26,6 +26,15 @@ let mk-vector(ty: Type<t>): Vector<t> = (
    mk-vector(type(t), 0)
 );
 
+let mk-vector(capacity: USize): Vector<t> = (
+   let ptr = mk-owned-data(type(t), capacity);
+   Vector( ptr, 0_sz, 0_sz )
+);
+
+let mk-vector(): Vector<t> = (
+   mk-vector(type(t), 0)
+);
+
 let .length(v: Vector<t>): USize = (
    v.end-offset - v.start-offset
 );

--- a/tests/promises/hashtable/comparison.lsts
+++ b/tests/promises/hashtable/comparison.lsts
@@ -1,4 +1,4 @@
 
 import lib2/core/bedrock.lsts;
 
-{} : Hashtable<1,2>;
+{} : Hashtable<U64,U64>;

--- a/tests/promises/hashtable/comparison.lsts
+++ b/tests/promises/hashtable/comparison.lsts
@@ -1,2 +1,4 @@
 
 import lib2/core/bedrock.lsts;
+
+{} : Hashtable<1,2>;


### PR DESCRIPTION
## Describe your changes
Features:
* `mk-hashtable` constructor with annotated return type
* this eliminates most special treatment of `List<x>` or `Hashtable<k,v>` in compiler
* return type specialization is really cool, but it is also a pretty strong feature that can be unwieldy
* all special treatment of `HashtableIs` and `HashtableEq` is being turned of in V3 compiler

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
