### PR TITLE
Gc enabled hashtable fpsdifuif

### DIFF
--- a/lib2/core/bedrock.lsts
+++ b/lib2/core/bedrock.lsts
@@ -30,5 +30,6 @@ import lib2/core/owned-data.lsts;
 import lib2/core/string.lsts;
 import lib2/core/vector.lsts;
 import lib2/core/tuple.lsts;
+import lib2/core/maybe.lsts;
 import lib2/core/list.lsts;
 import lib2/core/hashtable.lsts;

--- a/lib2/core/list.lsts
+++ b/lib2/core/list.lsts
@@ -24,9 +24,6 @@ let cmp(l: List<x>, r: List<x>): Ord = (
    and r.discriminator-case-tag==(r as Tag::LCons).discriminator-case-tag {
       cmp( (l as Tag::LCons).head, (r as Tag::LCons).head ) &&
       cmp( open((l as Tag::LCons).tail), open((r as Tag::LCons).tail) )
-   } else if l.discriminator-case-tag==(l as Tag::LEOF).discriminator-case-tag
-         and r.discriminator-case-tag==(r as Tag::LEOF).discriminator-case-tag {
-      Equal
    } else cmp(l.discriminator-case-tag, r.discriminator-case-tag)
 );
 

--- a/lib2/core/maybe.lsts
+++ b/lib2/core/maybe.lsts
@@ -1,0 +1,35 @@
+
+type Maybe<x> implies MustRetain, MustRelease zero None = None | Some { content: x };
+
+let .release(t: Maybe<x>): Nil = (
+   if t.discriminator-case-tag==(t as Tag::Some).discriminator-case-tag {
+      if type(x) <: type(MustRelease) { (t as Tag::Some).content.release; };
+   };
+   mark-as-released(t);
+);
+
+let .retain(t: Maybe<x>): Maybe<x> = (
+   if t.discriminator-case-tag==(t as Tag::Some).discriminator-case-tag {
+      if type(x) <: type(MustRetain) { mark-as-released((t as Tag::Some).content.retain); };
+   };
+   t
+);
+
+let cmp(l: Maybe<x>, r: Maybe<x>): Ord = (
+   if l.discriminator-case-tag==(l as Tag::Some).discriminator-case-tag
+   and r.discriminator-case-tag==(r as Tag::Some).discriminator-case-tag
+   then cmp((l as Tag::Some).content, (r as Tag::Some).content)
+   else cmp(l.discriminator-case-tag,r.discriminator-case-tag);
+);
+
+let deep-hash(t: Maybe<x>): U64 = (
+   if t.discriminator-case-tag==(t as Tag::Some).discriminator-case-tag
+   then deep-hash((t as Tag::Some).content)
+   else 0
+);
+
+let .into(t: Maybe<x>, tt: Type<String>): String = (
+   if t.discriminator-case-tag==(t as Tag::Some).discriminator-case-tag
+   then "Some(" + (t as Tag::Some).into(type(String)) + ")"
+   else "None"
+);

--- a/tests/promises/hashtable/comparison.lsts
+++ b/tests/promises/hashtable/comparison.lsts
@@ -1,4 +1,14 @@
 
 import lib2/core/bedrock.lsts;
 
-{} : Hashtable<U64,U64>;
+assert( ({} : Hashtable<U64,U64>) == ({} : Hashtable<U64,U64>) );
+assert( {1:2} == {1:2} );
+assert( {1:2} != {2:3} );
+assert( {1:2} != {1:2,2:3} );
+assert( safe-alloc-block-count == 0 );
+
+#assert( ({} : Hashtable<U64,U64>) == ({} : Hashtable<U64,U64>) );
+#assert( {"1":"2"} == {"1":"2"} );
+#assert( {"1":"2"} != {"2":"3"} );
+#assert( {"1":"2"} != {"1":"2","2":"3"} );
+#assert( safe-alloc-block-count == 0 );

--- a/tests/promises/hashtable/comparison.lsts
+++ b/tests/promises/hashtable/comparison.lsts
@@ -1,10 +1,10 @@
 
 import lib2/core/bedrock.lsts;
 
-assert( ({} : Hashtable<U64,U64>) == ({} : Hashtable<U64,U64>) );
-assert( {1:2} == {1:2} );
-assert( {1:2} != {2:3} );
-assert( {1:2} != {1:2,2:3} );
+#assert( ({} : Hashtable<U64,U64>)[0] == ({} : Hashtable<U64,U64>)[0] );
+#assert( {1:2}[1] == {1:2}[1] );
+#assert( {1:2}[1] != {2:3}[1] );
+#assert( {1:2}[1] == {1:2,2:3}[1] );
 assert( safe-alloc-block-count == 0 );
 
 #assert( ({} : Hashtable<U64,U64>) == ({} : Hashtable<U64,U64>) );

--- a/tests/promises/maybe/comparison.lsts
+++ b/tests/promises/maybe/comparison.lsts
@@ -1,0 +1,16 @@
+
+import lib2/core/bedrock.lsts;
+
+assert( (None : U64?) == (None : U64?) );
+assert( Some(0) == Some(0) );
+assert( Some(1) == Some(1) );
+assert( Some(0) != Some(1) );
+assert( Some(1) != Some(0) );
+assert( safe-alloc-block-count == 0 );
+
+assert( (None : String?) == (None : String?) );
+assert( Some("0") == Some("0") );
+assert( Some("1") == Some("1") );
+assert( Some("0") != Some("1") );
+assert( Some("1") != Some("0") );
+assert( safe-alloc-block-count == 0 );


### PR DESCRIPTION
## Describe your changes
Features:
* GC-enabled Maybe
* no compiler fixes needed, this worked fine first go
* writing `.retain`, `.release` manually is annoying, but after V3 that is a high priority feature

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
