### PR TITLE
More lmcommon typecheck core fusddsllsl

### DIFF
--- a/LM23COMMON/ascript-concrete-index.lsts
+++ b/LM23COMMON/ascript-concrete-index.lsts
@@ -2,43 +2,37 @@
 # A concrete type is an instance of a type that has been realized on a term
 # It is not an "in processing" or "theoretical" type anymore, but now an actual observed term
 
-let concrete-type-instances-index = {} : Hashtable<(CString,U64),List<Type>>;
+let concrete-type-instances-index = {} : Hashtable<(CString,U64),Vector<Type>>;
 
 let add-concrete-type-instance(tt: Type, blame: AST): Nil = (
-   let empty-type-list = [] : List<Type>; # this is a workaround for a phi bug that needs to be fixed 
-   if not(tt.is-phi-type) then {
-      tt = tt.normalize.sanitize-phi;
-      let lt = tt.slot(c"Array",2);
-      if non-zero(lt) then tt = lt else tt = tt.with-only-datatype;
-      if non-zero(tt) { match tt {
-         TGround{tag1=tag, parameters:[]} => (
-            if tt.is-datatype and not(does-concrete-type-instance-exist(tt)) {
-               let k = (tag1,0_u64);
-               concrete-type-instances-index = concrete-type-instances-index.bind(
-                  k, cons( tt, concrete-type-instances-index.lookup(k, empty-type-list) )
-               );
-            }
-         );
-         TGround{tag2=tag, ts=parameters} => (
-            if not(does-concrete-type-instance-exist(tt)) {
-               let k = (tag2, ts.length as U64);
-               concrete-type-instances-index = concrete-type-instances-index.bind(
-                  k, cons( tt, concrete-type-instances-index.lookup(k, empty-type-list) )
-               );
-            };
-            for ct in ts { add-concrete-type-instance(ct,blame) };
-         );
-      }}
+   match tt {
+      TAnd{ conjugate=conjugate } => (
+         for vector c in conjugate {
+            add-concrete-type-instance(c, blame);
+         }
+      );
+      TGround{ tag=tag, parameters=parameters } => (
+         if tt.is-datatype then {
+            let gta = tt.ground-tag-and-arity;
+            let row = concrete-type-instances-index.lookup(gta, mk-vector(type(Type)));
+            if not(row.contains(tt)) then row = row.push(tt);
+            concrete-type-instances-index = concrete-type-instances-index.bind(gta, row);
+         };
+         for list p in parameters {
+            add-concrete-type-instance(p, blame);
+         };
+      );
+      _ => ();
    }
 );
 
 let does-concrete-type-instance-exist(tt: Type): Bool = (
-   let empty-type-list = [] : List<Type>; # this is a workaround for a phi bug that needs to be fixed 
+   let empty-type-vector = mk-vector(type(Type)); # this is a workaround for a phi bug that needs to be fixed 
    match tt {
       TGround{tag=tag, ts=parameters} => (
          let exists = false;
          let k = (tag, ts.length as U64);
-         for vt in concrete-type-instances-index.lookup(k, empty-type-list) {
+         for vt in concrete-type-instances-index.lookup(k, empty-type-vector) {
             if vt==tt then exists = true;
          };
          exists

--- a/LM23COMMON/ascript-concrete-index.lsts
+++ b/LM23COMMON/ascript-concrete-index.lsts
@@ -13,7 +13,7 @@ let add-concrete-type-instance(tt: Type, blame: AST): Nil = (
       );
       TGround{ tag=tag, parameters=parameters } => (
          if tt.is-datatype then {
-            tt = tt.rewrite-type-alias;
+            tt = tt.rewrite-type-alias.without-any-phi;
             let gta = tt.ground-tag-and-arity;
             let row = concrete-type-instances-index.lookup(gta, mk-vector(type(Type)));
             if not(row.contains(tt)) then row = row.push(tt);

--- a/LM23COMMON/ascript-concrete-index.lsts
+++ b/LM23COMMON/ascript-concrete-index.lsts
@@ -13,6 +13,7 @@ let add-concrete-type-instance(tt: Type, blame: AST): Nil = (
       );
       TGround{ tag=tag, parameters=parameters } => (
          if tt.is-datatype then {
+            tt = tt.rewrite-type-alias;
             let gta = tt.ground-tag-and-arity;
             let row = concrete-type-instances-index.lookup(gta, mk-vector(type(Type)));
             if not(row.contains(tt)) then row = row.push(tt);

--- a/LM23COMMON/prop-core.lsts
+++ b/LM23COMMON/prop-core.lsts
@@ -63,7 +63,7 @@ let enrich-quick-prop(base: Type, pre: Type): Type = (
                   tctx.substitute(rt);
                ) else rt;
                if not(pre <: post) and not(base <: post) {
-                  pre = pre && post;
+                  pre = pre.extend(post);
                };
             );
          };
@@ -77,7 +77,7 @@ let enrich-quick-prop(base: Type, pre: Type): Type = (
                      tctx.substitute(rt);
                   ) else rt;
                   if not(pre <: post) and not(base <: post) {
-                     pre = pre && post;
+                     pre = pre.extend(post);
                   };
                );
             };

--- a/LM23COMMON/prop-expand-implied-phi.lsts
+++ b/LM23COMMON/prop-expand-implied-phi.lsts
@@ -5,12 +5,13 @@ let .expand-implied-phi(tt: Type): Type = (
    let original-tt = tt;
    if not(tt.is-t(c"Phi::State",1)) then match tt {
       TAnd{conjugate=conjugate} => (
+         tt = tand(conjugate);
          for vector c in conjugate {
             let ga = c.ground-tag-and-arity;
             let ip = implied-phi-index.lookup(ga,ta);
             let ps = t1(c"Phi::State",ip);
             if non-zero(ip) and not(can-unify(ps, tt)) {
-               tt = tt && ps
+               tt = tt.extend(ps)
             }
          }
       );

--- a/LM23COMMON/prop-expand-implied-phi.lsts
+++ b/LM23COMMON/prop-expand-implied-phi.lsts
@@ -23,7 +23,7 @@ let .expand-implied-phi(tt: Type): Type = (
          let ip = implied-phi-index.lookup(ga,ta);
          let ps = t1(c"Phi::State",ip);
          if non-zero(ip) and not(can-unify(ps, tt)) {
-            tt = tt && ps
+            tt = tt.extend(ps)
          }
       );
       _ => ();

--- a/LM23COMMON/prop-tctx-apply.lsts
+++ b/LM23COMMON/prop-tctx-apply.lsts
@@ -64,7 +64,7 @@ let .apply(tctx: TypeContext?, fname: CString, ft: Type, at: Type, blame: AST, r
 
    # Propagate cons root type for Prop functions
    # like, t0.prop0(t1,t2) : T0 && Prop0
-   if ft.is-t(c"Prop",0) then return-type = return-type && at.cons-root;  
+   if ft.is-t(c"Prop",0) then return-type = return-type.extend( at.cons-root );  
 
    (tctx, apply-tctx, closed-type, return-type)
 );

--- a/LM23COMMON/prop-typeof-var-raw.lsts
+++ b/LM23COMMON/prop-typeof-var-raw.lsts
@@ -3,9 +3,11 @@ let typeof-var-raw(sloc: AST, tctx: TypeContext?, vname: CString, must-not-fresh
    let rows = tctx.lookups(vname);
    if non-zero(rows) then {
       let tr = head(rows);
-      if tr.denormalized.is-t(c"MustRetain",0) and not(must-not-fresh) {
+      let dt = tr.denormalized;
+      if dt.is-t(c"MustRetain",0) and not(must-not-fresh) {
          (tctx, tr) = tctx.phi-fresh(tr);
+         dt = tr.denormalized;
       };
-      (tctx, tr.denormalized)
+      (tctx, dt)
    } else (tctx, ta)
 );

--- a/LM23COMMON/tctx-phi-fresh.lsts
+++ b/LM23COMMON/tctx-phi-fresh.lsts
@@ -11,8 +11,8 @@ let .phi-fresh(tctx: TypeContext?, tr: TypeContextRow): (TypeContext?, TypeConte
          if non-zero(phi-id) and non-zero(phi-state) {
             let new-phi-id = uuid();
             tctx = tctx.bind-phi(new-phi-id, phi-state, blame);
-            nt = nt.without-slot(c"Phi::Id",1) && t1(c"Phi::Id",t0(new-phi-id));
-            dt = dt.without-slot(c"Phi::Id",1) && t1(c"Phi::Id",t0(new-phi-id));
+            nt = nt.without-slot(c"Phi::Id",1).extend( t1(c"Phi::Id",t0(new-phi-id)) );
+            dt = dt.without-slot(c"Phi::Id",1).extend( t1(c"Phi::Id",t0(new-phi-id)) );
          };
          (tctx, TypeContextRow(key,nt,dt,blame))
       );
@@ -27,7 +27,7 @@ let .phi-fresh(tctx: TypeContext?, nt: Type, blame: AST): (TypeContext?, Type) =
    if non-zero(phi-id) and non-zero(phi-state) {
       let new-phi-id = uuid();
       tctx = tctx.bind-phi(new-phi-id, phi-state, blame);
-      nt = nt.without-slot(c"Phi::Id",1) && t1(c"Phi::Id",t0(new-phi-id));
+      nt = nt.without-slot(c"Phi::Id",1).extend( t1(c"Phi::Id",t0(new-phi-id)) );
    };
    (tctx, nt)
 );

--- a/LM23COMMON/tctx-unify.lsts
+++ b/LM23COMMON/tctx-unify.lsts
@@ -46,14 +46,14 @@ let unify-inner(fpt: Type, pt: Type, blame: AST): Maybe<TypeContext> = (
                         phi-id = new-phi-id;
                      );
                      TGround{tag:c"Phi::State",parameters:[new-phi-state..]} => (
-                        phi-state-in = phi-state-in && new-phi-state;
+                        phi-state-in = phi-state-in.extend( new-phi-state );
                      );
                      _ => ();
                   }};
                   if can-unify(phi-from, phi-state-in)
                   then (
                      result = result && unify(phi-from, phi-state-in, blame);
-                     phi-state-out = phi-state-out && phi-to;
+                     phi-state-out = phi-state-out.extend( phi-to );
                   );
                );
                TGround{ltag=tag} => (

--- a/LM23COMMON/type-can-unify.lsts
+++ b/LM23COMMON/type-can-unify.lsts
@@ -39,7 +39,7 @@ let can-unify(fpt: Type, pt: Type): Bool = (
                   let skip-state-check = false;
                   for vector st in rconjugate { match st {
                      TGround{tag:c"Phi::State",parameters:[new-phi-state..]} => (
-                        phi-state-in = phi-state-in && new-phi-state;
+                        phi-state-in = phi-state-in.extend(new-phi-state);
                      );
                      TGround{tag:c"Phi::Transition",parameters:[new-phi-to..new-phi-from..]} => (
                         result = result and can-unify(phi-to, new-phi-to) and can-unify(phi-from, new-phi-from);

--- a/LM23COMMON/type-constructor.lsts
+++ b/LM23COMMON/type-constructor.lsts
@@ -60,6 +60,39 @@ let $"&&"(lt: Type, rt: Type): Type = (
    };
 );
 
+# new allocations = 0 if either argument is ?
+#                 | 1
+let .extend(lt: Type, rt: Type): Type = (
+   match (lt, rt) {
+      Tuple{first:TAny{}} => rt;
+      Tuple{second:TAny{}} => lt;
+      Tuple{first:TAnd{lconjugate=conjugate},second:TAnd{rconjugate=conjugate}} => (
+         for vector c in rconjugate { lconjugate = lconjugate.push(c) };
+         lconjugate = lconjugate.sort;
+         TAnd(lconjugate)
+      );
+      Tuple{first=first,second:TAnd{rconjugate=conjugate}} => (
+         let result = mk-vector(type(Type), 1+rconjugate.length);
+         result = result.push(first);
+         for vector c in rconjugate { result = result.push(c) };
+         result = result.sort;
+         TAnd(result)
+      );
+      Tuple{first:TAnd{lconjugate=conjugate},second=second} => (
+         lconjugate = lconjugate.push(second);
+         lconjugate = lconjugate.sort;
+         TAnd(lconjugate)
+      );
+      Tuple{first=first,second=second} => (
+         let result = mk-vector(type(Type), 2);
+         result = result.push(first);
+         result = result.push(second);
+         result = result.sort;
+         TAnd(result)
+      );
+   };
+);
+
 # new allocations = 1
 # this is an upper bound, because the list implementation should be replaced with vector eventually
 let ts(tag: CString, ps: List<Type>): Type = TGround( tag, close(ps) );

--- a/LM23COMMON/typecheck-acontext-substitute.lsts
+++ b/LM23COMMON/typecheck-acontext-substitute.lsts
@@ -44,8 +44,8 @@ let substitute(ctx: List<(CString,AST)>, tt: List<Type>): List<Type> = (
 
 let substitute(ctx: List<(CString,AST)>, term: AST): AST = (
    match term {
-      App{left:Var{key:c"uuid"}, right:Var{x=key}} => ctx.lookup(x,term).unique;
-      Var{x=key} => ctx.lookup(x,term).unique;
+      App{left:Var{key:c"uuid"}, right:Var{x1=key}} => ctx.lookup(x1,term).unique;
+      Var{x2=key} => ctx.lookup(x2,term).unique;
       Lit{} => term.unique;
       Seq{seq=seq} => (
          let ret = mk-vector(type(AST), seq.length);

--- a/LM23COMMON/typecheck-infer-expr.lsts
+++ b/LM23COMMON/typecheck-infer-expr.lsts
@@ -271,6 +271,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
       App{ is-cons=is-cons, l=left, r=right } => (
          let is-macro = false;
          if is-cons {
+            if show-alloc-count then print("before cons blocks allocated: \{safe-alloc-block-count-monotonic}\n");
             let lhint = hint.slot(c"Cons",2).l1 && hint.slot(c"MustNotRetain",0) && hint.slot(c"MustNotFresh",0);
             let rhint = hint.slot(c"Cons",2).l2 && hint.slot(c"MustNotRetain",0) && hint.slot(c"MustNotFresh",0) && hint.slot(c"TailPosition",0);
             (tctx, let new-l) = std-infer-expr(tctx, l, false, if used.is-call then used else Unused, lhint);
@@ -279,10 +280,13 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             (tctx, let new-r) = std-infer-expr(tctx, r, false, if used.is-tail then used else if used.is-unused then used else Used, rhint);
             if not(is(l,new-l)) or not(is(r,new-r)) then { l = new-l; r = new-r; term = mk-cons(new-l, new-r) };
             tctx = tctx.ascript(term, if used.is-tail then typeof-term(r) else t2(c"Cons", typeof-term(l), typeof-term(r)));
+            if show-alloc-count then print("after cons blocks allocated: \{safe-alloc-block-count-monotonic}\n");
          } else {
             let rt = ta;
             if index-macro-table.has(var-name-if-var(l)) {
+               if show-alloc-count then print("Before apply macro \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                (tctx, term) = std-apply-macro(tctx, term, used);
+               if show-alloc-count then print("After apply macro \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                is-macro = true;
             } else {
                (tctx, let new-l) = std-infer-expr(tctx, l, false, used, ta);
@@ -391,6 +395,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          tctx = tctx.phi-move(typeof-term(term),term);
       }
    }};
+   if show-alloc-count then print("infer \{term} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
    (tctx, term);
 );
 

--- a/LM23COMMON/typecheck-infer-expr.lsts
+++ b/LM23COMMON/typecheck-infer-expr.lsts
@@ -271,7 +271,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
       App{ is-cons=is-cons, l=left, r=right } => (
          let is-macro = false;
          if is-cons {
-            if show-alloc-count then print("before cons blocks allocated: \{safe-alloc-block-count-monotonic}\n");
             let lhint = hint.slot(c"Cons",2).l1 && hint.slot(c"MustNotRetain",0) && hint.slot(c"MustNotFresh",0);
             let rhint = hint.slot(c"Cons",2).l2 && hint.slot(c"MustNotRetain",0) && hint.slot(c"MustNotFresh",0) && hint.slot(c"TailPosition",0);
             (tctx, let new-l) = std-infer-expr(tctx, l, false, if used.is-call then used else Unused, lhint);
@@ -280,7 +279,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             (tctx, let new-r) = std-infer-expr(tctx, r, false, if used.is-tail then used else if used.is-unused then used else Used, rhint);
             if not(is(l,new-l)) or not(is(r,new-r)) then { l = new-l; r = new-r; term = mk-cons(new-l, new-r) };
             tctx = tctx.ascript(term, if used.is-tail then typeof-term(r) else t2(c"Cons", typeof-term(l), typeof-term(r)));
-            if show-alloc-count then print("after cons blocks allocated: \{safe-alloc-block-count-monotonic}\n");
          } else {
             let rt = ta;
             if index-macro-table.has(var-name-if-var(l)) {
@@ -395,7 +393,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          tctx = tctx.phi-move(typeof-term(term),term);
       }
    }};
-   if show-alloc-count then print("infer \{term} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
    (tctx, term);
 );
 

--- a/LM23COMMON/typecheck-infer-expr.lsts
+++ b/LM23COMMON/typecheck-infer-expr.lsts
@@ -282,14 +282,11 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          } else {
             let rt = ta;
             if index-macro-table.has(var-name-if-var(l)) {
-               if show-alloc-count then print("Before apply macro \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                (tctx, term) = std-apply-macro(tctx, term, used);
-               if show-alloc-count then print("After apply macro \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                is-macro = true;
             } else {
                (tctx, let new-l) = std-infer-expr(tctx, l, false, used, ta);
                if not(is(l,new-l)) then { l = new-l; term = mk-app(l,r); };
-               if show-alloc-count then print("apply function 1.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                if typeof-term(l).is-arrow {
                   let direct-hint = hint-if-hint(l);
                   if hint.is-t(c"ReturnHint",0) then direct-hint = direct-hint && hint;
@@ -311,7 +308,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                   (tctx, let new-r) = std-infer-expr(tctx, r, false, Used, ta);
                   if not(is(l,new-l)) or not(is(r,new-r)) then { l = new-l; r = new-r; term = mk-app(l,r); };
                };
-               if show-alloc-count then print("apply function 2.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 
                (tctx, let function-type, rt) = if typeof-term(l).is-arrow and non-zero(lit-name-if-lit(l)) {
                   let direct-hint = hint-if-hint(l);
@@ -328,7 +324,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                } else {
                   (tctx, ta, t2(c"Cons", typeof-term(l), typeof-term(r)))
                };
-               if show-alloc-count then print("apply function 3.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                if not(used.is-call) { rt = rt.cons-tail-or-self; };
                if var-name-if-var-or-lit(l)==c"mov" and typeof-term(r).is-t(c"Cons",2) {
                   let from-tt = typeof-term(r).slot(c"Cons",2).l1;
@@ -338,12 +333,9 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                      tctx = tctx.phi-move(from-tt, term);
                   }
                };
-               if show-alloc-count then print("apply function 4.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 
                rt = tctx.with-phi(rt, term);
-               if show-alloc-count then print("apply function 5.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                tctx = tctx.ascript(term, rt);
-               if show-alloc-count then print("apply function 6.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 
                let is-released-after-call = false;
                if not(r.is-var-or-ascripted-var) {
@@ -378,13 +370,11 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                      term = new-term;
                   };
                };
-               if show-alloc-count then print("apply function 7.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                if not(is-released-after-call) and not(rt.is-t(c"Cons",2)) {
                   if function-type.is-t(c"MustRetainOnCall",0) and not(hint.is-t(c"MustNotRetain",0)) and not(tctx.get-or(mk-tctx()).is-blob) {
                      (tctx, term) = maybe-retain(tctx, term);
                   }
                };
-               if show-alloc-count then print("apply function 8.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
             };
          };
 
@@ -401,7 +391,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          tctx = tctx.phi-move(typeof-term(term),term);
       }
    }};
-   if show-alloc-count then print("Inferred \{term} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
    (tctx, term);
 );
 

--- a/LM23COMMON/typecheck-infer-expr.lsts
+++ b/LM23COMMON/typecheck-infer-expr.lsts
@@ -289,6 +289,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             } else {
                (tctx, let new-l) = std-infer-expr(tctx, l, false, used, ta);
                if not(is(l,new-l)) then { l = new-l; term = mk-app(l,r); };
+               if show-alloc-count then print("apply function 1.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                if typeof-term(l).is-arrow {
                   let direct-hint = hint-if-hint(l);
                   if hint.is-t(c"ReturnHint",0) then direct-hint = direct-hint && hint;
@@ -310,6 +311,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                   (tctx, let new-r) = std-infer-expr(tctx, r, false, Used, ta);
                   if not(is(l,new-l)) or not(is(r,new-r)) then { l = new-l; r = new-r; term = mk-app(l,r); };
                };
+               if show-alloc-count then print("apply function 2.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 
                (tctx, let function-type, rt) = if typeof-term(l).is-arrow and non-zero(lit-name-if-lit(l)) {
                   let direct-hint = hint-if-hint(l);
@@ -326,6 +328,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                } else {
                   (tctx, ta, t2(c"Cons", typeof-term(l), typeof-term(r)))
                };
+               if show-alloc-count then print("apply function 3.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                if not(used.is-call) { rt = rt.cons-tail-or-self; };
                if var-name-if-var-or-lit(l)==c"mov" and typeof-term(r).is-t(c"Cons",2) {
                   let from-tt = typeof-term(r).slot(c"Cons",2).l1;
@@ -335,9 +338,12 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                      tctx = tctx.phi-move(from-tt, term);
                   }
                };
+               if show-alloc-count then print("apply function 4.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 
                rt = tctx.with-phi(rt, term);
+               if show-alloc-count then print("apply function 5.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                tctx = tctx.ascript(term, rt);
+               if show-alloc-count then print("apply function 6.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 
                let is-released-after-call = false;
                if not(r.is-var-or-ascripted-var) {
@@ -372,11 +378,13 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                      term = new-term;
                   };
                };
+               if show-alloc-count then print("apply function 7.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
                if not(is-released-after-call) and not(rt.is-t(c"Cons",2)) {
                   if function-type.is-t(c"MustRetainOnCall",0) and not(hint.is-t(c"MustNotRetain",0)) and not(tctx.get-or(mk-tctx()).is-blob) {
                      (tctx, term) = maybe-retain(tctx, term);
                   }
                };
+               if show-alloc-count then print("apply function 8.0 \{var-name-if-var(l)} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
             };
          };
 

--- a/LM23COMMON/typecheck-infer-expr.lsts
+++ b/LM23COMMON/typecheck-infer-expr.lsts
@@ -393,6 +393,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          tctx = tctx.phi-move(typeof-term(term),term);
       }
    }};
+   if show-alloc-count then print("Inferred \{term} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
    (tctx, term);
 );
 

--- a/LM23COMMON/typecheck-release-locals.lsts
+++ b/LM23COMMON/typecheck-release-locals.lsts
@@ -7,7 +7,7 @@ let release-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AS
    let tctx-after-pctx = tctx-after.get-or(mk-tctx()).pctx;
    let needs-release = [] : List<TypeContextRow>;
    let needs-mark-release = [] : List<TypeContextRow>;
-   let pid-seen = {} : Hashtable<CString,U64>;
+   let pid-seen = {} : Hashtable<CString,Bool>;
    while non-zero(tctx-after-tctx) and not(is(tctx-before-tctx, tctx-after-tctx)) {
       let tr = head(tctx-after-tctx);
       let dt = tctx-after.with-phi(tr.denormalized, term);

--- a/LM23COMMON/typecheck-std-apply-macro.lsts
+++ b/LM23COMMON/typecheck-std-apply-macro.lsts
@@ -65,7 +65,9 @@ let std-apply-macro(tctx: Maybe<TypeContext>, mname: CString, margs: AST, used: 
    else if mname==c"macro::constant" then (tctx, result) = std-apply-macro-constant(tctx, mname, margs)
    else if mname==c"macro::tag" then (tctx, result) = std-apply-macro-tag(tctx, mname, margs)
    else {
+      if show-alloc-count then print("std-apply-macro .1 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
       let row = index-macro-table.lookup(mname, [] : List<(Type,Type,AST)>);
+      if show-alloc-count then print("std-apply-macro .2 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
       let peep-holes = ta;
       let peeped = ta;
       for Tuple{mtype=first, peep=second, mterm=third} in row {
@@ -77,15 +79,18 @@ let std-apply-macro(tctx: Maybe<TypeContext>, mname: CString, margs: AST, used: 
          };
       };
       (tctx, let peeped-type, margs) = std-infer-peeped-arguments(tctx, margs, peep-holes);
+      if show-alloc-count then print("std-apply-macro .3 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 
       let matched = [] : List<(Type,AST)>;
       for Tuple{mtype=first, mterm=third} in row {
          if can-unify(mtype, peeped-type) then matched = cons( (mtype,mterm), matched );
       }; 
+      if show-alloc-count then print("std-apply-macro .4 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 
       let dominant-type = ta;
       let candidates = [] : List<(Type,AST)>;
       for Tuple{mtype=first, mterm=second} in matched {
+      if show-alloc-count then print("std-apply-macro .5.0 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
          if non-zero(dominant-type) {
             if can-unify(mtype,dominant-type) and can-unify(dominant-type,mtype) {
                candidates = cons( (mtype,mterm), candidates );
@@ -99,13 +104,20 @@ let std-apply-macro(tctx: Maybe<TypeContext>, mname: CString, margs: AST, used: 
             candidates = [(mtype,mterm)];
          }
       };
+      if show-alloc-count then print("std-apply-macro .5.1 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
       (tctx, result) = std-apply-macro-candidates(tctx, mname, margs, candidates);
+      if show-alloc-count then print("std-apply-macro .5.2 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
    };
+   if show-alloc-count then print("std-apply-macro .5.4 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
+
    if strong and not(non-zero(result)) then exit-error("Failed to Apply Macro: \{mname}\nArgs: \{margs}\n", margs);
    if strong {
       (tctx, result) = std-infer-expr(tctx, result, false, used, ta);
+      if show-alloc-count then print("Inferred \{result}\n");
+      if show-alloc-count then print("std-apply-macro .6.1 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
       mark-free-and-seen(result);
    };
+   if show-alloc-count then print("std-apply-macro .6 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
    (tctx, result)
 );
 

--- a/LM23COMMON/typecheck-std-apply-macro.lsts
+++ b/LM23COMMON/typecheck-std-apply-macro.lsts
@@ -65,9 +65,7 @@ let std-apply-macro(tctx: Maybe<TypeContext>, mname: CString, margs: AST, used: 
    else if mname==c"macro::constant" then (tctx, result) = std-apply-macro-constant(tctx, mname, margs)
    else if mname==c"macro::tag" then (tctx, result) = std-apply-macro-tag(tctx, mname, margs)
    else {
-      if show-alloc-count then print("std-apply-macro .1 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
       let row = index-macro-table.lookup(mname, [] : List<(Type,Type,AST)>);
-      if show-alloc-count then print("std-apply-macro .2 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
       let peep-holes = ta;
       let peeped = ta;
       for Tuple{mtype=first, peep=second, mterm=third} in row {
@@ -79,18 +77,15 @@ let std-apply-macro(tctx: Maybe<TypeContext>, mname: CString, margs: AST, used: 
          };
       };
       (tctx, let peeped-type, margs) = std-infer-peeped-arguments(tctx, margs, peep-holes);
-      if show-alloc-count then print("std-apply-macro .3 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 
       let matched = [] : List<(Type,AST)>;
       for Tuple{mtype=first, mterm=third} in row {
          if can-unify(mtype, peeped-type) then matched = cons( (mtype,mterm), matched );
       }; 
-      if show-alloc-count then print("std-apply-macro .4 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 
       let dominant-type = ta;
       let candidates = [] : List<(Type,AST)>;
       for Tuple{mtype=first, mterm=second} in matched {
-      if show-alloc-count then print("std-apply-macro .5.0 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
          if non-zero(dominant-type) {
             if can-unify(mtype,dominant-type) and can-unify(dominant-type,mtype) {
                candidates = cons( (mtype,mterm), candidates );
@@ -104,20 +99,14 @@ let std-apply-macro(tctx: Maybe<TypeContext>, mname: CString, margs: AST, used: 
             candidates = [(mtype,mterm)];
          }
       };
-      if show-alloc-count then print("std-apply-macro .5.1 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
       (tctx, result) = std-apply-macro-candidates(tctx, mname, margs, candidates);
-      if show-alloc-count then print("std-apply-macro .5.2 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
    };
-   if show-alloc-count then print("std-apply-macro .5.4 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 
    if strong and not(non-zero(result)) then exit-error("Failed to Apply Macro: \{mname}\nArgs: \{margs}\n", margs);
    if strong {
       (tctx, result) = std-infer-expr(tctx, result, false, used, ta);
-      if show-alloc-count then print("Inferred \{result}\n");
-      if show-alloc-count then print("std-apply-macro .6.1 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
       mark-free-and-seen(result);
    };
-   if show-alloc-count then print("std-apply-macro .6 \{mname} blocks allocated: \{safe-alloc-block-count-monotonic}\n");
    (tctx, result)
 );
 

--- a/LM23COMMON/typecheck-std-direct-destructure-macro.lsts
+++ b/LM23COMMON/typecheck-std-direct-destructure-macro.lsts
@@ -2,10 +2,10 @@
 let std-direct-destructure-macro(margs: AST, mstruct: AST): AContext? = (
    let no = (None : AContext?)();
    match (margs, mstruct) {
-      Tuple{ val=first, second:Var{key=key} } => Some([(key,val)]);
-      Tuple{ first:App{lrest=left, val=right}, second:App{rrest=left, right:Var{key=key}} } => (
+      Tuple{ val=first, second:Var{key1=key} } => Some([(key1,val)]);
+      Tuple{ first:App{lrest=left, val=right}, second:App{rrest=left, right:Var{key2=key}} } => (
          let ctx = std-direct-destructure-macro(lrest, rrest);
-         if ctx.is-some then Some(cons((key,val), ctx.get-or-panic)) else no;
+         if ctx.is-some then Some(cons((key2,val), ctx.get-or-panic)) else no;
       );
       _ => fail("Unexpected std-direct-destructure-macro\nLeft: \{mstruct}\nRight: \{margs}\n");
    }

--- a/LM23COMMON/typecheck-validate-pctx-del.lsts
+++ b/LM23COMMON/typecheck-validate-pctx-del.lsts
@@ -1,6 +1,6 @@
 
 let validate-pctx-release(tctx: TypeContext?): Nil = (
-   let ps-seen = {} : Hashtable<CString,U64>;
+   let ps-seen = {} : Hashtable<CString,Bool>;
    for pr in tctx.get-or(mk-tctx()).pctx {
       if not(pr.is-global-or-zero) and not(ps-seen.has(pr.phi-id-or-zero)) {
          if pr.phi-tt-or-zero.is-linear-live

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = clang
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm --showalloc tests/promises/lm-typecheck/compilation-counting-diff1.lsts
+	#lm --showalloc tests/promises/lm-typecheck/compilation-counting-diff1.lsts
 	lm --showalloc tests/promises/lm-typecheck/compilation-counting-diff2.lsts > out.txt
 
 build: compile-production

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ CC = clang
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	#lm --showalloc tests/promises/lm-typecheck/compilation-counting-diff1.lsts
-	lm --showalloc tests/promises/lm-typecheck/compilation-counting-diff2.lsts > out.txt
+	lm tests/promises/list/comparison.lsts
+	gcc tmp.c
+	./a.out
 
 build: compile-production
 	time ./production --v2 --c -o deploy1.c SRC/index.lsts

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = cc
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/vector/constructor.lsts
+	lm tests/promises/lm-typecheck/direct-inference.lsts
 	gcc tmp.c
 	./a.out
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-CC = cc
+CC = clang
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm tests/promises/lm-typecheck/direct-inference.lsts
-	gcc tmp.c
-	./a.out
+	lm --showalloc --typecheck tests/promises/lm-typecheck/compilation-counting-diff1.lsts
+	lm --showalloc --typecheck tests/promises/lm-typecheck/compilation-counting-diff2.lsts
+	lm --showalloc tests/promises/lm-typecheck/compilation-counting-diff1.lsts
+	lm --showalloc tests/promises/lm-typecheck/compilation-counting-diff2.lsts
 
 build: compile-production
 	time ./production --v2 --c -o deploy1.c SRC/index.lsts

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ CC = clang
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
+	lm --showalloc --parse tests/promises/lm-typecheck/compilation-counting-diff1.lsts
+	lm --showalloc --parse tests/promises/lm-typecheck/compilation-counting-diff2.lsts
 	lm --showalloc --typecheck tests/promises/lm-typecheck/compilation-counting-diff1.lsts
 	lm --showalloc --typecheck tests/promises/lm-typecheck/compilation-counting-diff2.lsts
 	lm --showalloc tests/promises/lm-typecheck/compilation-counting-diff1.lsts

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,8 @@ CC = clang
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	lm --showalloc --parse tests/promises/lm-typecheck/compilation-counting-diff1.lsts
-	lm --showalloc --parse tests/promises/lm-typecheck/compilation-counting-diff2.lsts
-	lm --showalloc --typecheck tests/promises/lm-typecheck/compilation-counting-diff1.lsts
-	lm --showalloc --typecheck tests/promises/lm-typecheck/compilation-counting-diff2.lsts
 	lm --showalloc tests/promises/lm-typecheck/compilation-counting-diff1.lsts
-	lm --showalloc tests/promises/lm-typecheck/compilation-counting-diff2.lsts
+	lm --showalloc tests/promises/lm-typecheck/compilation-counting-diff2.lsts > out.txt
 
 build: compile-production
 	time ./production --v2 --c -o deploy1.c SRC/index.lsts

--- a/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
@@ -11,7 +11,7 @@ let std-c-compile-type-typedef(td: AST): Nil = (
    let cases = (td as Tag::Typedef).cases;
 
    if cases.length > 0 {
-   for concrete-type in concrete-type-instances-index.lookup(lhs-type.ground-tag-and-arity, [] : List<Type>) {
+   for vector concrete-type in concrete-type-instances-index.lookup(lhs-type.ground-tag-and-arity, mk-vector(type(Type))) {
       assemble-header-section = assemble-header-section + SAtom(c"typedef struct ") + std-c-mangle-type(concrete-type, td)
                               + SAtom(c" ") + std-c-mangle-type(concrete-type, td) + SAtom(c";\n");
       let tctx = unify(lhs-type, concrete-type, td);

--- a/SRC/main.lsts
+++ b/SRC/main.lsts
@@ -94,7 +94,9 @@ let main(argc: C_int, argv: CString[]): Nil = (
          };
       );
    };
-   if show-alloc-count then print("Total blocks allocated: \{safe-alloc-block-count-monotonic}\n");
+   if show-alloc-count then {
+      print("Total blocks allocated: \{safe-alloc-block-count-monotonic}\n");
+   };
 );
 
 let doby-say(): Nil = (

--- a/SRC/main.lsts
+++ b/SRC/main.lsts
@@ -32,6 +32,7 @@ let main(argc: C_int, argv: CString[]): Nil = (
    let highlight = false;
    let dump-tokens = false;
    let has-args = false;
+   let show-alloc-count = false;
    while argi < (argc as U64) {
       has-args = true;
       match argv[argi] {
@@ -48,6 +49,7 @@ let main(argc: C_int, argv: CString[]): Nil = (
             highlight = false;
          );
          c"--stripdebug" => config-strip-debug = true;
+         c"--showalloc" => show-alloc-count = true;
          c"-o" => (
             argi = argi + 1;
             config-target = argv[argi];
@@ -86,7 +88,8 @@ let main(argc: C_int, argv: CString[]): Nil = (
             ModeCompile{} => (preprocess(); typecheck(); plugin-current-backend(););
          };
       );
-   }
+   };
+   if show-alloc-count then print("Total blocks allocated: \{safe-alloc-block-count-monotonic}\n");
 );
 
 let doby-say(): Nil = (

--- a/SRC/main.lsts
+++ b/SRC/main.lsts
@@ -26,17 +26,19 @@ let print-toks-json(fp: CString): Nil = (
    print("]");
 );
 
+let show-alloc-count = false;
+
 let main(argc: C_int, argv: CString[]): Nil = (
    let argi = 1_u64;
    let input = [] : List<CString>;
    let highlight = false;
    let dump-tokens = false;
    let has-args = false;
-   let show-alloc-count = false;
    while argi < (argc as U64) {
       has-args = true;
       match argv[argi] {
          c"--typecheck" => config-mode = ModeTypecheck();
+         c"--parse" => config-mode = ModeParse();
          c"--compile" => config-mode = ModeCompile();
          c"--v2" => config-v3 = false;
          c"--v3" => config-v3 = true;
@@ -80,6 +82,9 @@ let main(argc: C_int, argv: CString[]): Nil = (
             };
             print("\n}\n");
          };
+      );
+      ModeParse{} => (
+         for fp in input.reverse { frontend(fp); };
       );
       _ => (
          for fp in input.reverse { frontend(fp); };

--- a/lib/std/array.lsts
+++ b/lib/std/array.lsts
@@ -26,6 +26,16 @@ declare-unop( $"&", raw-type(t), raw-type(t[]), (l"(&"; x; l")";) );
 declare-unop( raw, raw-type(t), raw-type(t), x );
 declare-unop( raw, raw-type(base-type[]), raw-type(base-type[]+Raw), x );
 
+# TODO: configure this with conditional compilation to remove if unused
+# EXAMPLE: # if CFG.debug
+#          let safe-alloc-block-count = 0_u64;
+#          let safe-alloc-block-count-monotonic = 0_u64;
+#          # endif
+# safe-alloc-block-count is an increment/decrement counter to track active malloc blocks
+# safe-alloc-block-count-monotonic is an increment-only counter to track historical malloc blocks
+let safe-alloc-block-count = 0_u64;
+let safe-alloc-block-count-monotonic = 0_u64;
+
 let mark-memory-as-safe(ptr: t[], len: U64): Nil = (
    # BEFORE CHANGING THIS: talk to alex
 
@@ -45,6 +55,11 @@ let safe-alloc-impl(nb: U64): ?[] = (
    };
 
    mark-memory-as-safe(ptr as U8[], nb);
+
+   # TODO: wrap counter adjustments in conditional compilation
+   safe-alloc-block-count = safe-alloc-block-count + 1;
+   safe-alloc-block-count-monotonic = safe-alloc-block-count-monotonic + 1;
+
    ptr
 );
 
@@ -57,6 +72,10 @@ let safe-realloc-impl(ptr: ?[], nb: U64): ?[] = (
    };
 
    mark-memory-as-safe(new_ptr as U8[], nb);
+
+   # TODO: wrap counter adjustments in conditional compilation
+   safe-alloc-block-count-monotonic = safe-alloc-block-count-monotonic + 1;
+
    new_ptr
 );
 

--- a/lib/std/primitives.lsts
+++ b/lib/std/primitives.lsts
@@ -20,6 +20,8 @@ declare-binop( $"primitive::field-set", raw-type(base-type), raw-type(field-type
 declare-unop( $"primitive::field-get-indirect", raw-type(base-type[]), raw-type(field-type), ( l"("; x; l"->"; mangle(field-name : L); l")"; ) );
 declare-binop( $"primitive::field-set-indirect", raw-type(base-type[]), raw-type(field-type), raw-type(Nil), ( l"("; x; l"->"; mangle(field-name : L); l"="; y; l")"; ) );
 
+declare-binop( $".into", type(Any), type(CString), raw-type(CString), () );
+
 # needs to be declared to prevent a special case during inference
 # this only needs to be declared if you want to support casting type information into String literals
 # EXAMPLE: print(typeof(x))

--- a/tests/promises/lm-typecheck/compilation-counting-diff1.lsts
+++ b/tests/promises/lm-typecheck/compilation-counting-diff1.lsts
@@ -1,0 +1,2 @@
+
+import lib2/core/bedrock.lsts;

--- a/tests/promises/lm-typecheck/compilation-counting-diff2.lsts
+++ b/tests/promises/lm-typecheck/compilation-counting-diff2.lsts
@@ -1,0 +1,9 @@
+
+import lib2/core/bedrock.lsts;
+
+match [1,2,3] {
+   [1..xs] => match xs {
+      [2.._] => print("hello 1\n");
+   };
+   [1..2..3..] => print("hello 2\n");
+};


### PR DESCRIPTION
## Describe your changes
Features:
* start performance tuning of core inference
* memory usage is down significantly depending on what you are trying to do
* speed is roughly 28% faster on self-compilation
* goal here is to be able to compile the compiler with GC enabled
* memory consumption is the major blocker here
* I have ~26GB available for the process and 0 garbage collection, so compilation is a limited runway here
* the inference core is currently compiling with GC-enabled. So hopefully a few more small optimizations will allow us to compile the rest of the entire project and then finally we can dump the lib1/permament allocations mess

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed an AI-assisted self-review of my code.
```
Can you review my pull request and provide some suggestions?
https://patch-diff.githubusercontent.com/raw/Lambda-Mountain-Compiler-Backend/lambda-mountain/pull/1926.diff
```
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
