### PR TITLE
Gc enabled lmcommon fdusiofd

### DIFF
--- a/LM23COMMON/ast-constructor.lsts
+++ b/LM23COMMON/ast-constructor.lsts
@@ -24,21 +24,21 @@ let mk-typedef(loc: SourceLocation, lhs-type: Type): AST = (
              ta, ta, ta, mk-vector(type((CString,Vector<(CString,Type)>))), ta, ta )
 );
 
-let .is-cons(t: AST): U64 = (
+let .is-cons(t: AST): Bool = (
    match t {
       App{is-cons=is-cons} => is-cons;
       _ => false;
    }
 );
 
-let .is-var(t: AST): U64 = (
+let .is-var(t: AST): Bool = (
    match t {
       Var{} => true;
       _ => false;
    }
 );
 
-let .is-var-or-ascripted-var(t: AST): U64 = (
+let .is-var-or-ascripted-var(t: AST): Bool = (
    match t {
       Var{} => true;
       App{ left:Var{key:c"as"}, right:App{ left:Var{}, right:AType{} } } => true;
@@ -195,8 +195,8 @@ let mk-meta(l: AST): AST = (
 let mk-nil(): AST = ASTNil();
 let mk-eof(): AST = ASTEOF();
 
-let .is-lit(t: AST): U64 = match t { Lit{} => true; _ => false; };
-let .is-ascript(t: AST): U64 = (
+let .is-lit(t: AST): Bool = match t { Lit{} => true; _ => false; };
+let .is-ascript(t: AST): Bool = (
    match t {
       App{ left:Lit{key:c":"}, right:App{ left:Lit{key=key}, right:AType{} } } => true;
       _ => false;
@@ -242,7 +242,7 @@ let .ascript(t: AST, tt: Type): AST = (
    )
 );
 
-let .is-nil(t: AST): U64 = (
+let .is-nil(t: AST): Bool = (
    match t {
       ASTNil{} => true;
       _ => false;

--- a/LM23COMMON/prop-is-phi-type.lsts
+++ b/LM23COMMON/prop-is-phi-type.lsts
@@ -1,6 +1,6 @@
 
-let phi-type-index = {} : HashtableEq<(CString,U64),U64>;
+let phi-type-index = {} : HashtableEq<(CString,U64),Bool>;
 
-let .is-phi-type(tt: Type): U64 = (
+let .is-phi-type(tt: Type): Bool = (
    phi-type-index.has(tt.ground-tag-and-arity)
 );

--- a/LM23COMMON/prop-is-special.lsts
+++ b/LM23COMMON/prop-is-special.lsts
@@ -1,5 +1,5 @@
 
-let is-special-index = {} : HashtableEq<(CString,Type),U64>;
+let is-special-index = {} : HashtableEq<(CString,Type),Bool>;
 
 let mark-as-special(name: CString, tt: Type): Nil = is-special-index = is-special-index.bind((name,tt), true);
-let is-special(name: CString, tt: Type): U64 = is-special-index.lookup((name,tt), false);
+let is-special(name: CString, tt: Type): Bool = is-special-index.lookup((name,tt), false);

--- a/LM23COMMON/prop-tctx-apply-callable.lsts
+++ b/LM23COMMON/prop-tctx-apply-callable.lsts
@@ -15,7 +15,7 @@ let .maybe-apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, b
    tctx.apply-callable(fname, arg-types, blame, return-type-hint, false);
 );
 
-let .apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type, failable: U64): (TypeContext?, Type) = (
+let .apply-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type, failable: Bool): (TypeContext?, Type) = (
    # Coerce types into denormalized format
    # TODO: replace with Into<Type::Format::Denormal> parameter types
    arg-types = denormalize-strong(arg-types);

--- a/LM23COMMON/prop-tctx-find-callable.lsts
+++ b/LM23COMMON/prop-tctx-find-callable.lsts
@@ -16,7 +16,7 @@ let .maybe-find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, bl
    tctx.find-callable(fname, arg-types, blame, return-type-hint, false);
 );
 
-let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type, failable: U64): TypeContextRow? = (
+let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: AST, return-type-hint: Type, failable: Bool): TypeContextRow? = (
    # Coerce argument types into Type::Format::Denormal
    # TODO: replace with Into<Type::Format::Denormal>
    arg-types = denormalize-strong(arg-types);

--- a/LM23COMMON/type-can-unify.lsts
+++ b/LM23COMMON/type-can-unify.lsts
@@ -138,7 +138,7 @@ let can-unify(fpt: Type, pt: Type): Bool = (
       Tuple{
           first:TGround{ltn=tag, lps=parameters},
           second:TGround{rtn=tag, rps=parameters}
-      } => (ltn==rtn || (ltn.has-suffix(c"::") and rtn.has-prefix(ltn))) and can-unify(lps,rps);
+      } => (ltn==rtn or (ltn.has-suffix(c"::") and rtn.has-prefix(ltn))) and can-unify(lps,rps);
       _ => false;
    };
 );

--- a/LM23COMMON/type-can-unify.lsts
+++ b/LM23COMMON/type-can-unify.lsts
@@ -1,7 +1,7 @@
 
-let $"<:"(pt: Type, fpt: Type): U64 = can-unify(fpt,pt);
+let $"<:"(pt: Type, fpt: Type): Bool = can-unify(fpt,pt);
 
-let can-unify(fpt: List<Type>, pt: List<Type>): U64 = (
+let can-unify(fpt: List<Type>, pt: List<Type>): Bool = (
    if fpt.length == pt.length {
       let ok = true;
       while ok and non-zero(fpt) {
@@ -12,7 +12,7 @@ let can-unify(fpt: List<Type>, pt: List<Type>): U64 = (
    } else false
 );
 
-let can-unify(fpt: Type, pt: Type): U64 = (
+let can-unify(fpt: Type, pt: Type): Bool = (
    match Tuple(fpt, pt) {
       Tuple{ first:TAny{} } => true;
       Tuple{ first:TGround{tag:c"Any"} } => true;
@@ -24,7 +24,7 @@ let can-unify(fpt: Type, pt: Type): U64 = (
       Tuple{ first:TVar{}, second:TGround{tag:c"Cons"} } => false;
       Tuple{ first:TVar{} } => true;
       Tuple{ first:TAnd{ lconjugate=conjugate }, second:TAnd{ rconjugate=conjugate } } => (
-         let result = true as U64;
+         let result = true;
          let ri = 0_u64;
          let phi-state-in = ta;
          for lc in lconjugate {
@@ -50,7 +50,7 @@ let can-unify(fpt: Type, pt: Type): U64 = (
                   if not(skip-state-check) then result = result && can-unify(phi-from, phi-state-in);
                );
                TGround{ltag=tag} => (
-                  let this-result-ok = false as U64;
+                  let this-result-ok = false;
                   let rc = rconjugate[ri];
                   let rtag = rc.simple-tag;
                   if not(non-zero(rtag)) then () else (
@@ -79,12 +79,12 @@ let can-unify(fpt: Type, pt: Type): U64 = (
          result;
       );
       Tuple{ first:TAnd{ lconjugate=conjugate }, rt=second } => (
-         let result = true as U64;
+         let result = true;
          for c in lconjugate { result = result && can-unify(c,rt) };
          result
       );
       Tuple{ lt=first, second:TAnd{ rconjugate=conjugate } } => (
-         let result = false as U64;
+         let result = false;
          for c in rconjugate { result = result || can-unify(lt,c) };
          result
       );

--- a/LM23COMMON/type-can-unify.lsts
+++ b/LM23COMMON/type-can-unify.lsts
@@ -25,7 +25,7 @@ let can-unify(fpt: Type, pt: Type): Bool = (
       Tuple{ first:TVar{} } => true;
       Tuple{ first:TAnd{ lconjugate=conjugate }, second:TAnd{ rconjugate=conjugate } } => (
          let result = true;
-         let ri = 0_u64;
+         let ri = 0_sz;
          let phi-state-in = ta;
          for lc in lconjugate {
             if result then (match lc {
@@ -42,12 +42,12 @@ let can-unify(fpt: Type, pt: Type): Bool = (
                         phi-state-in = phi-state-in && new-phi-state;
                      );
                      TGround{tag:c"Phi::Transition",parameters:[new-phi-to..new-phi-from..]} => (
-                        result = result && can-unify(phi-to, new-phi-to) && can-unify(phi-from, new-phi-from);
+                        result = result and can-unify(phi-to, new-phi-to) and can-unify(phi-from, new-phi-from);
                         skip-state-check = true;
                      );
                      _ => ();
                   }};
-                  if not(skip-state-check) then result = result && can-unify(phi-from, phi-state-in);
+                  if not(skip-state-check) then result = result and can-unify(phi-from, phi-state-in);
                );
                TGround{ltag=tag} => (
                   let this-result-ok = false;
@@ -63,7 +63,7 @@ let can-unify(fpt: Type, pt: Type): Bool = (
                      };
                      let scan-ri = ri;
                      while scan-ri<rconjugate.length and rtag==ltag {
-                        this-result-ok = this-result-ok || can-unify(lc,rc);
+                        this-result-ok = this-result-ok or can-unify(lc,rc);
                         scan-ri = scan-ri + 1;
                         if scan-ri < rconjugate.length {
                            rc = rconjugate[scan-ri];
@@ -71,21 +71,21 @@ let can-unify(fpt: Type, pt: Type): Bool = (
                         }
                      };
                   );
-                  result = result && this-result-ok;
+                  result = result and this-result-ok;
                );
-               _ => result = result && can-unify(lc,pt);
+               _ => result = result and can-unify(lc,pt);
             });
          };
          result;
       );
       Tuple{ first:TAnd{ lconjugate=conjugate }, rt=second } => (
          let result = true;
-         for c in lconjugate { result = result && can-unify(c,rt) };
+         for c in lconjugate { result = result and can-unify(c,rt) };
          result
       );
       Tuple{ lt=first, second:TAnd{ rconjugate=conjugate } } => (
          let result = false;
-         for c in rconjugate { result = result || can-unify(lt,c) };
+         for c in rconjugate { result = result or can-unify(lt,c) };
          result
       );
 
@@ -115,7 +115,7 @@ let can-unify(fpt: Type, pt: Type): Bool = (
           first:TGround{tag:c"...", parameters:[lp1..]},
           second:TGround{tag:c"Cons", parameters:[rp1..rpr..]}
       } => (
-         can-unify(lp1,rp1) && can-unify(fpt,rpr)
+         can-unify(lp1,rp1) and can-unify(fpt,rpr)
       );
       Tuple{
           first:TGround{tag:c"...", parameters:[lp1..]},

--- a/LM23COMMON/type-definition.lsts
+++ b/LM23COMMON/type-definition.lsts
@@ -5,7 +5,7 @@
 # TVar = 2
 # TAnd = 3
 type Type zero TAny
-        = TGround { tag:CString, parameters:List<Type>[] }
+        = TGround { tag:CString, parameters:OwnedData<List<Type>>[] }
         | TAny
         | TVar { name:CString }
         | TAnd { conjugate:Vector<Type> };

--- a/LM23COMMON/type-definition.lsts
+++ b/LM23COMMON/type-definition.lsts
@@ -5,7 +5,7 @@
 # TVar = 2
 # TAnd = 3
 type Type zero TAny
-        = TGround { tag:CString, parameters:OwnedData<List<Type>>[] }
+        = TGround { tag:CString, parameters:List<Type>[] }
         | TAny
         | TVar { name:CString }
         | TAnd { conjugate:Vector<Type> };

--- a/LM23COMMON/type-is-and.lsts
+++ b/LM23COMMON/type-is-and.lsts
@@ -1,5 +1,5 @@
 
-let .is-and(tt: Type): U64 = (
+let .is-and(tt: Type): Bool = (
    match tt {
       TAnd{} => true;
       _ => false;

--- a/LM23COMMON/type-is-any-arg-t.lsts
+++ b/LM23COMMON/type-is-any-arg-t.lsts
@@ -1,8 +1,8 @@
 
-let .is-any-arg-t(tt: Type, t-expect: CString, p-expect: U64): U64 = (
+let .is-any-arg-t(tt: Type, t-expect: CString, p-expect: U64): Bool = (
    match tt {
       TAnd { conjugate=conjugate } => (
-         let result = false as U64;
+         let result = false;
          for c in conjugate { result = result || c.is-any-arg-t(t-expect,p-expect) };
          result
       );

--- a/LM23COMMON/type-is-arrow.lsts
+++ b/LM23COMMON/type-is-arrow.lsts
@@ -1,8 +1,8 @@
 
-let .is-arrow(tt: Type): U64 = (
+let .is-arrow(tt: Type): Bool = (
    match tt {
       TAnd { conjugate=conjugate } => (
-         let result = false as U64;
+         let result = false;
          for c in conjugate { result = result or c.is-arrow };
          result
       );

--- a/LM23COMMON/type-is-linear-live.lsts
+++ b/LM23COMMON/type-is-linear-live.lsts
@@ -1,5 +1,5 @@
 
-let .is-linear-live(tt: Type): U64 = (
+let .is-linear-live(tt: Type): Bool = (
    match tt {
       TAnd{conjugate=conjugate} => (
          let return = false;

--- a/LM23COMMON/type-is-linear-live.lsts
+++ b/LM23COMMON/type-is-linear-live.lsts
@@ -3,14 +3,14 @@ let .is-linear-live(tt: Type): Bool = (
    match tt {
       TAnd{conjugate=conjugate} => (
          let return = false;
-         for c in conjugate { return = return || c.is-linear-live };
+         for c in conjugate { return = return or c.is-linear-live };
          return
       );
       TGround{tag:c"Linear",parameters:[TGround{tag:c"Phi::Moved",parameters:[]}..]} => false;
       TGround{tag:c"Linear",parameters:[_..]} => true;
       TGround{parameters=parameters} => (
          let return = false;
-         for c in parameters { return = return || c.is-linear-live };
+         for list c in parameters { return = return or c.is-linear-live };
          return
       );
       _ => false;

--- a/LM23COMMON/type-is-moved.lsts
+++ b/LM23COMMON/type-is-moved.lsts
@@ -1,5 +1,5 @@
 
-let .is-moved(tt: Type): U64 = (
+let .is-moved(tt: Type): Bool = (
    match tt {
       TAnd{conjugate=conjugate} => (
          let moved = false;

--- a/LM23COMMON/type-is-moved.lsts
+++ b/LM23COMMON/type-is-moved.lsts
@@ -4,15 +4,15 @@ let .is-moved(tt: Type): Bool = (
       TAnd{conjugate=conjugate} => (
          let moved = false;
          for c in conjugate {
-            moved = moved || c.is-moved;
+            moved = moved or c.is-moved;
          };
          moved
       );
       TGround{tag:c"Phi::Moved",parameters:[]} => true;
       TGround{tag=tag,parameters=parameters} => (
          let moved = false;
-         for c in parameters {
-            moved = moved || c.is-moved;
+         for list c in parameters {
+            moved = moved or c.is-moved;
          };
          moved
       );

--- a/LM23COMMON/type-is-open.lsts
+++ b/LM23COMMON/type-is-open.lsts
@@ -1,10 +1,10 @@
 
-let .is-open(tt: Type): U64 = (
+let .is-open(tt: Type): Bool = (
    match tt {
       TAny {} => true;
       TVar {} => true;
       TAnd { conjugate=conjugate } => (
-         let result = false as U64;
+         let result = false;
          for c in conjugate { result = result or c.is-open };
          result
       );

--- a/LM23COMMON/type-is-open.lsts
+++ b/LM23COMMON/type-is-open.lsts
@@ -12,7 +12,7 @@ let .is-open(tt: Type): Bool = (
       TGround { tag:c"Array", parameters:[_.. base-type..] } => base-type.is-open;
       TGround { parameters=parameters } => (
          let is-open = false;
-         for p in parameters { is-open = is-open or p.is-open; };
+         for list p in parameters { is-open = is-open or p.is-open; };
          is-open;
       );
    }

--- a/LM23COMMON/type-is-t.lsts
+++ b/LM23COMMON/type-is-t.lsts
@@ -1,8 +1,8 @@
 
-let .is-t(tt: Type, tt-tag: CString, tt-length: U64): U64 = (
+let .is-t(tt: Type, tt-tag: CString, tt-length: U64): Bool = (
    match tt {
       TAnd { conjugate=conjugate } => (
-         let result = false as U64;
+         let result = false;
          for c in conjugate { result = result or c.is-t(tt-tag, tt-length) };
          result
       );

--- a/LM23COMMON/type-remove-info.lsts
+++ b/LM23COMMON/type-remove-info.lsts
@@ -2,7 +2,7 @@
 let remove-info(base: Type, rm: Type): Type = (
    match base {
       TAnd{ conjugate=conjugate } => (
-         let result = mk-vector(type(Type), 0_u64);
+         let result = mk-vector(type(Type), 0);
          for c in conjugate {
             match remove-info(c,rm) {
                TAnd{rconjugate=conjugate} => for rc in rconjugate { result = result.push(rc) };
@@ -18,7 +18,7 @@ let remove-info(base: Type, rm: Type): Type = (
          if rm.is-t(c"MustNotMove",0) and base.is-t(c"MustNotMove",0) then ta
          else if rm.is-t(c"MustNotRetain",0) and base.is-t(c"MustNotRetain",0) then ta
          else if rm.is-t(c"MustNotFresh",0) and base.is-t(c"MustNotFresh",0) then ta
-         else if rm.is-t(c"MustNotMove",0) || rm.is-t(c"MustNotRetain",0) || rm.is-t(c"MustNotFresh",0) then base
+         else if rm.is-t(c"MustNotMove",0) or rm.is-t(c"MustNotRetain",0) or rm.is-t(c"MustNotFresh",0) then base
          else if base <: rm then ta else base
       );
       _ => base;

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/lm-util/uuid.lsts
+	lm tests/promises/lm-type/constructor.lsts
 	gcc tmp.c
 	./a.out
 

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -360,7 +360,9 @@ let lsts-parse-type-conjugate(tokens: List<Token>): Tuple<Type,List<Token>> = (
          };
          lsts-parse-expect(c">", tokens); tokens = tail(tokens);
       };
-      TGround ( base, close(args) );
+      if not(config-v3) and base==c"OwnedData" and args.length==1 {
+         head(args);
+      } else TGround ( base, close(args) );
    };
    while lsts-parse-head(tokens) == c"[" || lsts-parse-head(tokens)==c"?" {
       if lsts-parse-head(tokens)==c"[" {

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -1786,6 +1786,8 @@ let lsts-parse-atom-without-tail(tokens: List<Token>): Tuple<AST,List<Token>> = 
       term = AType( term-rest.first );
    } else if lsts-parse-head(tokens)==c"for" {
       let loc = head(tokens).location; tokens = tail(tokens);
+      let list = false;
+      if lsts-parse-head(tokens)==c"list" then { tokens = tail(tokens); list = true; };
       let lhs-rest = lsts-parse-lhs(tokens);
       tokens = lhs-rest.second;
       lsts-parse-expect(c"in", tokens); tokens = tail(tokens);
@@ -1799,22 +1801,41 @@ let lsts-parse-atom-without-tail(tokens: List<Token>): Tuple<AST,List<Token>> = 
          tokens = rhs-rest.second;
       };
       lsts-parse-expect(c"}", tokens); tokens = tail(tokens);
-      term = mk-app(
-         mk-app(
-            Var( c"for-each", with-location(mk-token("for-each"),loc) ),
-            mk-cons(
+      if list {
+         term = mk-app(
+            mk-app(
+               Var( c"for-each-list", with-location(mk-token("for-each-list"),loc) ),
                mk-cons(
-                  lhs-rest.first,
-                  Var( c"in", with-location(mk-token("in"),loc) )
-               ),
-               iter-rest.first
+                  mk-cons(
+                     lhs-rest.first,
+                     Var( c"in", with-location(mk-token("in"),loc) )
+                  ),
+                  iter-rest.first
+               )
+            ),
+            mk-app(
+               Var( c"scope", with-location(mk-token("scope"),loc) ),
+               rhs
             )
-         ),
-         mk-app(
-            Var( c"scope", with-location(mk-token("scope"),loc) ),
-            rhs
-         )
-      );         
+         );
+      } else {
+         term = mk-app(
+            mk-app(
+               Var( c"for-each", with-location(mk-token("for-each"),loc) ),
+               mk-cons(
+                  mk-cons(
+                     lhs-rest.first,
+                     Var( c"in", with-location(mk-token("in"),loc) )
+                  ),
+                  iter-rest.first
+               )
+            ),
+            mk-app(
+               Var( c"scope", with-location(mk-token("scope"),loc) ),
+               rhs
+            )
+         );
+      }         
    } else if lsts-parse-head(tokens)==c"while" {
       let loc = head(tokens).location; tokens = tail(tokens);
       let c-rest = lsts-parse-small-expression(tokens);

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -144,7 +144,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                then { cond = new-cond; t = new-t; f = new-f; term = mk-app(mk-app(mk-app(ifv,new-cond),new-t),new-f) };
                tctx = tctx.with-pctx( phi-merge(tctx,tctx-t.get-or(mk-tctx()).pctx,tctx-f.get-or(mk-tctx()).pctx,term) );
             };
-            if not(typeof-term(cond).is-t(c"Bool",0)) {
+            if not(typeof-term(cond).is-t(c"Bool",0) || typeof-term(cond).is-t(c"U64",0)) {
                tctx.apply-callable(c"into-branch-conditional", typeof-term(cond), cond);
             };
             let lub = if typeof-term(f).is-t(c"Never",0) then typeof-term(t)

--- a/lib/core/common-macros.lsts
+++ b/lib/core/common-macros.lsts
@@ -295,6 +295,15 @@ deprecated macro ( rl"for-each"(item(rl"in")(iterable))(loop) ) ((
    }
 ));
 
+deprecated macro ( rl"for-each-list"(item(rl"in")(iterable))(loop) ) ((
+   let uuid(iter-term) = iterable;
+   while non-zero(uuid(iter-term)) {
+      let item = head(uuid(iter-term));
+      uuid(iter-term) = tail(uuid(iter-term));
+      loop;
+   };
+));
+
 deprecated macro ( rl"assert"(c) ) (
    $"if"( not(c) )
         ( print(c"Assertion Failed At "); print(p(rl":Location:") : Constant+Literal+CString); exit(1_u64); )

--- a/lib2/core/common-macros.lsts
+++ b/lib2/core/common-macros.lsts
@@ -66,6 +66,15 @@ deprecated macro ( rl"for-each"(item(rl"in")(iterable))(loop) ) ((
    };
 ));
 
+deprecated macro ( rl"for-each-list"(item(rl"in")(iterable))(loop) ) ((
+   let uuid(iter-term) = iterable;
+   while non-zero(uuid(iter-term)) {
+      let item = head(uuid(iter-term));
+      uuid(iter-term) = tail(uuid(iter-term));
+      loop;
+   };
+));
+
 deprecated macro ( rl"let"(x)(y) ) ( (fn(x) = ())(y) );
 
 deprecated macro ( rl"set"(lhs)(rhs) ) ( mov(rhs,lhs) );

--- a/lib2/core/common-macros.lsts
+++ b/lib2/core/common-macros.lsts
@@ -57,6 +57,15 @@ typed macro macro::while(cond: lazy, body: lazy): lazy = (
    primitive::while( cond, body as Nil )
 );
 
+deprecated macro ( rl"for-each"(item(rl"in")(iterable))(loop) ) ((
+   let uuid(iter-term) = iterable;
+   let uuid(iter-i) = 0_sz;
+   while uuid(iter-i) < uuid(iter-term).length {
+      let item = uuid(iter-term)[uuid(iter-i)];
+      loop;
+   };
+));
+
 deprecated macro ( rl"let"(x)(y) ) ( (fn(x) = ())(y) );
 
 deprecated macro ( rl"set"(lhs)(rhs) ) ( mov(rhs,lhs) );

--- a/lib2/core/cstring.lsts
+++ b/lib2/core/cstring.lsts
@@ -5,6 +5,7 @@ type opaque alias CString suffix _s = C<"char">[];
 declare-unop( $".c-pointer", raw-type(CString), raw-type(C<"char">[]), x );
 
 let .length(l: CString): USize = strlen(l.c-pointer) as USize;
+let non-zero(l: CString): Bool = l.length > 0;
 
 let cmp(l: CString, r: CString): Ord = (
    let c = strcmp( l.c-pointer, r.c-pointer ) as I64;
@@ -60,4 +61,34 @@ let $"+"(l: CString, r: CString): CString = (
    strcat(buf, l as C<"char">[]);
    strcat(buf, r as C<"char">[]);
    buf as CString
+);
+
+let .has-suffix(s2: CString, s1: CString): Bool = (
+   let s1_length = s1.length;
+   let s2_length = s2.length;
+   if s1_length > s2_length then false else {
+      let i = 0_sz;
+      let return = true;
+      while i < s1_length {
+         if s1[s1_length - i - 1] != s2[s2_length - i - 1]
+         then return = false;
+         i = i + 1;
+      };
+      return
+   }
+);
+
+let .has-prefix(s2: CString, s1: CString): Bool = (
+   let s1_length = s1.length;
+   let s2_length = s2.length;
+   if s1_length > s2_length then false else {
+      let i = 0_sz;
+      let return = true;
+      while i < s1_length {
+         if s1[i] != s2[i]
+         then return = false;
+         i = i + 1;
+      };
+      return
+   }
 );

--- a/lib2/core/list.lsts
+++ b/lib2/core/list.lsts
@@ -68,6 +68,6 @@ let tail(l: List<x>): List<x> = if l.has-head then open((l as Tag::LCons).tail) 
 
 let .length(l: List<x>): U64 = (
    let li = 0_u64;
-   for _ in l { li = li + 1; };
+   for _ in l { li = li + 1 };
    li
 );

--- a/lib2/core/list.lsts
+++ b/lib2/core/list.lsts
@@ -36,3 +36,32 @@ let deep-hash(t: List<x>): U64 = (
 let .into(l: List<x>, tt: Type<String>): String = (
    "[..TODO..List.into(String)..]"
 );
+
+let .has-head(tt: List<x>): U64 = non-zero(tt);
+
+let .nth(tt: List<x>, idx: U64): Maybe<x> = (
+   let err = false;
+   while idx > 0 && not(err) {
+      if tt.has-head() {
+         tt = tail(tt);
+         idx = idx - 1;
+      } else {
+         err = true;
+      }
+   };
+
+   if err || not(tt.has-head()) {
+      None : Maybe<x>
+   } else {
+      Some(head(tt))
+   }
+);
+
+let .reverse(l: List<x>): List<x> = (
+   let r = [] : List<x>;
+   for v in l { r = cons(v,r); };
+   r
+);
+
+let head(l: List<x>): x = if l.has-head then (l as Tag::LCons).head else fail(c"list::head is fallible");
+let tail(l: List<x>): List<x> = if l.has-head then open((l as Tag::LCons).tail) else fail(c"list::tail is fallible");

--- a/lib2/core/list.lsts
+++ b/lib2/core/list.lsts
@@ -39,7 +39,7 @@ let .into(l: List<x>, tt: Type<String>): String = (
 
 let .has-head(tt: List<x>): Bool = non-zero(tt);
 
-let .nth(tt: List<x>, idx: U64): Maybe<x> = (
+let .nth(tt: List<x>, idx: USize): Maybe<x> = (
    let err = false;
    while idx > 0 && not(err) {
       if tt.has-head() {
@@ -55,6 +55,16 @@ let .nth(tt: List<x>, idx: U64): Maybe<x> = (
    } else {
       Some(head(tt))
    }
+);
+
+let $"[]"(tt: List<x>, idx: USize): x = (
+   while idx > 0 {
+      if not(tt.has-head()) {
+         fail(c"list index out of bounds");
+      };
+      tt = tail(tt);
+   };
+   head(tt)
 );
 
 let .reverse(l: List<x>): List<x> = (

--- a/lib2/core/list.lsts
+++ b/lib2/core/list.lsts
@@ -37,7 +37,7 @@ let .into(l: List<x>, tt: Type<String>): String = (
    "[..TODO..List.into(String)..]"
 );
 
-let .has-head(tt: List<x>): U64 = non-zero(tt);
+let .has-head(tt: List<x>): Bool = non-zero(tt);
 
 let .nth(tt: List<x>, idx: U64): Maybe<x> = (
    let err = false;
@@ -65,3 +65,9 @@ let .reverse(l: List<x>): List<x> = (
 
 let head(l: List<x>): x = if l.has-head then (l as Tag::LCons).head else fail(c"list::head is fallible");
 let tail(l: List<x>): List<x> = if l.has-head then open((l as Tag::LCons).tail) else fail(c"list::tail is fallible");
+
+let .length(l: List<x>): U64 = (
+   let li = 0_u64;
+   for _ in l { li = li + 1; };
+   li
+);

--- a/lib2/core/maybe.lsts
+++ b/lib2/core/maybe.lsts
@@ -33,3 +33,16 @@ let .into(t: Maybe<x>, tt: Type<String>): String = (
    then "Some(" + (t as Tag::Some).content.into(type(String)) + ")"
    else "None"
 );
+
+let .get-or(m: Maybe<x>, default: x): x = (
+   match m {
+      Some{content=content} => content;
+      None{} => default;
+   }
+);
+
+let .get-or-panic(m: Maybe<x>): x = (
+   match m {
+      Some{content=content} => content;
+   }
+);

--- a/tests/promises/cstring/comparison.lsts
+++ b/tests/promises/cstring/comparison.lsts
@@ -22,3 +22,6 @@ assert( c"abc"[1] == 98 );
 assert( c"abc"[2] == 99 );
 
 assert( c"a" + c"bc" == c"abc" );
+
+assert( c"abc".has-suffix(c"bc") );
+assert( not(c"abc".has-suffix(c"d")) );

--- a/tests/promises/maybe/comparison.lsts
+++ b/tests/promises/maybe/comparison.lsts
@@ -14,3 +14,17 @@ assert( Some("1") == Some("1") );
 assert( Some("0") != Some("1") );
 assert( Some("1") != Some("0") );
 assert( safe-alloc-block-count == 0 );
+
+assert( Some(1_u64).get-or(2_u64) == 1 );
+assert( (None : U64?).get-or(2_u64) == 2 );
+assert( safe-alloc-block-count == 0 );
+
+#assert( Some("1").get-or("2") == "1" );
+#assert( (None : String?).get-or("2") == "2" );
+#assert( safe-alloc-block-count == 0 );
+
+assert( Some(1_u64).get-or-panic == 1 );
+assert( safe-alloc-block-count == 0 );
+
+assert( Some("1").get-or-panic == "1" );
+assert( safe-alloc-block-count == 0 );


### PR DESCRIPTION
## Describe your changes
Features:
* quite a few lib2 convenience functions
* Use `Bool` throughout lib2 instead of U64, it is a direct alias in lib1 anyways
* Create a `for list x in y {}` syntax because we don't have type directed macros
   * thanks Alex but your macro doesn't work with garbage collection :(
* create a config-v2/v3 switch for OwnedData in types (that type just gets collapsed downwards)
   * Example `OwnedData<List<x>>[]` becomes just `List<x>[]` in v2 because OwnedData does not exist in the old library
* `lm-type` tests are close to working
* there is some missing phi id problem that is preventing that code from compiling, but I am done for today

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
