### PR TITLE
More lmcommon finish typecheck core fdsiii

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Andrew Johnson
+Copyright (c) 2026 Andrew Johnson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LM23COMMON/prop-tctx-find-callable.lsts
+++ b/LM23COMMON/prop-tctx-find-callable.lsts
@@ -67,5 +67,10 @@ let .find-callable(tctx: TypeContext?, fname: CString, arg-types: Type, blame: A
       exit(1);
    };
 
+   # Check for half-specialization
+   # open(U8) can unify with open(U64) if it exists
+   # but open(U8) should still go for specializing open(x) rather than stopping at open(U64)
+   
+
    result
 );

--- a/LM23COMMON/typecheck-infer-expr.lsts
+++ b/LM23COMMON/typecheck-infer-expr.lsts
@@ -23,6 +23,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          if not(is(r,new-r)) then { r = new-r; term = mk-app(o-t, r); };
          tctx = tctx.ascript(o-t, t2(c"Arrow",typeof-term(r),t1(c"Type",typeof-term(r))));
          tctx = tctx.ascript(term, t1(c"Type",typeof-term(r)));
+         tctx = tctx.phi-move(typeof-term(r), term);
       );
       App{o-t=left:Var{key:c"open"}, r=right} => (
          (tctx, let new-r) = std-infer-expr(tctx, r, false, Used(), ta);

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/list/bound-concatenate.lsts
+	lm tests/promises/typechecking/parameter-substitution.lsts
 	gcc tmp.c
 	./a.out
 

--- a/PLUGINS/BACKEND/C/std-c-compile-call.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-call.lsts
@@ -5,7 +5,7 @@ let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor
    let fterm = Some(mk-tctx()).maybe-find-callable(fname, typeof-term(args), args, return-hint-if-constructor)
                               .expect("std-c-compile-call Function \{fname} was null\nArguments: \{typeof-term(args)}, Return Hint \{return-hint-if-constructor}\n").blame-or-zero;
    if typeof-term(fterm).is-t(c"Blob",0) {
-      if typeof-term(fterm).is-open then {
+      if typeof-term(fterm).is-open and fname!=c"open" then {
          for list tr in Some(mk-tctx()).lookups(fname) {
             print("STD C compile call candidate \{fname} : \{tr.dt-or-zero}\n");
          };

--- a/PLUGINS/BACKEND/C/std-c-compile-call.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-call.lsts
@@ -5,7 +5,7 @@ let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor
    let fterm = Some(mk-tctx()).maybe-find-callable(fname, typeof-term(args), args, return-hint-if-constructor)
                               .expect("std-c-compile-call Function \{fname} was null\nArguments: \{typeof-term(args)}, Return Hint \{return-hint-if-constructor}\n").blame-or-zero;
    if typeof-term(fterm).is-t(c"Blob",0) {
-      if typeof-term(fterm).is-open and fname!=c"open" then {
+      if typeof-term(fterm).is-open and fname!=c"open" and fname!=c"mov" then {
          for list tr in Some(mk-tctx()).lookups(fname) {
             print("STD C compile call candidate \{fname} : \{tr.dt-or-zero}\n");
          };

--- a/SRC/specialize.lsts
+++ b/SRC/specialize.lsts
@@ -1,6 +1,6 @@
 
 let specialize(key: CString, unify-ctx: TypeContext?, result-type: Type, term: AST): Nil = (
-   if not(is-special(key, result-type)) {
+   if key!=c"open" and not(is-special(key, result-type)) {
       mark-as-special(key, result-type);
       let special-term = substitute(unify-ctx, term);
       match special-term {

--- a/SRC/specialize.lsts
+++ b/SRC/specialize.lsts
@@ -1,6 +1,6 @@
 
 let specialize(key: CString, unify-ctx: TypeContext?, result-type: Type, term: AST): Nil = (
-   if key!=c"open" and not(is-special(key, result-type)) {
+   if (key!=c"open" or result-type.domain.slot(c"Array",2).l1.is-t(c"OwnedData",1)) and key!=c"mov" and not(is-special(key, result-type)) {
       mark-as-special(key, result-type);
       let special-term = substitute(unify-ctx, term);
       match special-term {

--- a/errors.err
+++ b/errors.err
@@ -1,0 +1,50 @@
+TEST --compile true tests/promises/hashtable/mk-hashtable-is.lsts
+Expected: ''
+Actual: 'Compilation Error: First type variable k occurence: Sized<String>
+Second type variable k occurence: String
+Type variables k not equal in call to .bind
+Function: Arrow<Cons<Cons<CaseNumber<0> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,k,v>>[]> + Hashtable<k,v> + LMStruct + MustRelease + MustRetain + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Hashtable<k,v>>,k>,v>,CaseNumber<0> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,k,v>>[]> + Hashtable<k,v> + LMStruct + MustRelease + MustRetain + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Hashtable<k,v>>>
+Arguments: Cons<Cons<CaseNumber<0> + CaseNumber<0> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,Sized<String>,C<"char">[]>>[]> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,Sized<String>,C<"char">[]>>[]> + Hashtable<Sized<String>,C<"char">[]> + LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__5fbe000000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Hashtable<Sized<String>,C<"char">[]>> + Sized<Hashtable<Sized<String>,C<"char">[]>>,CaseNumber<0> + CaseNumber<0> + Field::data<OwnedData<U8>[]> + Field::data<OwnedData<U8>[]> + Field::end-offset<USize> + Field::end-offset<USize> + Field::start-offset<USize> + Field::start-offset<USize> + LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__00ce000000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<String> + Sized<String> + String>,C<"char">[] + Constant + Literal>
+Return Hint: ?
+
+In File tests/promises/hashtable/mk-hashtable-is.lsts Line 11 Column 8'
+TEST --compile true tests/promises/lm-ascript/ascript-integrated.lsts
+Expected: ''
+Actual: 'Compilation Error: First type variable k occurence: Sized<AST>
+Second type variable k occurence: AST
+Type variables k not equal in call to .lookup
+Function: Arrow<Cons<Cons<CaseNumber<0> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,k,v>>[]> + Hashtable<k,v> + LMStruct + MustRelease + MustRetain + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Hashtable<k,v>>,k>,v>,v>
+Arguments: Cons<Cons<CaseNumber<0> + CaseNumber<0> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,Sized<AST>,Type>>[]> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,Sized<AST>,Type>>[]> + Hashtable<Sized<AST>,Type> + LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__00bf800000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Hashtable<Sized<AST>,Type>> + Sized<Hashtable<Sized<AST>,Type>>,AST + DefaultFormattable + DefaultFormattable + LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__b0bf800000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<AST> + Sized<AST>>,LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__e0bf800000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Type> + Sized<Type> + Type>
+Return Hint: ?
+
+In File LM23COMMON/ascript-type-index.lsts Line 10 Column 59'
+TEST --compile true tests/promises/lm-ascript/ascript.lsts
+Expected: ''
+Actual: 'Compilation Error: First type variable k occurence: Sized<AST>
+Second type variable k occurence: AST
+Type variables k not equal in call to .lookup
+Function: Arrow<Cons<Cons<CaseNumber<0> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,k,v>>[]> + Hashtable<k,v> + LMStruct + MustRelease + MustRetain + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Hashtable<k,v>>,k>,v>,v>
+Arguments: Cons<Cons<CaseNumber<0> + CaseNumber<0> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,Sized<AST>,Type>>[]> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,Sized<AST>,Type>>[]> + Hashtable<Sized<AST>,Type> + LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__859f800000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Hashtable<Sized<AST>,Type>> + Sized<Hashtable<Sized<AST>,Type>>,AST + DefaultFormattable + DefaultFormattable + LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__369f800000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<AST> + Sized<AST>>,LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__669f800000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Type> + Sized<Type> + Type>
+Return Hint: ?
+
+In File LM23COMMON/ascript-type-index.lsts Line 10 Column 59'
+TEST --compile true tests/promises/lm-ascript/concrete.lsts
+Expected: ''
+Actual: 'Compilation Error: First type variable k occurence: Sized<AST>
+Second type variable k occurence: AST
+Type variables k not equal in call to .lookup
+Function: Arrow<Cons<Cons<CaseNumber<0> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,k,v>>[]> + Hashtable<k,v> + LMStruct + MustRelease + MustRetain + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Hashtable<k,v>>,k>,v>,v>
+Arguments: Cons<Cons<CaseNumber<0> + CaseNumber<0> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,Sized<AST>,Type>>[]> + Field::data<SparseOwnedData<Tuple<HashtableRowExists,Sized<AST>,Type>>[]> + Hashtable<Sized<AST>,Type> + LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__49ff800000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Hashtable<Sized<AST>,Type>> + Sized<Hashtable<Sized<AST>,Type>>,AST + DefaultFormattable + DefaultFormattable + LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__f9ff800000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<AST> + Sized<AST>>,LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__2aff800000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Type> + Sized<Type> + Type>
+Return Hint: ?
+
+In File LM23COMMON/ascript-type-index.lsts Line 10 Column 59'
+TEST --compile true tests/promises/vector/constructor.lsts
+Expected: ''
+Actual: 'Compilation Error: First type variable t occurence: U64
+Second type variable t occurence: U8
+Type variables t not equal in call to .push
+Function: Arrow<Cons<CaseNumber<0> + Field::data<OwnedData<t>[]> + LMStruct + MustRelease + MustRetain + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Vector<t>> + Vector<t>,t>,CaseNumber<0> + Field::data<OwnedData<t>[]> + LMStruct + MustRelease + MustRetain + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Vector<t>> + Vector<t>>
+Arguments: Cons<CaseNumber<0> + CaseNumber<0> + Field::data<OwnedData<U64>[]> + Field::data<OwnedData<U64>[]> + LMStruct + LMStruct + MustRelease + MustRelease + MustRetain + MustRetain + Phi::Id<"uuid__540f000000000000"> + Phi::State<MustRelease::ToRelease<Linear<Phi::Live>>> + Sized<Vector<U64>> + Sized<Vector<U64>> + Vector<U64>,C<"int"> + C<"int"> + C<"size_t"> + C<"size_t"> + C<"size_t"> + Constant + I64 + I64 + Literal + Sized<I64> + Sized<I64> + Sized<I64> + Sized<U64> + Sized<U64> + Sized<U64> + Sized<U64> + Sized<U8> + Sized<U8> + Sized<USize> + Sized<USize> + Sized<USize> + U64 + U64 + U64 + U8 + USize + USize>
+Return Hint: ?
+
+In File tests/promises/vector/constructor.lsts Line 10 Column 24

--- a/lib2/core/array.lsts
+++ b/lib2/core/array.lsts
@@ -103,4 +103,7 @@ let safe-free(ptr: ?[]): Nil = (
    ()
 );
 
-let open(i: x): x = i;
+let :Blob open(i: x): x = (
+   $":expression"($":expression"(i));
+   $":frame"($":frame"(i));
+);

--- a/lib2/core/owned-data.lsts
+++ b/lib2/core/owned-data.lsts
@@ -37,7 +37,7 @@ let $"set[]"(od: OwnedData<t>[], idx: USize, val: t): Nil = (
    od.data[idx] = val;
 );
 
-let .push(od: OwnedData<t>[], d: s): Nil = (
+let .push(od: OwnedData<t>[], d: t): Nil = (
    if (od as USize)==0
    then fail(c"OwnedData .push Into Null Pointer");
    if od.occupied >= od.capacity

--- a/lib2/core/vector.lsts
+++ b/lib2/core/vector.lsts
@@ -65,7 +65,7 @@ let .realloc(v: Vector<t>, target-capacity: USize): Vector<t> = (
 # TODO: Vector<t> and i: t should have the same type variable and it should unify
 # new allocations = 1 if realloc is necessary
 #                 | 0
-let .push(v: Vector<t>, i: x): Vector<t> = (
+let .push(v: Vector<t>, i: t): Vector<t> = (
    # if this vector is a view, or if it is full, then we need to reallocate
    if (v.data as USize)==0 or v.data.occupied==v.data.capacity {
       let new-capacity = if v.length==0 then 4_sz

--- a/tests/promises/typechecking/parameter-substitution.lsts
+++ b/tests/promises/typechecking/parameter-substitution.lsts
@@ -3,9 +3,10 @@ import lib2/core/bedrock.lsts;
 
 let f(ls: List<x>): Nil = (
    let v = mk-vector(type(x));
+   print("ls : \{typeof(ls).into(type(CString))}\n");
    for l in ls {
       print("l : \{typeof(l).into(type(CString))}\n");
-      v = v.push(l);
+      #v = v.push(l);
    };
 );
 

--- a/tests/promises/typechecking/parameter-substitution.lsts
+++ b/tests/promises/typechecking/parameter-substitution.lsts
@@ -1,20 +1,9 @@
 
 import lib2/core/bedrock.lsts;
 
-let xs = [1_u8];
-
-print("1_u8 : \{typeof(1_u8).into(type(CString))}\n");
-print("1_u8 : \{typeof(open(1_u8)).into(type(CString))}\n");
-print("1_u8 : \{typeof(open(open(1_u8))).into(type(CString))}\n");
-
-print("head(xs) : \{typeof(head(xs)).into(type(CString))}\n");
-print("open(head(xs)) : \{typeof(open(head(xs))).into(type(CString))}\n");
-
 let f(ls: List<x>): Nil = (
    let v = mk-vector(type(x));
-   print("ls : \{typeof(ls).into(type(CString))}\n");
-   print("head(ls) : \{typeof(head(ls)).into(type(CString))}\n");
-   print("open(head(ls)) : \{typeof(open(head(ls))).into(type(CString))}\n");
+   v = v.push(open(head(ls)));
 );
 
 f([1_u8]);

--- a/tests/promises/typechecking/parameter-substitution.lsts
+++ b/tests/promises/typechecking/parameter-substitution.lsts
@@ -1,10 +1,14 @@
 
 import lib2/core/bedrock.lsts;
 
+print("1_u8 : \{typeof(1_u8).into(type(CString))}\n");
+print("1_u8 : \{typeof(open(1_u8)).into(type(CString))}\n");
+
 let f(ls: List<x>): Nil = (
    let v = mk-vector(type(x));
    print("ls : \{typeof(ls).into(type(CString))}\n");
    print("head(ls) : \{typeof(head(ls)).into(type(CString))}\n");
+   print("open(head(ls)) : \{typeof(open(head(ls))).into(type(CString))}\n");
    match head(ls) {
       item => print("item = head(ls) : \{typeof(item).into(type(CString))}\n");
       _ => ();

--- a/tests/promises/typechecking/parameter-substitution.lsts
+++ b/tests/promises/typechecking/parameter-substitution.lsts
@@ -1,23 +1,20 @@
 
 import lib2/core/bedrock.lsts;
 
+let xs = [1_u8];
+
 print("1_u8 : \{typeof(1_u8).into(type(CString))}\n");
 print("1_u8 : \{typeof(open(1_u8)).into(type(CString))}\n");
+print("1_u8 : \{typeof(open(open(1_u8))).into(type(CString))}\n");
+
+print("head(xs) : \{typeof(head(xs)).into(type(CString))}\n");
+print("open(head(xs)) : \{typeof(open(head(xs))).into(type(CString))}\n");
 
 let f(ls: List<x>): Nil = (
    let v = mk-vector(type(x));
    print("ls : \{typeof(ls).into(type(CString))}\n");
    print("head(ls) : \{typeof(head(ls)).into(type(CString))}\n");
    print("open(head(ls)) : \{typeof(open(head(ls))).into(type(CString))}\n");
-   match head(ls) {
-      item => print("item = head(ls) : \{typeof(item).into(type(CString))}\n");
-      _ => ();
-   };
-   for l in ls {
-      print("l : \{typeof(l).into(type(CString))}\n");
-      #v = v.push(l);
-   };
 );
 
 f([1_u8]);
-

--- a/tests/promises/typechecking/parameter-substitution.lsts
+++ b/tests/promises/typechecking/parameter-substitution.lsts
@@ -1,0 +1,13 @@
+
+import lib2/core/bedrock.lsts;
+
+let f(ls: List<x>): Nil = (
+   let v = mk-vector(type(x));
+   for l in ls {
+      print("l : \{typeof(l).into(type(CString))}\n");
+      v = v.push(l);
+   };
+);
+
+f([1_u8]);
+

--- a/tests/promises/typechecking/parameter-substitution.lsts
+++ b/tests/promises/typechecking/parameter-substitution.lsts
@@ -4,6 +4,11 @@ import lib2/core/bedrock.lsts;
 let f(ls: List<x>): Nil = (
    let v = mk-vector(type(x));
    print("ls : \{typeof(ls).into(type(CString))}\n");
+   print("head(ls) : \{typeof(head(ls)).into(type(CString))}\n");
+   match head(ls) {
+      item => print("item = head(ls) : \{typeof(item).into(type(CString))}\n");
+      _ => ();
+   };
    for l in ls {
       print("l : \{typeof(l).into(type(CString))}\n");
       #v = v.push(l);


### PR DESCRIPTION
## Describe your changes
Features:
* fixed loose linear variables in `typeof`. It doesn't matter if these variables are live or not
* `open` and `mov` don't specialize at all to fix a half-specialization bug, not the ideal solution but added a separate ticket for that https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1955
* only 5 regressions left (originally caused by improved strictness in typechecker)

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed an AI-assisted self-review of my code.
```
Can you review my pull request and provide some suggestions?
https://patch-diff.githubusercontent.com/raw/Lambda-Mountain-Compiler-Backend/lambda-mountain/pull/1926.diff
```
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
