### PR TITLE
Gc enabled lmcommon fdusiofs

### DIFF
--- a/LM23COMMON/type-as-return-hint.lsts
+++ b/LM23COMMON/type-as-return-hint.lsts
@@ -2,7 +2,7 @@
 let .as-return-hint(tt: Type): Type = (
    match tt {
       TAnd { conjugate=conjugate } => (
-         let result = mk-vector(type(Type), 0_u64);
+         let result = mk-vector(type(Type), 0);
          for c in conjugate {
             c = c.as-return-hint;
             if non-zero(c) then result = result.push(c);

--- a/LM23COMMON/type-can-apply.lsts
+++ b/LM23COMMON/type-can-apply.lsts
@@ -1,2 +1,2 @@
 
-let can-apply(ft: Type, pt: Type): U64 = pt <: ft.domain;
+let can-apply(ft: Type, pt: Type): Bool = pt <: ft.domain;

--- a/LM23COMMON/type-can-receive.lsts
+++ b/LM23COMMON/type-can-receive.lsts
@@ -1,2 +1,2 @@
 
-let can-receive(ft: Type, pt: Type): U64 = pt <: ft.range;
+let can-receive(ft: Type, pt: Type): Bool = pt <: ft.range;

--- a/LM23COMMON/type-is-any-arg-t.lsts
+++ b/LM23COMMON/type-is-any-arg-t.lsts
@@ -3,10 +3,10 @@ let .is-any-arg-t(tt: Type, t-expect: CString, p-expect: U64): Bool = (
    match tt {
       TAnd { conjugate=conjugate } => (
          let result = false;
-         for c in conjugate { result = result || c.is-any-arg-t(t-expect,p-expect) };
+         for c in conjugate { result = result or c.is-any-arg-t(t-expect,p-expect) };
          result
       );
-      TGround { tag:c"Cons", parameters:[l1..l2..] } => l1.is-any-arg-t(t-expect,p-expect) || l2.is-any-arg-t(t-expect,p-expect);
+      TGround { tag:c"Cons", parameters:[l1..l2..] } => l1.is-any-arg-t(t-expect,p-expect) or l2.is-any-arg-t(t-expect,p-expect);
       TGround { tag:tag, parameters:parameters } => tag==t-expect and parameters.length==p-expect;
       _ => false;
    }

--- a/LM23COMMON/type-sanitize-phi.lsts
+++ b/LM23COMMON/type-sanitize-phi.lsts
@@ -2,7 +2,7 @@
 let .sanitize-phi(tt: Type): Type = (
    match tt {
       TAnd { conjugate=conjugate } => (
-         let result = mk-vector(type(Type), 0_u64);
+         let result = mk-vector(type(Type), 0);
          for c in conjugate {
             match c.sanitize-phi {
                TAnd{rconjugate=conjugate} => for rc in rconjugate { result = result.push(rc) };

--- a/LM23COMMON/type-without-any-phi.lsts
+++ b/LM23COMMON/type-without-any-phi.lsts
@@ -6,7 +6,7 @@
 let .without-any-phi(tt: Type): Type = (
    match tt {
       TAnd { conjugate=conjugate } => (
-         let result = mk-vector(type(Type), 0_u64);
+         let result = mk-vector(type(Type), 0);
          for c in conjugate {
             c = c.without-any-phi;
             if non-zero(c) then result = result.push(c);

--- a/LM23COMMON/type-without-phi-keep-id.lsts
+++ b/LM23COMMON/type-without-phi-keep-id.lsts
@@ -8,7 +8,7 @@
 let .without-phi-keep-id(tt: Type): Type = (
    match tt {
       TAnd { conjugate=conjugate } => (
-         let result = mk-vector(type(Type), 0_u64);
+         let result = mk-vector(type(Type), 0);
          for c in conjugate {
             c = c.without-phi-keep-id;
             if non-zero(c) then result = result.push(c);

--- a/LM23COMMON/type-without-phi-keep-state.lsts
+++ b/LM23COMMON/type-without-phi-keep-state.lsts
@@ -8,7 +8,7 @@
 let .without-phi-keep-state(tt: Type): Type = (
    match tt {
       TAnd { conjugate=conjugate } => (
-         let result = mk-vector(type(Type), 0_u64);
+         let result = mk-vector(type(Type), 0);
          for c in conjugate {
             c = c.without-phi-keep-state;
             if non-zero(c) then result = result.push(c);

--- a/LM23COMMON/type-without-phi.lsts
+++ b/LM23COMMON/type-without-phi.lsts
@@ -9,7 +9,7 @@
 let .without-phi(tt: Type): Type = (
    match tt {
       TAnd { conjugate=conjugate } => (
-         let result = mk-vector(type(Type), 0_u64);
+         let result = mk-vector(type(Type), 0);
          for c in conjugate {
             c = c.without-phi;
             if non-zero(c) then result = result.push(c);

--- a/LM23COMMON/type-without-slot.lsts
+++ b/LM23COMMON/type-without-slot.lsts
@@ -2,7 +2,7 @@
 let .without-slot(tt: Type, t-tag: CString, t-arity: U64): Type = (
    match tt {
       TAnd { conjugate=conjugate } => (
-         let result = mk-vector(type(Type), 0_u64);
+         let result = mk-vector(type(Type), 0);
          for c in conjugate {
             c = c.without-slot(t-tag, t-arity);
             if non-zero(c) then result = result.push(c);

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/tuple/match-destructuring-1.lsts
+	lm tests/promises/lm-type/constructor.lsts
 	gcc tmp.c
 	./a.out
 

--- a/PLUGINS/BACKEND/C/std-c-compile-destructure-args.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-destructure-args.lsts
@@ -5,14 +5,14 @@ let std-c-compile-destructure-args(ctx: FContext, lhs: AST, is-fragment: U64): F
          ctx = std-c-compile-destructure-args(ctx, rst, is-fragment);
          if is-fragment then { kt = denormalize(kt); }
          else { kt = kt.normalize && t0(c"LocalVariable"); };
-         let fragment = if std-c-is-ctype(kt) then mk-expression(k) else mk-expression(uuid());
+         let fragment = if std-c-is-ctype(kt) then mk-expression(k.replace(c"-",c"_")) else mk-expression(uuid());
          ctx = ctx.bind(k, kt, fragment);
          std-c-fragment-context = std-c-fragment-context.bind(lhs-v, fragment);
       );
       App{ left:Lit{key:c":"}, right:App{ lhs-v=left:Var{k=key}, right:AType{kt=tt} } } => (
          if is-fragment then { kt = denormalize(kt); }
          else { kt = kt.normalize && t0(c"LocalVariable"); };
-         let fragment = if std-c-is-ctype(kt) then mk-expression(k) else mk-expression(uuid());
+         let fragment = if std-c-is-ctype(kt) then mk-expression(k.replace(c"-",c"_")) else mk-expression(uuid());
          ctx = ctx.bind(k, kt, fragment);
          std-c-fragment-context = std-c-fragment-context.bind(lhs-v, fragment);
       );

--- a/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
@@ -21,7 +21,7 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
       );
       App{ left:Abs{lhs=lhs:Var{name=key}, rhs:ASTNil{}}, rhs=right } => (
          let lt = typeof-term(lhs).without-modifiers;
-         let vid = if lt.is-t(c"Nil",0) then SAtom(c"({})") else if std-c-is-ctype(lt) then SAtom(name) else SAtom(uuid());
+         let vid = if lt.is-t(c"Nil",0) then SAtom(c"({})") else if std-c-is-ctype(lt) then SAtom(name.replace(c"-",c"_")) else SAtom(uuid());
          let v = mk-fragment().set(c"expression",vid);
          let f = mk-fragment();
          std-c-fragment-context = std-c-fragment-context.bind( lhs, v );

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -152,10 +152,15 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             else if typeof-term(f).is-t(c"Nil",0) || typeof-term(t).is-t(c"Nil",0) then t0(c"Nil")
             else { (tctx, let lub) = tctx.least-upper-bound(typeof-term(t), typeof-term(f), term); lub };
             tctx = tctx.ascript(term, lub);
+            let term-phi-id = typeof-term(term).slot(c"Phi::Id",1).l1.simple-tag;
+            let t-phi-id = typeof-term(t).slot(c"Phi::Id",1).l1.simple-tag;
+            let f-phi-id = typeof-term(f).slot(c"Phi::Id",1).l1.simple-tag;
             if is-scoped {
-               (tctx, term) = release-locals(tctx, tctx-t, term, hint, false); # tctx-t includes both tctx-cond and tctx-t
-               (tctx, term) = release-locals(tctx, tctx-f, term, hint, false);
+               (tctx, term) = release-locals(tctx, tctx-t, term, hint, false ); # tctx-t includes both tctx-cond and tctx-t
+               (tctx, term) = release-locals(tctx, tctx-f, term, hint, false );
             };
+            if non-zero(term-phi-id) and term-phi-id != t-phi-id then tctx = tctx.phi-move(typeof-term(t), t);
+            if non-zero(term-phi-id) and term-phi-id != f-phi-id then tctx = tctx.phi-move(typeof-term(f), f);
          }
       );
       ASTEOF{} => tctx = tctx.ascript(term, t0(c"Nil"));

--- a/lib2/core/array.lsts
+++ b/lib2/core/array.lsts
@@ -51,17 +51,17 @@ let safe-alloc-impl(nb: USize): ?[] = (
 let safe-realloc-impl(ptr: ?[], nb: USize): ?[] = (
    # BEFORE CHANGING THIS: talk to alex
 
-   let new_ptr = realloc(ptr as C<"void">[], nb) as ?[];
+   let new-ptr = realloc(ptr as C<"void">[], nb) as ?[];
 
-   if new_ptr as USize == 0_sz {
+   if new-ptr as USize == 0_sz {
       fail(c"realloc fail");
    };
 
    # Zero Out Memory
-   memset(new_ptr as C<"void">[], 0, nb);
+   memset(new-ptr as C<"void">[], 0, nb);
 
-   mark-memory-as-safe(new_ptr as U8[], nb);
-   new_ptr
+   mark-memory-as-safe(new-ptr as U8[], nb);
+   new-ptr
 );
 
 ## this will fail() if len is 0

--- a/lib2/core/baremetal-into.lsts
+++ b/lib2/core/baremetal-into.lsts
@@ -5,55 +5,55 @@ let .into(i: USize, tt: Type<String>): String = (i as U64).into(type(String));
 
 let .into(i: I64, tt: Type<String>): String = (
    let od = mk-owned-data(type(U8), 20_sz);
-   let cs_length = 0_sz;
+   let cs-length = 0_sz;
    let is-negative = false;
    if i < 0_i64 {
       is-negative = true;
       od.push(45);
-      cs_length = cs_length + 1;
+      cs-length = cs-length + 1;
    } else if i == 0_i64 {
       od.push(48);
-      cs_length = cs_length + 1;
+      cs-length = cs-length + 1;
    };
    while i != 0_i64 {
       od.push(48 + (abs(i % 10) as U8));
-      cs_length = cs_length + 1;
+      cs-length = cs-length + 1;
       i = i / 10;
    };
-   let start_i = if is-negative then 1_sz else 0_sz;
-   let end_i = cs_length - 1_sz;
-   while start_i < end_i {
-      let tmpc = od.data[start_i];
-      od.data[start_i] = od.data[end_i];
-      od.data[end_i] = tmpc;
-      start_i = start_i + 1_sz;
-      end_i = end_i - 1_sz;
+   let start-i = if is-negative then 1_sz else 0_sz;
+   let end-i = cs-length - 1_sz;
+   while start-i < end-i {
+      let tmpc = od.data[start-i];
+      od.data[start-i] = od.data[end-i];
+      od.data[end-i] = tmpc;
+      start-i = start-i + 1_sz;
+      end-i = end-i - 1_sz;
    };
-   String(0 as USize, cs_length, od)
+   String(0 as USize, cs-length, od)
 );
 
 let .into(i: U64, tt: Type<String>): String = (
    let od = mk-owned-data(type(U8), 20_sz);
-   let cs_length = 0_sz;
+   let cs-length = 0_sz;
    if i == 0_u64 {
       od.push(48);
-      cs_length = cs_length + 1;
+      cs-length = cs-length + 1;
    };
    while i != 0_u64 {
       od.push(48 + ((i % 10) as U8));
-      cs_length = cs_length + 1;
+      cs-length = cs-length + 1;
       i = i / 10;
    };
-   let start_i = 0_sz;
-   let end_i = cs_length - 1_sz;
-   while start_i < end_i {
-      let tmpc = od.data[start_i];
-      od.data[start_i] = od.data[end_i];
-      od.data[end_i] = tmpc;
-      start_i = start_i + 1_sz;
-      end_i = end_i - 1_sz;
+   let start-i = 0_sz;
+   let end-i = cs-length - 1_sz;
+   while start-i < end-i {
+      let tmpc = od.data[start-i];
+      od.data[start-i] = od.data[end-i];
+      od.data[end-i] = tmpc;
+      start-i = start-i + 1_sz;
+      end-i = end-i - 1_sz;
    };
-   String(0 as USize, cs_length, od)
+   String(0 as USize, cs-length, od)
 );
 
 let .to-hex(i: U64): String = (

--- a/lib2/core/cstring.lsts
+++ b/lib2/core/cstring.lsts
@@ -48,9 +48,9 @@ let $"[]"(l: CString, idx: USize): U8 = (
 
 let hash(key: CString): U64 = (
    let i = 0_sz;
-   let key_length = key.length;
+   let key-length = key.length;
    let result = 0_u64;
-   while i < key_length {
+   while i < key-length {
       result = result + key[i];
       result = result + (result << 10);
       result = result ^ (result >> 6);
@@ -72,13 +72,13 @@ let $"+"(l: CString, r: CString): CString = (
 );
 
 let .has-suffix(s2: CString, s1: CString): Bool = (
-   let s1_length = s1.length;
-   let s2_length = s2.length;
-   if s1_length > s2_length then false else {
+   let s1-length = s1.length;
+   let s2-length = s2.length;
+   if s1-length > s2-length then false else {
       let i = 0_sz;
       let return = true;
-      while i < s1_length {
-         if s1[s1_length - i - 1] != s2[s2_length - i - 1]
+      while i < s1-length {
+         if s1[s1-length - i - 1] != s2[s2-length - i - 1]
          then return = false;
          i = i + 1;
       };
@@ -87,12 +87,12 @@ let .has-suffix(s2: CString, s1: CString): Bool = (
 );
 
 let .has-prefix(s2: CString, s1: CString): Bool = (
-   let s1_length = s1.length;
-   let s2_length = s2.length;
-   if s1_length > s2_length then false else {
+   let s1-length = s1.length;
+   let s2-length = s2.length;
+   if s1-length > s2-length then false else {
       let i = 0_sz;
       let return = true;
-      while i < s1_length {
+      while i < s1-length {
          if s1[i] != s2[i]
          then return = false;
          i = i + 1;

--- a/lib2/core/cstring.lsts
+++ b/lib2/core/cstring.lsts
@@ -61,6 +61,7 @@ let hash(key: CString): U64 = (
    result = result + (result << 15);
    result
 );
+let deep-hash(key: CString): U64 = hash(key);
 
 let $"+"(l: CString, r: CString): CString = (
    let buf = malloc(l.length + r.length + 1) as C<"char">[];

--- a/lib2/core/hashtable.lsts
+++ b/lib2/core/hashtable.lsts
@@ -39,12 +39,12 @@ let mk-hashtable(): Hashtable<k,v> = (
 
 let .realloc(h: Hashtable<k,v>, target-capacity: USize): Hashtable<k,v> = (
    let new-data = mk-sparse-owned-data(type((HashtableRowExists,k,v)), target-capacity);
-   let old_i = 0_sz;
-   while old_i < h.data.capacity {
-      let old_kv = h.data[old_i];
-      if is(old_kv.first,HashtableRowFilled)
-      then new-data[old_i] = h.data[old_i];
-      old_i = old_i + 1;
+   let old-i = 0_sz;
+   while old-i < h.data.capacity {
+      let old-kv = h.data[old-i];
+      if is(old-kv.first,HashtableRowFilled)
+      then new-data[old-i] = h.data[old-i];
+      old-i = old-i + 1;
    };
    Hashtable(new-data)
 );
@@ -68,10 +68,10 @@ let .bind(h: Hashtable<k,v>, key: k, val: v): Hashtable<k,v> = (
 
 let .bind-direct(h: Hashtable<k,v>, key: k, val: v): Nil = (
    if (h.data as USize) != 0 and h.data.capacity > 0 {
-      let key_hash = hash(key);
+      let key-hash = hash(key);
       let found = false;
       let contents = h.data;
-      let ki = (key_hash as USize) % contents.capacity;
+      let ki = (key-hash as USize) % contents.capacity;
       let kv = contents[ki];
       if is(kv.first,HashtableRowFilled) and kv.second==key { found = true; };
       while not(found) and is(kv.first,HashtableRowFilled) {
@@ -90,19 +90,19 @@ let $"map::cons"(key: k, val: v, h: Hashtable<k,v>): Hashtable<k,v> = (
 
 
 let $"[]"(h: Hashtable<k,v>, key: k): Maybe<k> = (
-   let row_index = h.find-row-index-by-key(key);
-   if row_index == (-1 as USize)
+   let row-index = h.find-row-index-by-key(key);
+   if row-index == (-1 as USize)
    then (None : Maybe<v>)
-   else Some(h.data[row_index].third)
+   else Some(h.data[row-index].third)
 );
 
 let .find-row-index-by-key(h: Hashtable<k,v>, key: k): USize = (
-   let row_index = -1 as USize;
+   let row-index = -1 as USize;
    if (h.data as USize) != 0 and h.data.capacity > 0 {
-      let key_hash = hash(key);
+      let key-hash = hash(key);
       let found = false;
       let contents = h.data;
-      let ki = (key_hash as USize) % contents.capacity;
+      let ki = (key-hash as USize) % contents.capacity;
       let kv = contents[ki];
       if is(kv.first,HashtableRowFilled) and kv.second==key { found = true; };
       while not(is(kv.first,HashtableRowEmpty)) and not(found) {
@@ -110,7 +110,7 @@ let .find-row-index-by-key(h: Hashtable<k,v>, key: k): USize = (
          kv = contents[ki];
          if is(kv.first,HashtableRowFilled) and kv.second==key { found = true; };
       };
-      if found then row_index = ki;
+      if found then row-index = ki;
    };
-   row_index
+   row-index
 );

--- a/lib2/core/list.lsts
+++ b/lib2/core/list.lsts
@@ -2,6 +2,7 @@
 type List<x> implies MustRetain, MustRelease zero LEOF = LEOF | LCons { head: x, tail: OwnedData<List<x>>[] };
 
 let $"list::cons"(hd: x, tl: List<x>): List<x> = LCons(hd, close(tl));
+let cons(hd: x, tl: List<x>): List<x> = LCons(hd, close(tl));
 
 let .release(t: List<x>): Nil = (
    if t.discriminator-case-tag==(t as Tag::LCons).discriminator-case-tag {
@@ -41,7 +42,7 @@ let .has-head(tt: List<x>): Bool = non-zero(tt);
 
 let .nth(tt: List<x>, idx: USize): Maybe<x> = (
    let err = false;
-   while idx > 0 && not(err) {
+   while idx > 0 and not(err) {
       if tt.has-head() {
          tt = tail(tt);
          idx = idx - 1;
@@ -50,7 +51,7 @@ let .nth(tt: List<x>, idx: USize): Maybe<x> = (
       }
    };
 
-   if err || not(tt.has-head()) {
+   if err or not(tt.has-head()) {
       None : Maybe<x>
    } else {
       Some(head(tt))

--- a/lib2/core/string.lsts
+++ b/lib2/core/string.lsts
@@ -32,17 +32,17 @@ let .length(s: String): USize = s.end-offset - s.start-offset;
 let non-zero(s: String): Bool = s.length > 0;
 
 let cmp(l: String, r: String): Ord = (
-   let l_size = l.end-offset - l.start-offset;
-   let r_size = r.end-offset - r.start-offset;
+   let l-size = l.end-offset - l.start-offset;
+   let r-size = r.end-offset - r.start-offset;
    let c = memcmp(
       (l.data.data + l.start-offset) as C<"void">[],
       (r.data.data + r.start-offset) as C<"void">[],
-      min(l_size, r_size)
+      min(l-size, r-size)
    ) as I64;
    if c < 0 then LessThan
    else if c > 0 then GreaterThan
-   else if l_size < r_size then LessThan
-   else if l_size > r_size then GreaterThan
+   else if l-size < r-size then LessThan
+   else if l-size > r-size then GreaterThan
    else Equal
 );
 
@@ -50,15 +50,15 @@ let intern(cs: CString): String = cs.into(type(String));
 let intern(s: String): String = s;
 let .into(s: String, tt: Type<String>): String = s;
 let .into(cs: CString, tt: Type<String>): String = (
-   let cs_length = cs.length;
-   let od = mk-owned-data(type(U8), cs_length);
+   let cs-length = cs.length;
+   let od = mk-owned-data(type(U8), cs-length);
    let csi = 0_sz;
-   while csi < cs_length {
+   while csi < cs-length {
       od.push(cs[csi] as U8);
       csi = csi + 1;
    };
    # This constructor will call .retain on itself before exiting
-   String(0 as USize, cs_length, od)
+   String(0 as USize, cs-length, od)
 );
 
 let .into(s: String, tt: Type<CString>): CString = (
@@ -67,16 +67,16 @@ let .into(s: String, tt: Type<CString>): CString = (
 );
 
 let $"[:]"(s: String, begin: I64, end: I64): String = (
-   let s_length = s.length as I64;
-   if end == minimum-I64 then end = s_length;
-   if begin < 0_i64 then begin = s_length + begin;
-   if end < 0_i64 then end = s_length + end;
-   if begin < 0_i64 or begin > s_length then fail(c"String [:] Slice Start Index Out of Bounds");
-   if end < 0_i64 or end > s_length then fail(c"String [:] Slice End Index Out of Bounds");
-   let start_offset = ((s.start-offset as I64) + begin) as USize;
-   let end_offset = ((s.start-offset as I64) + end) as USize;
+   let s-length = s.length as I64;
+   if end == minimum-I64 then end = s-length;
+   if begin < 0_i64 then begin = s-length + begin;
+   if end < 0_i64 then end = s-length + end;
+   if begin < 0_i64 or begin > s-length then fail(c"String [:] Slice Start Index Out of Bounds");
+   if end < 0_i64 or end > s-length then fail(c"String [:] Slice End Index Out of Bounds");
+   let start-offset = ((s.start-offset as I64) + begin) as USize;
+   let end-offset = ((s.start-offset as I64) + end) as USize;
    s.data.retain;
-   String(start_offset, end_offset, s.data)
+   String(start-offset, end-offset, s.data)
 );
 
 let $"[]"(s: String, idx: USize): U8 = (
@@ -94,13 +94,13 @@ let eprint(s: String): Nil = (
 );
 
 let $"+"(l: String, r: String): String = (
-   let l_length = l.length;
-   let r_length = r.length;
-   let cs_length = l_length + r_length;
-   let od = mk-owned-data(type(U8), cs_length);
-   memcpy(od.data as C<"void">[], l.data.data as C<"void">[], l_length as USize);
-   memcpy((od.data + l_length) as C<"void">[], r.data.data as C<"void">[], r_length as USize);
-   String(0 as USize, cs_length, od) 
+   let l-length = l.length;
+   let r-length = r.length;
+   let cs-length = l-length + r-length;
+   let od = mk-owned-data(type(U8), cs-length);
+   memcpy(od.data as C<"void">[], l.data.data as C<"void">[], l-length as USize);
+   memcpy((od.data + l-length) as C<"void">[], r.data.data as C<"void">[], r-length as USize);
+   String(0 as USize, cs-length, od) 
 );
 
 let fail(msg: String): Never = (
@@ -110,9 +110,9 @@ let fail(msg: String): Never = (
 
 let hash(key: String): U64 = (
    let i = 0_sz;
-   let key_length = key.length;
+   let key-length = key.length;
    let result = 0_u64;
-   while i < key_length {
+   while i < key-length {
       result = result + key[i];
       result = result + (result << 10);
       result = result ^ (result >> 6);

--- a/lib2/core/string.lsts
+++ b/lib2/core/string.lsts
@@ -29,6 +29,7 @@ let .retain(x: String): String = (
 );
 
 let .length(s: String): USize = s.end-offset - s.start-offset;
+let non-zero(s: String): Bool = s.length > 0;
 
 let cmp(l: String, r: String): Ord = (
    let l_size = l.end-offset - l.start-offset;
@@ -46,6 +47,7 @@ let cmp(l: String, r: String): Ord = (
 );
 
 let intern(cs: CString): String = cs.into(type(String));
+let intern(s: String): String = s;
 let .into(s: String, tt: Type<String>): String = s;
 let .into(cs: CString, tt: Type<String>): String = (
    let cs_length = cs.length;

--- a/lib2/core/vector.lsts
+++ b/lib2/core/vector.lsts
@@ -56,9 +56,9 @@ let .realloc(v: Vector<t>, target-capacity: USize): Vector<t> = (
 let .push(v: Vector<t>, i: x): Vector<t> = (
    # if this vector is a view, or if it is full, then we need to reallocate
    if (v.data as USize)==0 or v.data.occupied==v.data.capacity {
-      let new_capacity = if v.length==0 then 4_sz
+      let new-capacity = if v.length==0 then 4_sz
       else (v.length >> 1_sz) + v.length; # this is mul 1.5, not 3
-      v = v.realloc(new_capacity);
+      v = v.realloc(new-capacity);
    };
    v.data.push(i);
    v

--- a/lib2/core/vector.lsts
+++ b/lib2/core/vector.lsts
@@ -118,3 +118,8 @@ let .buffer-into-string(v: Vector<U8>): String = (
    v.data.retain;
    String(0, v.length - 1, v.data)
 );
+
+let $"set[]"( v: Vector<t>, i: USize, val: t ): Nil = (
+   if i >= v.length then fail(c"Vector Index Out of Bounds");
+   v.data[i] = val;
+);

--- a/tests/promises/tuple/match-destructuring-1.lsts
+++ b/tests/promises/tuple/match-destructuring-1.lsts
@@ -16,8 +16,6 @@ let .ground-tag-and-arity(tt: Type): (CString,U64) = (
       );
       TGround { tag:c"Sized" } => (c"", 9999999_u64);
       TGround { tag=tag, parameters=parameters } => (tag, parameters.length);
-      TAny {} => (c"?", 0_u64);
-      TVar {} => (c"", 9999999_u64);
       TAnd { conjugate=conjugate } => (
          let result = (c"", 9999999_u64);
          for c in conjugate { if result.second==9999999 then result = c.ground-tag-and-arity };

--- a/tests/promises/tuple/match-destructuring-1.lsts
+++ b/tests/promises/tuple/match-destructuring-1.lsts
@@ -4,13 +4,13 @@ import lib2/core/bedrock.lsts;
 type T = { tag:CString };
 
 let .ground-tag-and-arity(tt: T): (CString,U64) = (
-   let t1 = open(tt);
+   let t1 = tt;
    (scope($"if"
       (
          let c1 = false;
          $"if"
             (
-               let t2 = open((t1 as Tag::T).tag);
+               let t2 = t1.tag;
                t2 == c"Array"
             )
             (c1 = true)
@@ -21,17 +21,12 @@ let .ground-tag-and-arity(tt: T): (CString,U64) = (
       ((c"Array", 2_u64))
       (scope($"if"
          (
-            let t3 = t1;
             let c2 = false;
-            $"if"
-               (t3.discriminator-case-tag == (t3 as Tag::T).discriminator-case-tag)
-               ($"if"
-                 (let tag = open((t3 as Tag::T).tag); branchtrue())
-                 (c2 = true)
-                 ()
-               )
-               ()
-            ;
+            ($"if"
+              (let tag = t1.tag; branchtrue())
+              (c2 = true)
+              ()
+            );
             c2
          )
          ((tag, 1_u64))

--- a/tests/promises/tuple/match-destructuring-1.lsts
+++ b/tests/promises/tuple/match-destructuring-1.lsts
@@ -7,11 +7,7 @@ let .ground-tag-and-arity(t1: T): (CString,U64) = (
    (scope($"if"
       (true)
       ((c"A", 2_u64))
-      (scope($"if"
-         (true)
-         ((c"B", 1_u64))
-         (fail(c"Pattern Match Failure"))
-      ))
+      ((c"B", 1_u64))
    ))
 );
 

--- a/tests/promises/tuple/match-destructuring-1.lsts
+++ b/tests/promises/tuple/match-destructuring-1.lsts
@@ -1,15 +1,11 @@
 
 import lib2/core/bedrock.lsts;
 
-type Type zero TAny
-        = TGround { tag:CString, parameters:OwnedData<List<Type>>[] }
-        | TAny
-        | TVar { name:CString }
-        | TAnd { conjugate:Vector<Type> };
+type T = { tag:CString };
 
-let .ground-tag-and-arity(tt: Type): (CString,U64) = (
+let .ground-tag-and-arity(tt: T): (CString,U64) = (
    match tt {
-      TGround { tag:c"Array", parameters:[_.. TAny{}..] } => (c"Array", 2_u64);
-      TGround { tag=tag, parameters=parameters } => (tag, parameters.length);
+      T { tag:c"Array" } => (c"Array", 2_u64);
+      T { tag=tag } => (tag, 1_u64);
    }
 );

--- a/tests/promises/tuple/match-destructuring-1.lsts
+++ b/tests/promises/tuple/match-destructuring-1.lsts
@@ -6,10 +6,10 @@ type T = { tag:CString };
 let .ground-tag-and-arity(t1: T): (CString,U64) = (
    (scope($"if"
       (true)
-      ((c"Array", 2_u64))
+      ((c"A", 2_u64))
       (scope($"if"
-         (let tag = t1.tag; true)
-         ((tag, 1_u64))
+         (true)
+         ((c"B", 1_u64))
          (fail(c"Pattern Match Failure"))
       ))
    ))

--- a/tests/promises/tuple/match-destructuring-1.lsts
+++ b/tests/promises/tuple/match-destructuring-1.lsts
@@ -8,7 +8,7 @@ let .ground-tag-and-arity(t1: T): (CString,U64) = (
       (true)
       ((c"Array", 2_u64))
       (scope($"if"
-         (let tag = t1.tag; branchtrue())
+         (let tag = t1.tag; true)
          ((tag, 1_u64))
          (fail(c"Pattern Match Failure"))
       ))

--- a/tests/promises/tuple/match-destructuring-1.lsts
+++ b/tests/promises/tuple/match-destructuring-1.lsts
@@ -10,11 +10,6 @@ type Type zero TAny
 let .ground-tag-and-arity(tt: Type): (CString,U64) = (
    match tt {
       TGround { tag:c"Array", parameters:[_.. TAny{}..] } => (c"Array", 2_u64);
-      TGround { tag:c"Array", parameters:[_.. array-base..] } => (
-         let ga = array-base.ground-tag-and-arity;
-         ( ga.first, ga.second + 1000 )
-      );
-      TGround { tag:c"Sized" } => (c"", 9999999_u64);
       TGround { tag=tag, parameters=parameters } => (tag, parameters.length);
       TAnd { conjugate=conjugate } => (
          let result = (c"", 9999999_u64);

--- a/tests/promises/tuple/match-destructuring-1.lsts
+++ b/tests/promises/tuple/match-destructuring-1.lsts
@@ -4,8 +4,40 @@ import lib2/core/bedrock.lsts;
 type T = { tag:CString };
 
 let .ground-tag-and-arity(tt: T): (CString,U64) = (
-   match tt {
-      T { tag:c"Array" } => (c"Array", 2_u64);
-      T { tag=tag } => (tag, 1_u64);
-   }
+   let t1 = open(tt);
+   (scope($"if"
+      (
+         let c1 = false;
+         $"if"
+            (
+               let t2 = open((t1 as Tag::T).tag);
+               t2 == c"Array"
+            )
+            (c1 = true)
+            ()
+         ;
+         c1
+      )
+      ((c"Array", 2_u64))
+      (scope($"if"
+         (
+            let t3 = t1;
+            let c2 = false;
+            $"if"
+               (t3.discriminator-case-tag == (t3 as Tag::T).discriminator-case-tag)
+               ($"if"
+                 (let tag = open((t3 as Tag::T).tag); branchtrue())
+                 (c2 = true)
+                 ()
+               )
+               ()
+            ;
+            c2
+         )
+         ((tag, 1_u64))
+         (fail(c"Pattern Match Failure"))
+      ))
+   ))
 );
+
+

--- a/tests/promises/tuple/match-destructuring-1.lsts
+++ b/tests/promises/tuple/match-destructuring-1.lsts
@@ -3,32 +3,12 @@ import lib2/core/bedrock.lsts;
 
 type T = { tag:CString };
 
-let .ground-tag-and-arity(tt: T): (CString,U64) = (
-   let t1 = tt;
+let .ground-tag-and-arity(t1: T): (CString,U64) = (
    (scope($"if"
-      (
-         let c1 = false;
-         $"if"
-            (
-               let t2 = t1.tag;
-               t2 == c"Array"
-            )
-            (c1 = true)
-            ()
-         ;
-         c1
-      )
+      (true)
       ((c"Array", 2_u64))
       (scope($"if"
-         (
-            let c2 = false;
-            ($"if"
-              (let tag = t1.tag; branchtrue())
-              (c2 = true)
-              ()
-            );
-            c2
-         )
+         (let tag = t1.tag; branchtrue())
          ((tag, 1_u64))
          (fail(c"Pattern Match Failure"))
       ))

--- a/tests/promises/tuple/match-destructuring-1.lsts
+++ b/tests/promises/tuple/match-destructuring-1.lsts
@@ -11,10 +11,5 @@ let .ground-tag-and-arity(tt: Type): (CString,U64) = (
    match tt {
       TGround { tag:c"Array", parameters:[_.. TAny{}..] } => (c"Array", 2_u64);
       TGround { tag=tag, parameters=parameters } => (tag, parameters.length);
-      TAnd { conjugate=conjugate } => (
-         let result = (c"", 9999999_u64);
-         for c in conjugate { if result.second==9999999 then result = c.ground-tag-and-arity };
-         result
-      );
    }
 );


### PR DESCRIPTION
## Describe your changes
Features:
* LM23COMMON is now starting to compile
* the common types are not GC-enabled, so they are leaking memory, but semantically they are working with lib2 now
* complex match destructuring is working with lib2 and garbage collection
* added test case for weird leaked linear variable
* added some features to lib2
* fixed backend to always allow kebab case variable names
   * it is still possible to get duplicate variable conflicts with this solution, but it fixes the vast majority of cases with kebab-case names being leaked into C code

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
