### PR TITLE
Gc enabled lmcommon fdsufdiso

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/tuple/tuple-field-access.lsts > out.txt
+	lm tests/promises/tuple/tuple-field-access.lsts
 	gcc tmp.c
 	./a.out
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/lm-prop/empty-but-initializes-state.lsts
+	lm tests/promises/tuple/tuple-field-access.lsts
 	gcc tmp.c
 	./a.out
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/tuple/tuple-field-access.lsts
+	lm tests/promises/tuple/tuple-field-access.lsts > out.txt
 	gcc tmp.c
 	./a.out
 

--- a/SRC/infer-global-terms.lsts
+++ b/SRC/infer-global-terms.lsts
@@ -28,11 +28,9 @@ let infer-global-terms(tctx: TypeContext?, term: AST): (TypeContext?, AST) = (
          mark-global-as-seen(k.key, ktd, ta);
          tctx = tctx.ascript(term, ktd);
          (tctx, _) = tctx.maybe-apply-callable(c"mov", t2(c"Cons",ktd.without-phi,ktd.without-phi), term);
-         print("Glb \{term}\n");
       );
       _ => (
          (tctx, term) = std-infer-expr(tctx, term, false, Unused, ta);
-         print("Glb \{term}\n");
       );
    };
    (tctx, term)

--- a/SRC/infer-global-terms.lsts
+++ b/SRC/infer-global-terms.lsts
@@ -28,9 +28,11 @@ let infer-global-terms(tctx: TypeContext?, term: AST): (TypeContext?, AST) = (
          mark-global-as-seen(k.key, ktd, ta);
          tctx = tctx.ascript(term, ktd);
          (tctx, _) = tctx.maybe-apply-callable(c"mov", t2(c"Cons",ktd.without-phi,ktd.without-phi), term);
+         print("Glb \{term}\n");
       );
       _ => (
          (tctx, term) = std-infer-expr(tctx, term, false, Unused, ta);
+         print("Glb \{term}\n");
       );
    };
    (tctx, term)

--- a/SRC/maybe-retain.lsts
+++ b/SRC/maybe-retain.lsts
@@ -1,5 +1,12 @@
 
 let maybe-retain(tctx: TypeContext?, term: AST): (TypeContext?, AST) = (
+   match term {
+      App{ left:Var{key:c".first"}, right=right } => (
+         print("maybe retain \{term} : \{typeof-term(term)}\n");
+         print("maybe retain argument \{right} : \{typeof-term(right)}\n");
+      );
+      _ => ();
+   };
    if typeof-term(term).is-t(c"MustRetain",0)
    then wrap-call(tctx, c".retain", term)
    else (tctx, term)

--- a/SRC/maybe-retain.lsts
+++ b/SRC/maybe-retain.lsts
@@ -1,12 +1,5 @@
 
 let maybe-retain(tctx: TypeContext?, term: AST): (TypeContext?, AST) = (
-   match term {
-      App{ left:Var{key:c".first"}, right=right } => (
-         print("maybe retain \{term} : \{typeof-term(term)}\n");
-         print("maybe retain argument \{right} : \{typeof-term(right)}\n");
-      );
-      _ => ();
-   };
    if typeof-term(term).is-t(c"MustRetain",0)
    then wrap-call(tctx, c".retain", term)
    else (tctx, term)

--- a/SRC/release-locals.lsts
+++ b/SRC/release-locals.lsts
@@ -32,7 +32,6 @@ let release-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AS
          let phi-id = nd.denormalized.slot(c"Phi::Id",1).l1.simple-tag;
          pid-seen = pid-seen.bind(nd.denormalized.slot(c"Phi::Id",1).l1.simple-tag,true);
          let do-release = mk-app(mk-var(c".release"),mk-var(nd.key-or-zero));
-         print("Release locals do release\n");
          (tctx-after, do-release) = std-infer-expr(tctx-after, do-release, false, Used, ta);
          term = mk-cons(term, do-release); tctx-after = tctx-after.ascript(term, t0(c"Nil"));
       };

--- a/SRC/release-locals.lsts
+++ b/SRC/release-locals.lsts
@@ -32,6 +32,7 @@ let release-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AS
          let phi-id = nd.denormalized.slot(c"Phi::Id",1).l1.simple-tag;
          pid-seen = pid-seen.bind(nd.denormalized.slot(c"Phi::Id",1).l1.simple-tag,true);
          let do-release = mk-app(mk-var(c".release"),mk-var(nd.key-or-zero));
+         print("Release locals do release\n");
          (tctx-after, do-release) = std-infer-expr(tctx-after, do-release, false, Used, ta);
          term = mk-cons(term, do-release); tctx-after = tctx-after.ascript(term, t0(c"Nil"));
       };

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -328,17 +328,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                rt = tctx.with-phi(rt, term);
                tctx = tctx.ascript(term, rt);
 
-               match term {
-                  App{ left:Var{key:c".first"}, right=right } => (
-                     print("pre should? maybe retain \{term} : \{typeof-term(term)}\n");
-                     print("pre should? maybe retain argument \{right} : \{typeof-term(right)}\n");
-                     print("pre should? maybe retain function-type: \{function-type}\n");
-                     print("pre should? maybe retain hint: \{hint}\n");
-                     print("pre should? maybe retain tctx.is-blob: \{tctx.get-or(mk-tctx()).is-blob}\n");
-                  );
-                  _ => ();
-               };
-
                let is-released-after-call = false;
                if not(r.is-var-or-ascripted-var) {
                   # if a field access is not retained and is just a variable reference then it shouldn't be released after the call
@@ -358,6 +347,9 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                      mark-var-to-def-todo(tctx, tmp-id, ta, tmp-var);
                      let tmp-nil = mk-nil(); ascript-force(tmp-nil, t0(c"Nil"));
                      let declare = mk-abs(tmp-def, tmp-nil, ta); ascript-force(declare, t0(c"Nil"));
+                     if function-type.is-t(c"MustRetainOnCall",0) && not(hint.is-t(c"MustNotRetain",0)) && not(tctx.get-or(mk-tctx()).is-blob) {
+                        (tctx, term) = maybe-retain(tctx, term);
+                     };
                      let bind = mk-app(declare, term); ascript-force(bind, t0(c"Nil"));
 
                      let new-term = bind;
@@ -366,29 +358,13 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                      };
                      new-term = mk-cons(new-term, postfix); ascript-force(new-term, typeof-term(postfix));
                      new-term = mk-cons(new-term, tmp-var); ascript-force(new-term, typeof-term(term));
-                     print("MustReleaseAfterCall rewrite pre: \{term}\n");
-                     print("MustReleaseAfterCall rewrite post: \{new-term}\n");
-                     print("MustReleaseAfterCall rewritten type: \{typeof-term(new-term)}\n");
                      term = new-term;
                   };
                };
-               if not(is-released-after-call) {
-                  if not(rt.is-t(c"Cons",2)) {
-                     if function-type.is-t(c"MustRetainOnCall",0) && not(hint.is-t(c"MustNotRetain",0)) && not(tctx.get-or(mk-tctx()).is-blob) {
-                        (tctx, term) = maybe-retain(tctx, term);
-                     }
-                  };
-               };
-
-               match term {
-                  App{ left:Var{key:c".first"}, right=right } => (
-                     print("should? maybe retain \{term} : \{typeof-term(term)}\n");
-                     print("should? maybe retain argument \{right} : \{typeof-term(right)}\n");
-                     print("should? maybe retain function-type: \{function-type}\n");
-                     print("should? maybe retain hint: \{hint}\n");
-                     print("should? maybe retain tctx.is-blob: \{tctx.get-or(mk-tctx()).is-blob}\n");
-                  );
-                  _ => ();
+               if not(is-released-after-call) and not(rt.is-t(c"Cons",2)) {
+                  if function-type.is-t(c"MustRetainOnCall",0) && not(hint.is-t(c"MustNotRetain",0)) && not(tctx.get-or(mk-tctx()).is-blob) {
+                     (tctx, term) = maybe-retain(tctx, term);
+                  }
                };
             };
          };
@@ -401,7 +377,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
    };
    if used.is-unused && typeof-term(term).slot(c"Phi::State",1).is-linear-live {
       if typeof-term(term).slot(c"Phi::State",1).l1.is-t(c"MustRelease::ToRelease",1) {
-         print("std-infer-expr release unused\n");
          (tctx, term) = wrap-call(tctx, c".release", term);
       } else if typeof-term(term).is-t(c"MustRetain",0) {
          tctx = tctx.phi-move(typeof-term(term),term);

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -357,6 +357,16 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                   };
                };
 
+               match term {
+                  App{ left:Var{key:c".first"}, right=right } => (
+                     print("should? maybe retain \{term} : \{typeof-term(term)}\n");
+                     print("should? maybe retain argument \{right} : \{typeof-term(right)}\n");
+                     print("should? maybe retain function-type: \{function-type}\n");
+                     print("should? maybe retain hint: \{hint}\n");
+                     print("should? maybe retain tctx.is-blob: \{tctx.get-or(mk-tctx()).is-blob}\n");
+                  );
+                  _ => ();
+               };
                if not(rt.is-t(c"Cons",2)) {
                   if function-type.is-t(c"MustRetainOnCall",0) && not(hint.is-t(c"MustNotRetain",0)) && not(tctx.get-or(mk-tctx()).is-blob) {
                      (tctx, term) = maybe-retain(tctx, term);

--- a/SRC/std-infer-expr.lsts
+++ b/SRC/std-infer-expr.lsts
@@ -328,6 +328,18 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                rt = tctx.with-phi(rt, term);
                tctx = tctx.ascript(term, rt);
 
+               match term {
+                  App{ left:Var{key:c".first"}, right=right } => (
+                     print("pre should? maybe retain \{term} : \{typeof-term(term)}\n");
+                     print("pre should? maybe retain argument \{right} : \{typeof-term(right)}\n");
+                     print("pre should? maybe retain function-type: \{function-type}\n");
+                     print("pre should? maybe retain hint: \{hint}\n");
+                     print("pre should? maybe retain tctx.is-blob: \{tctx.get-or(mk-tctx()).is-blob}\n");
+                  );
+                  _ => ();
+               };
+
+               let is-released-after-call = false;
                if not(r.is-var-or-ascripted-var) {
                   # if a field access is not retained and is just a variable reference then it shouldn't be released after the call
                   # this is complicated to do in the type system atm, so we just hard code it for now
@@ -336,6 +348,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                   #    x.data.release
                   (tctx, let prefix, let postfix, let new-args) = std-maybe-release-after-call(tctx, function-type, r);
                   if non-zero(postfix) {
+                     is-released-after-call = true;
                      if not(is(r,new-args)) { term = mk-app(l,new-args); ascript-force(term,rt); };
 
                      let tmp-id = uuid();
@@ -353,7 +366,17 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                      };
                      new-term = mk-cons(new-term, postfix); ascript-force(new-term, typeof-term(postfix));
                      new-term = mk-cons(new-term, tmp-var); ascript-force(new-term, typeof-term(term));
+                     print("MustReleaseAfterCall rewrite pre: \{term}\n");
+                     print("MustReleaseAfterCall rewrite post: \{new-term}\n");
+                     print("MustReleaseAfterCall rewritten type: \{typeof-term(new-term)}\n");
                      term = new-term;
+                  };
+               };
+               if not(is-released-after-call) {
+                  if not(rt.is-t(c"Cons",2)) {
+                     if function-type.is-t(c"MustRetainOnCall",0) && not(hint.is-t(c"MustNotRetain",0)) && not(tctx.get-or(mk-tctx()).is-blob) {
+                        (tctx, term) = maybe-retain(tctx, term);
+                     }
                   };
                };
 
@@ -367,11 +390,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                   );
                   _ => ();
                };
-               if not(rt.is-t(c"Cons",2)) {
-                  if function-type.is-t(c"MustRetainOnCall",0) && not(hint.is-t(c"MustNotRetain",0)) && not(tctx.get-or(mk-tctx()).is-blob) {
-                     (tctx, term) = maybe-retain(tctx, term);
-                  }
-               };
             };
          };
 
@@ -383,6 +401,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
    };
    if used.is-unused && typeof-term(term).slot(c"Phi::State",1).is-linear-live {
       if typeof-term(term).slot(c"Phi::State",1).l1.is-t(c"MustRelease::ToRelease",1) {
+         print("std-infer-expr release unused\n");
          (tctx, term) = wrap-call(tctx, c".release", term);
       } else if typeof-term(term).is-t(c"MustRetain",0) {
          tctx = tctx.phi-move(typeof-term(term),term);

--- a/SRC/std-maybe-release-after-call.lsts
+++ b/SRC/std-maybe-release-after-call.lsts
@@ -2,7 +2,7 @@
 let std-maybe-release-after-call(tctx: TypeContext?, function-type: Type, args: AST): (TypeContext?, AST, AST, AST) = (
    if function-type.domain.is-any-arg-t(c"MustReleaseAfterCall",0)
    && is-paired-release(function-type.domain, typeof-term(args))
-   then std-release-after-call(tctx, function-type.domain, mk-eof(), mk-eof(), args);
+   then std-release-after-call(tctx, function-type, function-type.domain, mk-eof(), mk-eof(), args);
    else (tctx, mk-eof(), mk-eof(), args)
 );
 
@@ -13,11 +13,11 @@ let is-paired-release(pt: Type, at: Type): U64 = (
    else (pt.is-t(c"MustReleaseAfterCall",0) and at.is-t(c"MustRelease",0))
 );
 
-let std-release-after-call(tctx: TypeContext?, param-types: Type, prefix: AST, postfix: AST, args: AST): (TypeContext?, AST, AST, AST) = (
+let std-release-after-call(tctx: TypeContext?, function-type: Type, param-types: Type, prefix: AST, postfix: AST, args: AST): (TypeContext?, AST, AST, AST) = (
    if param-types.is-t(c"Cons",2) { match args {
       App{ left=left, right=right } => (
-         (tctx, prefix, postfix, left) = std-release-after-call(tctx, param-types.slot(c"Cons",2).l1, prefix, postfix, left);
-         (tctx, prefix, postfix, right) = std-release-after-call(tctx, param-types.slot(c"Cons",2).l2, prefix, postfix, right);
+         (tctx, prefix, postfix, left) = std-release-after-call(tctx, function-type, param-types.slot(c"Cons",2).l1, prefix, postfix, left);
+         (tctx, prefix, postfix, right) = std-release-after-call(tctx, function-type, param-types.slot(c"Cons",2).l2, prefix, postfix, right);
          let new-args = mk-cons(left, right);
          ascript-force(new-args, typeof-term(args));
          (tctx, prefix, postfix, new-args)
@@ -33,6 +33,14 @@ let std-release-after-call(tctx: TypeContext?, param-types: Type, prefix: AST, p
       let tmp-return = args;
       if param-types.is-t(c"MustReleaseAfterCall",0) and typeof-term(args).is-t(c"MustRelease",0)
       then {
+         #if function-type.is-t(c"MustRetainOnCall",0) && args-type.is-t(c"MustRetain",0) {
+         #   let retain-type = tctx.find-callable(c".retain", args-type, args ).dt-or-zero;
+         #   let retain-var = mk-var(c".retain"); ascript-force(retain-var, retain-type);
+         #   (tctx, let retain-result) = tctx.apply-callable(c".retain", args-type, args);
+         #   args = mk-app(retain-var, args); ascript-force(args, retain-result);
+         #   args-type = retain-result;
+         #};
+
          (let tmp-release, tmp-return) = if param-types.is-t(c"MustNotRewrite",0) {
             let tmp-id = uuid();
             let tmp-def = mk-var(tmp-id); ascript-force(tmp-def, args-type);
@@ -67,6 +75,7 @@ let std-release-after-call(tctx: TypeContext?, param-types: Type, prefix: AST, p
             (tmp-var2, tmp-direct)
          };
 
+         print("Find callable in std-maybe-release?\n");
          let release-type = tctx.find-callable(c".release", args-type, args ).dt-or-zero;
          let release-var = mk-var(c".release"); ascript-force(release-var, release-type);
          (tctx, let release-return) = tctx.apply-callable(c".release", args-type, args);

--- a/SRC/std-maybe-release-after-call.lsts
+++ b/SRC/std-maybe-release-after-call.lsts
@@ -75,7 +75,6 @@ let std-release-after-call(tctx: TypeContext?, function-type: Type, param-types:
             (tmp-var2, tmp-direct)
          };
 
-         print("Find callable in std-maybe-release?\n");
          let release-type = tctx.find-callable(c".release", args-type, args ).dt-or-zero;
          let release-var = mk-var(c".release"); ascript-force(release-var, release-type);
          (tctx, let release-return) = tctx.apply-callable(c".release", args-type, args);


### PR DESCRIPTION
## Describe your changes
Features:
* fix the counting bug
* the problem was `MustReleaseAfterCall` had a race condition that leads to `.release` of the base object potentially being called before `.retain` on the result.

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1745

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
