### PR TITLE
Type bound fasdfioo

### DIFF
--- a/LM23COMMON/type-constructor.lsts
+++ b/LM23COMMON/type-constructor.lsts
@@ -1,12 +1,26 @@
 
 let ta = TAny;
 
+# new allocations = 1
+#    1 from close
+#    0 from 0 length list
 let t0(tag: CString): Type = TGround(tag, close([] : List<Type>));
+
+# new allocations = 2
+#    1 from close
+#    1 from 1 length list
 let t1(tag: CString, p1: Type): Type = TGround(tag, close([p1]));
+
+# new allocations = 3
+#    1 from close
+#    2 from 2 length list
 let t2(tag: CString, p1: Type, p2: Type): Type = TGround(tag, close([p2, p1]));
 
+# new allocations = 0
 let tv(name: CString): Type = TVar(name);
 
+# new allocations = 0 if either argument is ?
+#                 | 1
 let $"&&"(lt: Type, rt: Type): Type = (
    match (lt, rt) {
       Tuple{first:TAny{}} => rt;
@@ -42,7 +56,14 @@ let $"&&"(lt: Type, rt: Type): Type = (
    };
 );
 
+# new allocations = 1
 let ts(tag: CString, ps: List<Type>): Type = TGround( tag, close(ps) );
+
+# new allocations = 0
 let tand(t: Vector<Type>): Type = TAnd(t.sort);
+
+# new allocations = 1
 let tand(tt: Type): Type = TAnd(mk-vector(type(Type)).push(tt));
+
+# new allocations = 0
 let $"||"(lt: Type, rt: Type): Type = if non-zero(lt) then lt else rt;

--- a/LM23COMMON/type-constructor.lsts
+++ b/LM23COMMON/type-constructor.lsts
@@ -1,19 +1,23 @@
 
+# new allocations = 0
 let ta = TAny;
 
 # new allocations = 1
 #    1 from close
 #    0 from 0 length list
+# this is an upper bound, because the list implementation should be replaced with vector eventually
 let t0(tag: CString): Type = TGround(tag, close([] : List<Type>));
 
 # new allocations = 2
 #    1 from close
 #    1 from 1 length list
+# this is an upper bound, because the list implementation should be replaced with vector eventually
 let t1(tag: CString, p1: Type): Type = TGround(tag, close([p1]));
 
 # new allocations = 3
 #    1 from close
 #    2 from 2 length list
+# this is an upper bound, because the list implementation should be replaced with vector eventually
 let t2(tag: CString, p1: Type, p2: Type): Type = TGround(tag, close([p2, p1]));
 
 # new allocations = 0
@@ -57,6 +61,7 @@ let $"&&"(lt: Type, rt: Type): Type = (
 );
 
 # new allocations = 1
+# this is an upper bound, because the list implementation should be replaced with vector eventually
 let ts(tag: CString, ps: List<Type>): Type = TGround( tag, close(ps) );
 
 # new allocations = 0

--- a/LM23COMMON/type-definition.lsts
+++ b/LM23COMMON/type-definition.lsts
@@ -4,6 +4,8 @@
 # TAny = 1
 # TVar = 2
 # TAnd = 3
+# TODO: replace TGround List implementation with Vector which is much more efficient
+# for this reason allocation counts only have an upper bound rather than exact bound
 type Type zero TAny implies MustRetain, MustRelease
         = TGround { tag:CString, parameters:OwnedData<List<Type>>[] }
         | TAny

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -363,6 +363,10 @@ let lsts-parse-type-conjugate(tokens: List<Token>): Tuple<Type,List<Token>> = (
       };
       if not(config-v3) and base==c"OwnedData" and args.length==1 {
          head(args);
+      } else if not(config-v3) and base==c"OwnedList" and args.length==1 {
+         t2(c"Array",head(args),ta);
+      } else if config-v3 and base==c"OwnedList" and args.length==1 {
+         head(args)
       } else TGround ( base, close(args) );
    };
    while lsts-parse-head(tokens) == c"[" || lsts-parse-head(tokens)==c"?" {

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -363,10 +363,6 @@ let lsts-parse-type-conjugate(tokens: List<Token>): Tuple<Type,List<Token>> = (
       };
       if not(config-v3) and base==c"OwnedData" and args.length==1 {
          head(args);
-      } else if not(config-v3) and base==c"OwnedList" and args.length==1 {
-         t2(c"Array",head(args),ta);
-      } else if config-v3 and base==c"OwnedList" and args.length==1 {
-         head(args)
       } else TGround ( base, close(args) );
    };
    while lsts-parse-head(tokens) == c"[" || lsts-parse-head(tokens)==c"?" {

--- a/tests/promises/lm-type/bound-constructor.lsts
+++ b/tests/promises/lm-type/bound-constructor.lsts
@@ -8,17 +8,17 @@ safe-alloc-block-count-monotonic = 0;
 
 assert( t0(c"A") == t0(c"A") );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 0 );
+assert( safe-alloc-block-count-monotonic == 2 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( t1(c"A",ta) == t1(c"A",ta) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 2 );
+assert( safe-alloc-block-count-monotonic == 4 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( t2(c"A",ta,ta) == t2(c"A",ta,ta) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 2 );
+assert( safe-alloc-block-count-monotonic == 6 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( tv(c"a") == tv(c"a") );
@@ -28,7 +28,7 @@ safe-alloc-block-count-monotonic = 0;
 
 assert( (ta && t0(c"A")) == t0(c"A") );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 0 );
+assert( safe-alloc-block-count-monotonic == 2 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( (tv(c"a") && ta) == tv(c"a") );
@@ -38,37 +38,37 @@ safe-alloc-block-count-monotonic = 0;
 
 assert( (tv(c"a") && t0(c"A")) == (tv(c"a") && t0(c"A")) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 2 );
+assert( safe-alloc-block-count-monotonic == 4 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( (tv(c"a") && (t0(c"A") && t0(c"B"))) == (tv(c"a") && (t0(c"A") && t0(c"B"))) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 4 );
+assert( safe-alloc-block-count-monotonic == 8 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( ((tv(c"a") && t0(c"A")) && t0(c"B")) == ((tv(c"a") && t0(c"A")) && t0(c"B")) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 4 );
+assert( safe-alloc-block-count-monotonic == 8 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( ( (tv(c"a") && t0(c"A")) && (t0(c"B") && t0(c"C")) ) == ( (tv(c"a") && t0(c"A")) && (t0(c"B") && t0(c"C")) ) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 6 );
+assert( safe-alloc-block-count-monotonic == 12 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( ts(c"A",[ta]) == ts(c"A",[ta]) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 2 );
+assert( safe-alloc-block-count-monotonic == 4 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( ts(c"A",[ta,ta]) == ts(c"A",[ta,ta]) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 2 );
+assert( safe-alloc-block-count-monotonic == 6 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( (ta || t0(c"A")) == t0(c"A") );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 0 );
+assert( safe-alloc-block-count-monotonic == 2 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( (tv(c"a") || ta) == tv(c"a") );
@@ -78,10 +78,10 @@ safe-alloc-block-count-monotonic = 0;
 
 assert( (tv(c"a") || t0(c"A")) == tv(c"a") );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 0 );
+assert( safe-alloc-block-count-monotonic == 1 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( tand(mk-vector(type(Type)).push(t0(c"A")).push(t0(c"B"))) == tand(mk-vector(type(Type)).push(t0(c"A")).push(t0(c"B"))) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 2 );
+assert( safe-alloc-block-count-monotonic == 6 );
 safe-alloc-block-count-monotonic = 0;

--- a/tests/promises/lm-type/bound-constructor.lsts
+++ b/tests/promises/lm-type/bound-constructor.lsts
@@ -1,0 +1,87 @@
+
+import LM23COMMON/unit-type-core.lsts;
+
+assert( ta == ta );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 0 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( t0(c"A") == t0(c"A") );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 0 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( t1(c"A",ta) == t1(c"A",ta) );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 2 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( t2(c"A",ta,ta) == t2(c"A",ta,ta) );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 2 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( tv(c"a") == tv(c"a") );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 0 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( (ta && t0(c"A")) == t0(c"A") );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 0 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( (tv(c"a") && ta) == tv(c"a") );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 0 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( (tv(c"a") && t0(c"A")) == (tv(c"a") && t0(c"A")) );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 2 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( (tv(c"a") && (t0(c"A") && t0(c"B"))) == (tv(c"a") && (t0(c"A") && t0(c"B"))) );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 4 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( ((tv(c"a") && t0(c"A")) && t0(c"B")) == ((tv(c"a") && t0(c"A")) && t0(c"B")) );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 4 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( ( (tv(c"a") && t0(c"A")) && (t0(c"B") && t0(c"C")) ) == ( (tv(c"a") && t0(c"A")) && (t0(c"B") && t0(c"C")) ) );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 6 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( ts(c"A",[ta]) == ts(c"A",[ta]) );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 2 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( ts(c"A",[ta,ta]) == ts(c"A",[ta,ta]) );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 2 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( (ta || t0(c"A")) == t0(c"A") );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 0 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( (tv(c"a") || ta) == tv(c"a") );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 0 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( (tv(c"a") || t0(c"A")) == tv(c"a") );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 0 );
+safe-alloc-block-count-monotonic = 0;
+
+assert( tand(mk-vector(type(Type)).push(t0(c"A")).push(t0(c"B"))) == tand(mk-vector(type(Type)).push(t0(c"A")).push(t0(c"B"))) );
+assert( safe-alloc-block-count == 0 );
+assert( safe-alloc-block-count-monotonic == 2 );
+safe-alloc-block-count-monotonic = 0;

--- a/tests/promises/lm-type/bound-constructor.lsts
+++ b/tests/promises/lm-type/bound-constructor.lsts
@@ -1,6 +1,8 @@
 
 import LM23COMMON/unit-type-core.lsts;
 
+# some of these counts are upper bounds because List will be replaced with Vector implementation
+
 assert( ta == ta );
 assert( safe-alloc-block-count == 0 );
 assert( safe-alloc-block-count-monotonic == 0 );
@@ -8,17 +10,17 @@ safe-alloc-block-count-monotonic = 0;
 
 assert( t0(c"A") == t0(c"A") );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 2 );
+assert( safe-alloc-block-count-monotonic <= 2 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( t1(c"A",ta) == t1(c"A",ta) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 4 );
+assert( safe-alloc-block-count-monotonic <= 4 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( t2(c"A",ta,ta) == t2(c"A",ta,ta) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 6 );
+assert( safe-alloc-block-count-monotonic <= 6 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( tv(c"a") == tv(c"a") );
@@ -28,7 +30,7 @@ safe-alloc-block-count-monotonic = 0;
 
 assert( (ta && t0(c"A")) == t0(c"A") );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 2 );
+assert( safe-alloc-block-count-monotonic <= 2 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( (tv(c"a") && ta) == tv(c"a") );
@@ -38,37 +40,37 @@ safe-alloc-block-count-monotonic = 0;
 
 assert( (tv(c"a") && t0(c"A")) == (tv(c"a") && t0(c"A")) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 4 );
+assert( safe-alloc-block-count-monotonic <= 4 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( (tv(c"a") && (t0(c"A") && t0(c"B"))) == (tv(c"a") && (t0(c"A") && t0(c"B"))) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 8 );
+assert( safe-alloc-block-count-monotonic <= 8 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( ((tv(c"a") && t0(c"A")) && t0(c"B")) == ((tv(c"a") && t0(c"A")) && t0(c"B")) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 8 );
+assert( safe-alloc-block-count-monotonic <= 8 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( ( (tv(c"a") && t0(c"A")) && (t0(c"B") && t0(c"C")) ) == ( (tv(c"a") && t0(c"A")) && (t0(c"B") && t0(c"C")) ) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 12 );
+assert( safe-alloc-block-count-monotonic <= 12 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( ts(c"A",[ta]) == ts(c"A",[ta]) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 4 );
+assert( safe-alloc-block-count-monotonic <= 4 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( ts(c"A",[ta,ta]) == ts(c"A",[ta,ta]) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 6 );
+assert( safe-alloc-block-count-monotonic <= 6 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( (ta || t0(c"A")) == t0(c"A") );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 2 );
+assert( safe-alloc-block-count-monotonic <= 2 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( (tv(c"a") || ta) == tv(c"a") );
@@ -78,10 +80,10 @@ safe-alloc-block-count-monotonic = 0;
 
 assert( (tv(c"a") || t0(c"A")) == tv(c"a") );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 1 );
+assert( safe-alloc-block-count-monotonic <= 1 );
 safe-alloc-block-count-monotonic = 0;
 
 assert( tand(mk-vector(type(Type)).push(t0(c"A")).push(t0(c"B"))) == tand(mk-vector(type(Type)).push(t0(c"A")).push(t0(c"B"))) );
 assert( safe-alloc-block-count == 0 );
-assert( safe-alloc-block-count-monotonic == 6 );
+assert( safe-alloc-block-count-monotonic <= 6 );
 safe-alloc-block-count-monotonic = 0;


### PR DESCRIPTION
## Describe your changes
Features:
* start bounding types with performance constraints
* vector would be asymptotically more efficient to use here, but it is also impossible to destructure without typed macros

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1925

## Checklist before requesting a review
- [ TBD ] I have performed an AI-assisted self-review of my code.
```
Can you review my pull request and provide some suggestions?
https://patch-diff.githubusercontent.com/raw/Lambda-Mountain-Compiler-Backend/lambda-mountain/pull/1926.diff
```
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
