### PR TITLE
Gc enabled compiler lmcommon fdsuolll

### DIFF
--- a/LM23COMMON/util-uuid.lsts
+++ b/LM23COMMON/util-uuid.lsts
@@ -1,15 +1,12 @@
 
 let uuid-counter = 0_u64;
 
-let uuid(): CString = (
-   uuid-counter = uuid-counter + 1;
-   clone-rope(SCons(
-      close(SAtom( c"uuid__" )),
-      close(SAtom( to-hex(uuid-counter) ))
-   ))
-);
-
 let iuid(): U64 = (
    uuid-counter = uuid-counter + 1;
    uuid-counter;
 );
+
+let uuid(): CString = (
+   ("uuid__" + iuid().to-hex).retain.into(type(CString));
+);
+

--- a/LM23COMMON/util-uuid.lsts
+++ b/LM23COMMON/util-uuid.lsts
@@ -7,6 +7,6 @@ let iuid(): U64 = (
 );
 
 let uuid(): CString = (
-   ("uuid__" + iuid().to-hex).retain.into(type(CString));
+   c"uuid__" + iuid().to-hex.into(type(CString));
 );
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/util/uuid.lsts
+	lm tests/promises/lm-util/uuid.lsts
 	gcc tmp.c
 	./a.out
 

--- a/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
+++ b/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
@@ -26,7 +26,6 @@ let std-c-mangle-type-internal(tt: Type, blame: AST): S = (
          modifiers + result;
       );
       TAny{} => SNil();
-      TGround{tag:c"LMCString", parameters:[]} => SNil;
       TGround{tag:c"Nil", parameters:[]} => SAtom(c"void");
       TGround{tag:c"Never", parameters:[]} => SAtom(c"void");
       TGround{tag:c"U8", parameters:[]} => SAtom(c"char");

--- a/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
+++ b/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
@@ -26,6 +26,7 @@ let std-c-mangle-type-internal(tt: Type, blame: AST): S = (
          modifiers + result;
       );
       TAny{} => SNil();
+      TGround{tag:c"LMCString", parameters:[]} => SNil;
       TGround{tag:c"Nil", parameters:[]} => SAtom(c"void");
       TGround{tag:c"Never", parameters:[]} => SAtom(c"void");
       TGround{tag:c"U8", parameters:[]} => SAtom(c"char");

--- a/lib/std/string.lsts
+++ b/lib/std/string.lsts
@@ -62,6 +62,7 @@ let $"[]"(base: CString, idx: U64): U8 = (
 );
 
 let .into(s: CString, tgt: Type<String>): String = intern(s);
+let .into(s: CString, tgt: Type<CString>): CString = s;
 let .into(s: String, tgt: Type<CString>): CString = untern(s);
 
 let .split(s: String, sep: String): List<String> = (

--- a/lib/std/u64.lsts
+++ b/lib/std/u64.lsts
@@ -73,7 +73,7 @@ let to-u64(s: CString): U64 = (
    i
 );
 
-let to-hex(i: U64): CString = (
+let .to-hex(i: U64): CString = (
    let buff = mk-vector(type(U8), 17);
    let rpt = 16_u64;
    while rpt > 0_u64 {

--- a/lib2/core/array.lsts
+++ b/lib2/core/array.lsts
@@ -14,6 +14,7 @@ declare-binop( $"-", raw-type(base-type[]), raw-type(USize), raw-type(base-type[
 declare-binop( $"-", raw-type(base-type[]), raw-type(base-type[]), raw-type(USize), ( l"("; x; l"-"; y; l")"; ) );
 
 declare-unop( $"&", raw-type(t+MustNotRetain), raw-type(t[]), (l"(&"; x; l")";) );
+declare-unop( $".void-pointer", raw-type(?[]), raw-type(C<"void">[]), x );
 
 let mark-memory-as-safe(ptr: t[], len: USize): Nil = (
    # BEFORE CHANGING THIS: talk to alex

--- a/lib2/core/baremetal-into.lsts
+++ b/lib2/core/baremetal-into.lsts
@@ -55,3 +55,31 @@ let .into(i: U64, tt: Type<String>): String = (
    };
    String(0 as USize, cs_length, od)
 );
+
+let .to-hex(i: U64): String = (
+   let buff = mk-vector(type(U8), 17);
+   let rpt = 16_u64;
+   while rpt > 0_u64 {
+      match i % 16 {
+         0 => buff = buff.push(48);
+         1 => buff = buff.push(49);
+         2 => buff = buff.push(50);
+         3 => buff = buff.push(51);
+         4 => buff = buff.push(52);
+         5 => buff = buff.push(53);
+         6 => buff = buff.push(54);
+         7 => buff = buff.push(55);
+         8 => buff = buff.push(56);
+         9 => buff = buff.push(57);
+         10 => buff = buff.push(97);
+         11 => buff = buff.push(98);
+         12 => buff = buff.push(99);
+         13 => buff = buff.push(100);
+         14 => buff = buff.push(101);
+         15 => buff = buff.push(102);
+      };
+      i = i / 16;
+      rpt = rpt - 1;
+   };
+   buff.buffer-into-string
+);

--- a/lib2/core/cstring.lsts
+++ b/lib2/core/cstring.lsts
@@ -1,36 +1,37 @@
 
 # The "LMCString" makes the CString a subtype of C<"char">[] instead of a direct alias
-type alias CString suffix _s = LMCString + C<"char">[];
+type opaque alias CString suffix _s = C<"char">[];
 
-let .length(l: CString): USize = strlen(l) as USize;
+declare-unop( $".c-pointer", raw-type(CString), raw-type(C<"char">[]), x );
+
+let .length(l: CString): USize = strlen(l.c-pointer) as USize;
 
 let cmp(l: CString, r: CString): Ord = (
-   let c = strcmp( l, r ) as I64;
-   print("CString Str Cmp \{l}, \{r} = \{c}\n");
+   let c = strcmp( l.c-pointer, r.c-pointer ) as I64;
    if c < 0 then LessThan
    else if c > 0 then GreaterThan
    else Equal
 );
 
 let fail(msg: CString): Never = (
-   fputs(msg, stderr);
+   fputs(msg.c-pointer, stderr);
    exit(1);
    () as Never
 );
 
 let fail(msg1: CString, msg2: CString): Never = (
-   fputs(msg1, stderr);
-   fputs(msg2, stderr);
+   fputs(msg1.c-pointer, stderr);
+   fputs(msg2.c-pointer, stderr);
    exit(1);
    () as Never
 );
 
 let print(msg: CString): Nil = (
-   fputs(msg, stdout); ()
+   fputs(msg.c-pointer, stdout); ()
 );
 
 let eprint(msg: CString): Nil = (
-   fputs(msg, stderr); ()
+   fputs(msg.c-pointer, stderr); ()
 );
 
 let $"[]"(l: CString, idx: USize): U8 = (
@@ -51,4 +52,12 @@ let hash(key: CString): U64 = (
    result = result ^ (result >> 11);
    result = result + (result << 15);
    result
+);
+
+let $"+"(l: CString, r: CString): CString = (
+   let buf = malloc(l.length + r.length + 1) as C<"char">[];
+   memset(buf.void-pointer, 0, l.length+r.length+1);
+   strcat(buf, l as C<"char">[]);
+   strcat(buf, r as C<"char">[]);
+   buf as CString
 );

--- a/lib2/core/cstring.lsts
+++ b/lib2/core/cstring.lsts
@@ -1,10 +1,12 @@
 
-type alias CString suffix _s = C<"char">[];
+# The "LMCString" makes the CString a subtype of C<"char">[] instead of a direct alias
+type alias CString suffix _s = LMCString + C<"char">[];
 
 let .length(l: CString): USize = strlen(l) as USize;
 
 let cmp(l: CString, r: CString): Ord = (
    let c = strcmp( l, r ) as I64;
+   print("CString Str Cmp \{l}, \{r} = \{c}\n");
    if c < 0 then LessThan
    else if c > 0 then GreaterThan
    else Equal

--- a/lib2/core/string.lsts
+++ b/lib2/core/string.lsts
@@ -59,6 +59,11 @@ let .into(cs: CString, tt: Type<String>): String = (
    String(0 as USize, cs_length, od)
 );
 
+let .into(s: String, tt: Type<CString>): CString = (
+   s.data.retain;
+   s.data.data as CString
+);
+
 let $"[:]"(s: String, begin: I64, end: I64): String = (
    let s_length = s.length as I64;
    if end == minimum-I64 then end = s_length;

--- a/lib2/core/vector.lsts
+++ b/lib2/core/vector.lsts
@@ -112,3 +112,9 @@ let .sort(v: Vector<t>): Vector<t> = (
    };
    v
 );
+
+let .buffer-into-string(v: Vector<U8>): String = (
+   v = v.push(0);
+   v.data.retain;
+   String(0, v.length - 1, v.data)
+);

--- a/tests/promises/cstring/comparison.lsts
+++ b/tests/promises/cstring/comparison.lsts
@@ -20,3 +20,5 @@ assert( c"ab".length == 2 );
 assert( c"abc"[0] == 97 );
 assert( c"abc"[1] == 98 );
 assert( c"abc"[2] == 99 );
+
+assert( c"a" + c"bc" == c"abc" );

--- a/tests/promises/lm-util/uuid.lsts
+++ b/tests/promises/lm-util/uuid.lsts
@@ -1,2 +1,7 @@
 
 import LM23COMMON/unit-util.lsts;
+
+assert( iuid() == 1 );
+assert( iuid() == 2 );
+assert( uuid() == c"uuid__3000000000000000" );
+assert( uuid() == c"uuid__4000000000000000" );

--- a/tests/promises/string/leak-cstring.lsts
+++ b/tests/promises/string/leak-cstring.lsts
@@ -1,0 +1,5 @@
+
+import lib2/core/bedrock.lsts;
+
+assert( "ABC".into(type(CString)) == c"ABC" );
+assert( safe-alloc-block-count == 1 );

--- a/tests/promises/u64/comparison.lsts
+++ b/tests/promises/u64/comparison.lsts
@@ -4,3 +4,8 @@ import lib2/core/bedrock.lsts;
 assert( cmp(1_u64, 1_u64) == Equal );
 assert( cmp(1_u64, 2_u64) == LessThan );
 assert( cmp(2_u64, 1_u64) == GreaterThan );
+assert( safe-alloc-block-count == 0 );
+
+assert( 1.to-hex == "1000000000000000" );
+assert( 10.to-hex == "a000000000000000" );
+assert( safe-alloc-block-count == 0 );

--- a/tests/promises/vector/buffer-into-string.lsts
+++ b/tests/promises/vector/buffer-into-string.lsts
@@ -1,0 +1,7 @@
+
+import lib2/core/bedrock.lsts;
+
+assert( mk-vector(type(U8)).push(51).buffer-into-string == "3" );
+assert( mk-vector(type(U8)).push(89).buffer-into-string == "Y" );
+assert( mk-vector(type(U8)).push(51).push(89).buffer-into-string == "3Y" );
+assert( safe-alloc-block-count == 0 );


### PR DESCRIPTION
## Describe your changes
Features:
* promises for util uuid is now working on GC-enabled lib2
* add some helper methods to lib2 such as `.to-hex`
* CString is now an *opaque* type alias
   * I am not 100% happy with this, but it was messing up the best-fit resolution, so we can revisit this later
   * problem Candidates:
   * `let $"=="(x: base-type[], y: base-type[]): Bool;`
   * `let $"=="(x: x, y: y): Bool = cmp(x, y);`
   * I think this may be an issue with the `$"=="` definition, and not really the alias.
   * If we put a more specific type on that function then we wouldn't have this issue.

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
