### PR TITLE
Gc enabled lmcommon fdspqrqpq

### DIFF
--- a/lib2/core/owned-data.lsts
+++ b/lib2/core/owned-data.lsts
@@ -84,6 +84,7 @@ let .release(od: OwnedData<t>[]): Nil = (
 
 let .retain(od: OwnedData<t>[]): Nil = (
    if (od as USize)!=0 {
+      if od.reference-count==0 then fail(c"OwnedData.retain called when reference count is zero. This object has already been freed!");
       od.reference-count = od.reference-count + 1;
    }
 );

--- a/lib2/core/sparse-owned-data.lsts
+++ b/lib2/core/sparse-owned-data.lsts
@@ -56,6 +56,7 @@ let .release(od: SparseOwnedData<t>[]): Nil = (
 
 let .retain(od: SparseOwnedData<t>[]): Nil = (
    if (od as USize)!=0 {
+      if od.reference-count==0 then fail(c"SparseOwnedData.retain called when reference count is zero. This object has already been freed!");
       od.reference-count = od.reference-count + 1;
    }
 );

--- a/tests/promises/lm-prop/empty-but-initializes-state.lsts
+++ b/tests/promises/lm-prop/empty-but-initializes-state.lsts
@@ -1,13 +1,6 @@
 
 import LM23COMMON/unit-tctx-core.lsts;
 
-let .custom-substitute(tctx: TypeContext?, tt: List<Type>): List<Type> = (
-   match tt {
-      LCons{head=head,tail=tail} => cons( tctx.custom-substitute(head), tctx.custom-substitute(tail) );
-      _ => tt;
-   }
-);
-
 let .custom-substitute(tctx: TypeContext?, tt: Type): Type = (
    match tt {
       TAnd{conjugate=conjugate} => (
@@ -23,7 +16,7 @@ let .custom-substitute(tctx: TypeContext?, tt: Type): Type = (
          else if result.length==1 then result[0]
          else tand(result)
       );
-      TGround{tag=tag,parameters=parameters} => TGround(tag,close(tctx.custom-substitute(parameters)));
+      TGround{tag=tag,parameters=parameters} => TGround(tag,close(parameters));
       _ => tt;
    }
 );

--- a/tests/promises/lm-prop/empty-but-initializes-state.lsts
+++ b/tests/promises/lm-prop/empty-but-initializes-state.lsts
@@ -6,11 +6,6 @@ let .custom-substitute(tctx: TypeContext?, tt: Type): Type = (
       TAnd{conjugate=conjugate} => (
          let result = mk-vector(type(Type), 0);
          for vector c in conjugate {
-            match tctx.custom-substitute(c) {
-               TAnd{rconjugate=conjugate} => for vector rc in rconjugate { result = result.push(rc) };
-               TAny{} => ();
-               rc => ( result = result.push(rc); () );
-            }
          };
          if result.length==0 then ta
          else if result.length==1 then result[0]

--- a/tests/promises/lm-prop/empty-but-initializes-state.lsts
+++ b/tests/promises/lm-prop/empty-but-initializes-state.lsts
@@ -2,18 +2,7 @@
 import LM23COMMON/unit-tctx-core.lsts;
 
 let .custom-substitute(tctx: TypeContext?, tt: Type): Type = (
-   match tt {
-      TAnd{conjugate=conjugate} => (
-         let result = mk-vector(type(Type), 0);
-         for vector c in conjugate {
-         };
-         if result.length==0 then ta
-         else if result.length==1 then result[0]
-         else tand(result)
-      );
-      TGround{tag=tag,parameters=parameters} => TGround(tag,close(parameters));
-      _ => tt;
-   }
+   TGround((tt as Tag::TGround).tag,close(open((tt as Tag::TGround).parameters)));
 );
 
 let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST, return-type-hint: Type): (TypeContext?, TypeContext?, Type, Type) = (

--- a/tests/promises/lm-prop/empty-but-initializes-state.lsts
+++ b/tests/promises/lm-prop/empty-but-initializes-state.lsts
@@ -1,11 +1,38 @@
 
 import LM23COMMON/unit-tctx-core.lsts;
 
+let .custom-substitute(tctx: TypeContext?, tt: List<Type>): List<Type> = (
+   match tt {
+      LCons{head=head,tail=tail} => cons( tctx.custom-substitute(head), tctx.custom-substitute(tail) );
+      _ => tt;
+   }
+);
+
+let .custom-substitute(tctx: TypeContext?, tt: Type): Type = (
+   match tt {
+      TAnd{conjugate=conjugate} => (
+         let result = mk-vector(type(Type), 0);
+         for vector c in conjugate {
+            match tctx.custom-substitute(c) {
+               TAnd{rconjugate=conjugate} => for vector rc in rconjugate { result = result.push(rc) };
+               TAny{} => ();
+               rc => ( result = result.push(rc); () );
+            }
+         };
+         if result.length==0 then ta
+         else if result.length==1 then result[0]
+         else tand(result)
+      );
+      TGround{tag=tag,parameters=parameters} => TGround(tag,close(tctx.custom-substitute(parameters)));
+      _ => tt;
+   }
+);
+
 let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST, return-type-hint: Type): (TypeContext?, TypeContext?, Type, Type) = (
    let apply-tctx = Some(mk-tctx());
 
 #   # Specialize the function type
-   let closed-type = apply-tctx.substitute(ft);
+   let closed-type = apply-tctx.custom-substitute(ft);
 
    # Specialize the return type
    let return-type = ta;
@@ -14,5 +41,3 @@ let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST, r
 );
 
 assert( Some(mk-tctx()).apply(c"f", t2(c"Arrow",t0(c"A"),t0(c"B")), t0(c"A"), mk-eof(), ta ).third == t2(c"Arrow",t0(c"A"),t0(c"B")) );
-
-# TODO: find what combination of libraries imported and "apply" calling reproduces this crash

--- a/tests/promises/lm-prop/empty-but-initializes-state.lsts
+++ b/tests/promises/lm-prop/empty-but-initializes-state.lsts
@@ -1,7 +1,8 @@
 
 import LM23COMMON/unit-tctx-core.lsts;
 
-let .apply(tctx: TypeContext?, fname: CString, at: Type, blame: AST, return-type-hint: Type): (TypeContext?, TypeContext?, Type, Type) = (
+let apply(): (TypeContext?, TypeContext?, Type, Type) = (
+   let tctx = Some(mk-tctx());
    let ft = t2(c"Arrow",t0(c"A"),t0(c"B"));
    let apply-tctx = Some(mk-tctx());
 
@@ -14,4 +15,4 @@ let .apply(tctx: TypeContext?, fname: CString, at: Type, blame: AST, return-type
    (tctx, apply-tctx, closed-type, return-type)
 );
 
-assert( Some(mk-tctx()).apply(c"f", t0(c"A"), mk-eof(), ta ).third == t2(c"Arrow",t0(c"A"),t0(c"B")) );
+assert( apply().third == t2(c"Arrow",t0(c"A"),t0(c"B")) );

--- a/tests/promises/lm-prop/empty-but-initializes-state.lsts
+++ b/tests/promises/lm-prop/empty-but-initializes-state.lsts
@@ -1,4 +1,4 @@
 
 import LM23COMMON/unit-tctx-core.lsts;
 
-assert( (Some(mk-tctx()), Some(mk-tctx()), t2(c"Arrow",t0(c"A"),t0(c"B")), ta).third == t2(c"Arrow",t0(c"A"),t0(c"B")) );
+assert( (t2(c"Arrow",t0(c"A"),t0(c"B")), 1).first == t2(c"Arrow",t0(c"A"),t0(c"B")) );

--- a/tests/promises/lm-prop/empty-but-initializes-state.lsts
+++ b/tests/promises/lm-prop/empty-but-initializes-state.lsts
@@ -1,18 +1,4 @@
 
 import LM23COMMON/unit-tctx-core.lsts;
 
-let apply(): (TypeContext?, TypeContext?, Type, Type) = (
-   let tctx = Some(mk-tctx());
-   let ft = t2(c"Arrow",t0(c"A"),t0(c"B"));
-   let apply-tctx = Some(mk-tctx());
-
-#   # Specialize the function type
-   let closed-type = TGround((ft as Tag::TGround).tag,close(open((ft as Tag::TGround).parameters)));
-
-   # Specialize the return type
-   let return-type = ta;
-
-   (tctx, apply-tctx, closed-type, return-type)
-);
-
-assert( apply().third == t2(c"Arrow",t0(c"A"),t0(c"B")) );
+assert( (Some(mk-tctx()), Some(mk-tctx()), t2(c"Arrow",t0(c"A"),t0(c"B")), ta).third == t2(c"Arrow",t0(c"A"),t0(c"B")) );

--- a/tests/promises/lm-prop/empty-but-initializes-state.lsts
+++ b/tests/promises/lm-prop/empty-but-initializes-state.lsts
@@ -1,7 +1,8 @@
 
 import LM23COMMON/unit-tctx-core.lsts;
 
-let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST, return-type-hint: Type): (TypeContext?, TypeContext?, Type, Type) = (
+let .apply(tctx: TypeContext?, fname: CString, at: Type, blame: AST, return-type-hint: Type): (TypeContext?, TypeContext?, Type, Type) = (
+   let ft = t2(c"Arrow",t0(c"A"),t0(c"B"));
    let apply-tctx = Some(mk-tctx());
 
 #   # Specialize the function type
@@ -13,4 +14,4 @@ let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST, r
    (tctx, apply-tctx, closed-type, return-type)
 );
 
-assert( Some(mk-tctx()).apply(c"f", t2(c"Arrow",t0(c"A"),t0(c"B")), t0(c"A"), mk-eof(), ta ).third == t2(c"Arrow",t0(c"A"),t0(c"B")) );
+assert( Some(mk-tctx()).apply(c"f", t0(c"A"), mk-eof(), ta ).third == t2(c"Arrow",t0(c"A"),t0(c"B")) );

--- a/tests/promises/lm-prop/empty-but-initializes-state.lsts
+++ b/tests/promises/lm-prop/empty-but-initializes-state.lsts
@@ -1,15 +1,11 @@
 
 import LM23COMMON/unit-tctx-core.lsts;
 
-let .custom-substitute(tctx: TypeContext?, tt: Type): Type = (
-   TGround((tt as Tag::TGround).tag,close(open((tt as Tag::TGround).parameters)));
-);
-
 let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST, return-type-hint: Type): (TypeContext?, TypeContext?, Type, Type) = (
    let apply-tctx = Some(mk-tctx());
 
 #   # Specialize the function type
-   let closed-type = apply-tctx.custom-substitute(ft);
+   let closed-type = TGround((ft as Tag::TGround).tag,close(open((ft as Tag::TGround).parameters)));
 
    # Specialize the return type
    let return-type = ta;


### PR DESCRIPTION
## Describe your changes
Features:
* narrowed down a failing test case to a very small error involving only a recursive type definition and a tuple with field access
* add an assertion for OwnedData and SparseOwnedData to fail if `.retain` is called on an object that has already been freed
* this does not always catch this problem obviously, but it sometimes works
* it just checks to see if the reference count is currently 0
* since OwnedData is initialized as 1, this means that the object will have already been freed
* if the memory is corrupted or reused, then this doesn't always work
* but if the memory is untouched, this will catch these errors
* think of it as training wheels for the garbage collector while we work out the problems
* we can remove this from non-debug builds later with a compiler flag

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1745

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
