### PR TITLE
Gc enabled phi tests hashtable fusifdso

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/phi/linear-assign-must-retain.lsts
+	lm tests/promises/vector/constructor.lsts
 	gcc tmp.c
 	./a.out
 

--- a/SRC/infer-global-terms.lsts
+++ b/SRC/infer-global-terms.lsts
@@ -31,6 +31,7 @@ let infer-global-terms(tctx: TypeContext?, term: AST): (TypeContext?, AST) = (
       );
       _ => (
          (tctx, term) = std-infer-expr(tctx, term, false, Unused, ta);
+         print("Glb \{term}\n");
       );
    };
    (tctx, term)

--- a/SRC/infer-global-terms.lsts
+++ b/SRC/infer-global-terms.lsts
@@ -31,7 +31,6 @@ let infer-global-terms(tctx: TypeContext?, term: AST): (TypeContext?, AST) = (
       );
       _ => (
          (tctx, term) = std-infer-expr(tctx, term, false, Unused, ta);
-         print("Glb \{term}\n");
       );
    };
    (tctx, term)

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -195,7 +195,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                mark-var-to-def(new-term, term);
                term = new-term;
             };
-            print("Glb \{term}\n");
          };
       );
       Var{key=key, token=token} => (
@@ -359,7 +358,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
       _ => fail("Unexpected Term in std-infer-expr\n\{term}\n");
    };
    if used.is-unused && typeof-term(term).slot(c"Phi::State",1).is-linear-live {
-      if typeof-term(term).slot(c"Phi::State",1).is-t(c"MustRelease::ToRelease",1) {
+      if typeof-term(term).slot(c"Phi::State",1).l1.is-t(c"MustRelease::ToRelease",1) {
          (tctx, term) = wrap-call(tctx, c".release", term);
       } else if typeof-term(term).is-t(c"MustRetain",0) {
          tctx = tctx.phi-move(typeof-term(term),term);

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -195,6 +195,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                mark-var-to-def(new-term, term);
                term = new-term;
             };
+            print("Glb \{term}\n");
          };
       );
       Var{key=key, token=token} => (

--- a/lib2/core/vector.lsts
+++ b/lib2/core/vector.lsts
@@ -18,7 +18,7 @@ let .retain(x: Vector<t>): Vector<t> = (
 );
 
 let mk-vector(ty: Type<t>, capacity: USize): Vector<t> = (
-   Vector( mk-owned-data(type(t), capacity) )
+   if capacity==0 then Vector(0 as OwnedData<t>[]) else Vector( mk-owned-data(type(t), capacity) )
 );
 
 let mk-vector(ty: Type<t>): Vector<t> = (
@@ -26,7 +26,7 @@ let mk-vector(ty: Type<t>): Vector<t> = (
 );
 
 let mk-vector(capacity: USize): Vector<t> = (
-   Vector( mk-owned-data(type(t), capacity) )
+   if capacity==0 then Vector(0 as OwnedData<t>[]) else Vector( mk-owned-data(type(t), capacity) )
 );
 
 let mk-vector(): Vector<t> = (

--- a/tests/promises/vector/constructor.lsts
+++ b/tests/promises/vector/constructor.lsts
@@ -10,19 +10,39 @@ assert( safe-alloc-block-count == 0 );
 mk-vector(type(U64), 2).push(123);
 assert( safe-alloc-block-count == 0 );
 
-mk-vector(type(String), 2).push("A");
-mk-vector(type(String), 2).push("A").push("B");
-mk-vector(type(String), 2).push("A").push("B").push("C");
+mk-vector(type(U64), 0).push(123);
 assert( safe-alloc-block-count == 0 );
 
 assert( mk-vector(type(U64), 2).push(123).push(456)[0] == 123 );
 assert( safe-alloc-block-count == 0 );
 
+assert( mk-vector(type(U64), 0).push(123).push(456)[0] == 123 );
+assert( safe-alloc-block-count == 0 );
+
 assert( mk-vector(type(U64), 2).push(123).push(456)[1] == 456 );
+assert( safe-alloc-block-count == 0 );
+
+assert( mk-vector(type(U64), 0).push(123).push(456)[1] == 456 );
+assert( safe-alloc-block-count == 0 );
+
+mk-vector(type(String), 2).push("A");
+mk-vector(type(String), 2).push("A").push("B");
+mk-vector(type(String), 2).push("A").push("B").push("C");
+assert( safe-alloc-block-count == 0 );
+
+mk-vector(type(String), 0).push("A");
+mk-vector(type(String), 0).push("A").push("B");
+mk-vector(type(String), 0).push("A").push("B").push("C");
 assert( safe-alloc-block-count == 0 );
 
 assert(
    mk-vector(type(String), 2).push("A").push("B").push("C") ==
    mk-vector(type(String), 2).push("A").push("B").push("C")
+);
+assert( safe-alloc-block-count == 0 );
+
+assert(
+   mk-vector(type(String), 0).push("A").push("B").push("C") ==
+   mk-vector(type(String), 0).push("A").push("B").push("C")
 );
 assert( safe-alloc-block-count == 0 );


### PR DESCRIPTION
## Describe your changes
Features:
* fix regression in GC-enabled Vector
* make 0-length vectors allocate on stack only initially
* add more tests to cover vector allocation

RCA:
* typo in a check to release unused values

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1744

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
