### PR TITLE
Gc enabled hashtable fsudfiosd

### DIFF
--- a/PLUGINS/BACKEND/C/std-c-compile-call.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-call.lsts
@@ -3,7 +3,7 @@ let std-c-compile-call(ctx: FContext, fname: CString, args: AST): Fragment = std
 
 let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor: Type, args: AST): Fragment = (
    let fterm = Some(mk-tctx()).maybe-find-callable(fname, typeof-term(args), args, return-hint-if-constructor)
-                              .expect("std-c-compile-call Function was null\nArguments: \{typeof-term(args)}\n").blame;
+                              .expect("std-c-compile-call Function \{fname} was null\nArguments: \{typeof-term(args)}, Return Hint \{return-hint-if-constructor}\n").blame;
    if typeof-term(fterm).is-t(c"Blob",0) {
       if typeof-term(fterm).is-open then exit-error("STD C compile call is open \{fname} (\{typeof-term(args)})\n\{typeof-term(fterm)}\n", args);
       let r = mk-fragment();

--- a/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
@@ -182,8 +182,16 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
                       _ => std-c-compile-call(ctx, fname, right);
                    }
                 );
-                Var{fname=key} => std-c-compile-call(ctx, fname, right);
-                App{ left:Lit{key:c":"}, right:App{ left:Var{fname=key}, right:AType{tt=tt} } } => std-c-compile-call(ctx, fname, right);
+                Var{fname=key} => (
+                   let return-hint = ta;
+                   if fname==c"mk-hashtable" then return-hint = typeof-term(t).normalize;
+                   std-c-compile-call(ctx, fname, return-hint, right);
+                );
+                App{ left:Lit{key:c":"}, right:App{ left:Var{fname=key}, right:AType{tt=tt} } } => (
+                   let return-hint = ta;
+                   if fname==c"mk-hashtable" then return-hint = typeof-term(t).normalize;
+                   std-c-compile-call(ctx, fname, return-hint, right);
+                );
                 Lit{fname=key} => (
                    let return-type = typeof-term(t).normalize;
                    std-c-compile-call(ctx, fname, return-type, right);

--- a/lib2/core/hashtable.lsts
+++ b/lib2/core/hashtable.lsts
@@ -20,21 +20,21 @@ let .retain(x: Hashtable<k,v>): Hashtable<k,v> = (
 );
 
 let mk-hashtable(tyk: Type<k>, tyv: Type<v>, capacity: USize): Hashtable<k,v> = (
-   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), capacity) )
+   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), capacity, capacity) )
 );
 
 let mk-hashtable(tyk: Type<k>, tyv: Type<v>): Hashtable<k,v> = (
    # Default initial hashtable size is 16
-   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), 16) )
+   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), 16, 16) )
 );
 
 let mk-hashtable(capacity: USize): Hashtable<k,v> = (
-   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), capacity) )
+   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), capacity, capacity) )
 );
 
 let mk-hashtable(): Hashtable<k,v> = (
    # Default initial hashtable size is 16
-   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), 16) )
+   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), 16, 16) )
 );
 
 let .bind(h: Hashtable<k,v>, key: k, val: v): Hashtable<k,v> = (

--- a/lib2/core/hashtable.lsts
+++ b/lib2/core/hashtable.lsts
@@ -24,7 +24,8 @@ let mk-hashtable(tyk: Type<k>, tyv: Type<v>, capacity: USize): Hashtable<k,v> = 
 );
 
 let mk-hashtable(tyk: Type<k>, tyv: Type<v>): Hashtable<k,v> = (
-   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), 0) )
+   # Default initial hashtable size is 16
+   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), 16) )
 );
 
 let mk-hashtable(capacity: USize): Hashtable<k,v> = (
@@ -32,15 +33,40 @@ let mk-hashtable(capacity: USize): Hashtable<k,v> = (
 );
 
 let mk-hashtable(): Hashtable<k,v> = (
-   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), 0) )
+   # Default initial hashtable size is 16
+   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), 16) )
 );
 
-let .bind(h: Hashtable<k,v>, key: k): Hashtable<k,v> = (
+let .bind(h: Hashtable<k,v>, key: k, val: v): Hashtable<k,v> = (
+   if (h.data as USize) == 0 or h.data.capacity == 0 {
+      h = mk-hashtable() : Hashtable<k,v>;
+   };
+   let occupied = h.data.occupied;
+   let capacity = h.data.capacity;
+   let contents = h.data;
+   # Resize if >= 2/3 full
+   if occupied >= capacity * 2 / 3 {
+      # Growth factor is 2x
+      let new-h = mk-hashtable(capacity * 2) : Hashtable<k,v>;
+      let old-i = 0_sz;
+      while old-i < capacity {
+         let old-kv = contents[old-i];
+         if is(old-kv.first,HashtableRowFilled)
+         then new-h.bind-direct(old-kv.second, old-kv.third);
+         old-i = old-i + 1;
+      };
+      h.data.replace(new-h.data);
+   };
+   h.bind-direct(key, val);
    h
+);
+
+let .bind-direct(h: Hashtable<k,v>, key: k, val: v): Nil = (
+   print("Bind Direct \{key} : \{val}\n");
 );
 
 let $"map::cons"(key: k, val: v, h: Hashtable<k,v>): Hashtable<k,v> = (
-   h
+   h.bind(key,val)
 );
 
 

--- a/lib2/core/hashtable.lsts
+++ b/lib2/core/hashtable.lsts
@@ -24,8 +24,8 @@ let mk-hashtable(tyk: Type<k>, tyv: Type<v>, capacity: USize): Hashtable<k,v> = 
 );
 
 let mk-hashtable(tyk: Type<k>, tyv: Type<v>): Hashtable<k,v> = (
-   # Default initial hashtable size is 16
-   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), 16, 16) )
+   # Default initial hashtable size is 0 (Stack Only)
+   Hashtable( 0 as OwnedData<(HashtableRowExists,k,v)>[] )
 );
 
 let mk-hashtable(capacity: USize): Hashtable<k,v> = (
@@ -33,13 +33,15 @@ let mk-hashtable(capacity: USize): Hashtable<k,v> = (
 );
 
 let mk-hashtable(): Hashtable<k,v> = (
-   # Default initial hashtable size is 16
-   Hashtable( mk-owned-data(type((HashtableRowExists,k,v)), 16, 16) )
+   # Default initial hashtable size is 0 (Stack Only)
+   Hashtable( 0 as OwnedData<(HashtableRowExists,k,v)>[] )
 );
 
 let .bind(h: Hashtable<k,v>, key: k, val: v): Hashtable<k,v> = (
    if (h.data as USize) == 0 or h.data.capacity == 0 {
-      h = mk-hashtable() : Hashtable<k,v>;
+      # Hashtables can be allocated on the stack as empty values
+      # Resize these to size 32 next
+      h = mk-hashtable(32) : Hashtable<k,v>;
    };
    let occupied = h.data.occupied;
    let capacity = h.data.capacity;
@@ -55,7 +57,7 @@ let .bind(h: Hashtable<k,v>, key: k, val: v): Hashtable<k,v> = (
          then new-h.bind-direct(old_kv.second, old_kv.third);
          old_i = old_i + 1;
       };
-      h.data.replace(new-h.data);
+      h = new-h;
    };
    h.bind-direct(key, val);
    h

--- a/lib2/core/hashtable.lsts
+++ b/lib2/core/hashtable.lsts
@@ -48,12 +48,12 @@ let .bind(h: Hashtable<k,v>, key: k, val: v): Hashtable<k,v> = (
    if occupied >= capacity * 2 / 3 {
       # Growth factor is 2x
       let new-h = mk-hashtable(capacity * 2) : Hashtable<k,v>;
-      let old-i = 0_sz;
-      while old-i < capacity {
-         let old-kv = contents[old-i];
-         if is(old-kv.first,HashtableRowFilled)
-         then new-h.bind-direct(old-kv.second, old-kv.third);
-         old-i = old-i + 1;
+      let old_i = 0_sz;
+      while old_i < capacity {
+         let old_kv = contents[old_i];
+         if is(old_kv.first,HashtableRowFilled)
+         then new-h.bind-direct(old_kv.second, old_kv.third);
+         old_i = old_i + 1;
       };
       h.data.replace(new-h.data);
    };

--- a/lib2/core/hashtable.lsts
+++ b/lib2/core/hashtable.lsts
@@ -47,10 +47,9 @@ let $"map::cons"(key: k, val: v, h: Hashtable<k,v>): Hashtable<k,v> = (
 let $"[]"(h: Hashtable<k,v>, key: k): Maybe<k> = (
    let row_index = h.find-row-index-by-key(key);
    print("Row Index \{row_index}\n");
-   None : Maybe<k>
-   #if row_index == (-1 as USize)
-   #then (None : Maybe<k>)
-   #else Some(h.data[row_index])
+   if row_index == (-1 as USize)
+   then (None : Maybe<v>)
+   else Some(h.data[row_index].third)
 );
 
 let .find-row-index-by-key(h: Hashtable<k,v>, key: k): USize = (

--- a/lib2/core/owned-data.lsts
+++ b/lib2/core/owned-data.lsts
@@ -29,7 +29,7 @@ let .replace(od1: OwnedData<t>[], od2: OwnedData<t>[]): Nil = (
 let $"[]"(od: OwnedData<t>[], idx: USize): t = (
    if (od as USize)==0
    then fail(c"OwnedData [] Access Null Pointer");
-   if idx >= od.occupied then fail(c"OwnedData [] Index Access Out of Bounds");
+   if idx >= od.occupied then fail("OwnedData [\{idx}] Index Access Out of Bounds");
    od.data[idx]
 );
 

--- a/lib2/core/owned-data.lsts
+++ b/lib2/core/owned-data.lsts
@@ -22,14 +22,6 @@ let mk-owned-data(tt: Type<t>, capacity: USize): OwnedData<t>[] = (
    mk-owned-data(tt, capacity, 0)
 );
 
-# Overwrites the contents behind the previous owned data
-# This allows destructive mutation such as resizing a hashtable
-# while still maintaining referential consistency
-# i.e. old variables holding the hashtable as a value don't need to be updated
-let .replace(od1: OwnedData<t>[], od2: OwnedData<t>[]): Nil = (
- 
-);
-
 let $"[]"(od: OwnedData<t>[], idx: USize): t = (
    if (od as USize)==0
    then fail(c"OwnedData [] Access Null Pointer");

--- a/lib2/core/owned-data.lsts
+++ b/lib2/core/owned-data.lsts
@@ -1,7 +1,7 @@
 
 type OwnedData<t> = {
    reference-count: USize,
-   current-length: USize,
+   occupied: USize,
    capacity: USize,
    data: t[]+FlexibleArrayMember
 };
@@ -13,34 +13,42 @@ let mk-owned-data(tt: Type<t>, capacity: USize): OwnedData<t>[] = (
       type(OwnedData<t>)
    );
    od.reference-count = 1;
-   od.current-length = 0;
+   od.occupied = 0;
    od.capacity = capacity;
    od
+);
+
+# Overwrites the contents behind the previous owned data
+# This allows destructive mutation such as resizing a hashtable
+# while still maintaining referential consistency
+# i.e. old variables holding the hashtable as a value don't need to be updated
+let .replace(od1: OwnedData<t>[], od2: OwnedData<t>[]): Nil = (
+ 
 );
 
 let $"[]"(od: OwnedData<t>[], idx: USize): t = (
    if (od as USize)==0
    then fail(c"OwnedData [] Access Null Pointer");
-   if idx >= od.current-length then fail(c"OwnedData [] Index Access Out of Bounds");
+   if idx >= od.occupied then fail(c"OwnedData [] Index Access Out of Bounds");
    od.data[idx]
 );
 
 let .push(od: OwnedData<t>[], d: s): Nil = (
    if (od as USize)==0
    then fail(c"OwnedData .push Into Null Pointer");
-   if od.current-length >= od.capacity
+   if od.occupied >= od.capacity
    then fail(c"OwnedData .push Exceeds Maximum Length");
-   od.data[od.current-length] = d;
-   od.current-length = od.current-length + 1;
+   od.data[od.occupied] = d;
+   od.occupied = od.occupied + 1;
 );
 
 let .pop(od: OwnedData<t>[]): t = (
    if (od as USize)==0
    then fail(c"OwnedData .pop From Null Pointer");
-   if od.current-length == 0
+   if od.occupied == 0
    then fail(c"OwnedData .pop From Empty Data");
-   od.current-length = od.current-length - 1;
-   od.data[od.current-length]
+   od.occupied = od.occupied - 1;
+   od.data[od.occupied]
 );
 
 let open(od: OwnedData<t>[]): t = (
@@ -59,7 +67,7 @@ let .release(od: OwnedData<t>[]): Nil = (
       if od.reference-count == 0 {
          if type(t) <: type(MustRelease) {
             let dlo = 0_sz;
-            let dhi = od.current-length;
+            let dhi = od.occupied;
             while dlo < dhi {
                od.data[dlo].release;
                dlo = dlo + 1;

--- a/lib2/core/owned-data.lsts
+++ b/lib2/core/owned-data.lsts
@@ -6,16 +6,20 @@ type OwnedData<t> = {
    data: t[]+FlexibleArrayMember
 };
 
-let mk-owned-data(tt: Type<t>, capacity: USize): OwnedData<t>[] = (
+let mk-owned-data(tt: Type<t>, capacity: USize, occupied: USize): OwnedData<t>[] = (
    let od = safe-alloc(
       # TODO: make sizeof return USize
       (sizeof(OwnedData<t>) as USize) + (sizeof(t) as USize) * capacity,
       type(OwnedData<t>)
    );
    od.reference-count = 1;
-   od.occupied = 0;
+   od.occupied = occupied;
    od.capacity = capacity;
    od
+);
+
+let mk-owned-data(tt: Type<t>, capacity: USize): OwnedData<t>[] = (
+   mk-owned-data(tt, capacity, 0)
 );
 
 # Overwrites the contents behind the previous owned data

--- a/lib2/core/vector.lsts
+++ b/lib2/core/vector.lsts
@@ -51,13 +51,13 @@ let .realloc(v: Vector<t>, target-capacity: USize): Vector<t> = (
       new-data.push(v[dlo]);
       dlo = dlo + 1;
    };
-   Vector( new-data, 0, new-data.current-length )
+   Vector( new-data, 0, new-data.occupied )
 );
 
 # TODO: Vector<t> and i: t should have the same type variable and it should unify
 let .push(v: Vector<t>, i: x): Vector<t> = (
    # if this vector is a view, or if it is full, then we need to reallocate
-   if (v.data as USize)==0 or v.end-offset < v.data.current-length or v.end-offset >= v.data.capacity {
+   if (v.data as USize)==0 or v.end-offset < v.data.occupied or v.end-offset >= v.data.capacity {
       let new_capacity = if v.start-offset==v.end-offset then 4_sz
       else (v.length >> 1_sz) + v.length; # this is mul 1.5, not 3
       let old-data = v.data; # TODO automatically call .release on mov destination

--- a/tests/promises/hashtable/comparison.lsts
+++ b/tests/promises/hashtable/comparison.lsts
@@ -2,9 +2,9 @@
 import lib2/core/bedrock.lsts;
 
 assert( ({} : Hashtable<U64,U64>)[0] == ({} : Hashtable<U64,U64>)[0] );
-#assert( {1:2}[1] == {1:2}[1] );
-#assert( {1:2}[1] != {2:3}[1] );
-#assert( {1:2}[1] == {1:2,2:3}[1] );
+assert( {1:2}[1] == {1:2}[1] );
+assert( {1:2}[1] != {2:3}[1] );
+assert( {1:2}[1] == {1:2,2:3}[1] );
 assert( safe-alloc-block-count == 0 );
 
 #assert( ({} : Hashtable<String,String>)["0"] == ({} : Hashtable<String,String>)["0"] );

--- a/tests/promises/hashtable/comparison.lsts
+++ b/tests/promises/hashtable/comparison.lsts
@@ -7,6 +7,10 @@ assert( {1:2}[1] != {2:3}[1] );
 assert( {1:2}[1] == {1:2,2:3}[1] );
 assert( safe-alloc-block-count == 0 );
 
+# Resize threshold is 16 so just checking
+assert( {1:2}[1] == {1:2,2:3,3:4,4:5,5:6,6:7,7:8,8:9,9:10,10:11,11:12,12:13,13:14,14:15,15:16,16:17,17:18}[1] );
+assert( safe-alloc-block-count == 0 );
+
 #assert( ({} : Hashtable<String,String>)["0"] == ({} : Hashtable<String,String>)["0"] );
 #assert( {"1":"2"} == {"1":"2"} );
 #assert( {"1":"2"} != {"2":"3"} );


### PR DESCRIPTION
## Describe your changes
* Most footwork for hashtable is working
* Needed to create a different constructor for `OwnedData` when it is a sparse array
* Hashtable/Vector are unique to LSTS in the respect that they don't guarantee referential transparency to older versions during resize
* this allows for these data structures to be allocated entirely on the stack until a value is added to them
* I would like to eventually push language users towards using persistent data structures later, but for now this is very fast

### Persistent Data Structures
* very pleasant user experience

### Dirty Heap State Data Structures
* very fast

We are taking the *most extreme / optimized* versions of each of these cases. If you need speed, then you can have it, but watch out because you can't expect old values to be consistent.

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
