### PR TITLE
Move plugins into lmcommon fdusioskkk

### DIFF
--- a/LM23COMMON/backend-fctx-lookup.lsts
+++ b/LM23COMMON/backend-fctx-lookup.lsts
@@ -9,7 +9,7 @@ let .lookup-soft(ctx: FContext, k: CString, kt: Type, sloc: AST): Fragment = (
 
 # TODO: unify lookup and lookups logic, with common logical elements isolated and explanation of algorithm
 
-let .lookup(ctx: FContext, k: CString, kt: Type, sloc: AST, hard: U64): Fragment = (
+let .lookup(ctx: FContext, k: CString, kt: Type, sloc: AST, hard: Bool): Fragment = (
    let original-ctx = ctx;
    let found = ta;
    let r = mk-fragment();
@@ -18,7 +18,7 @@ let .lookup(ctx: FContext, k: CString, kt: Type, sloc: AST, hard: U64): Fragment
       FCtxBind { remainder=remainder, ctx-k=k, ctx-kt=kt, ctx-kv=kv } => (
          if k==ctx-k {
             if ctx-kt.is-arrow and not(kt.is-t(c"Any",0)) {
-               if kt==ta || can-unify( ctx-kt.domain, kt ) || can-unify(ctx-kt.domain, kt.domain) {
+               if kt==ta or can-unify( ctx-kt.domain, kt ) or can-unify(ctx-kt.domain, kt.domain) {
                   if non-zero(found) {
                      if can-unify(found, ctx-kt.domain) {
                         r = ctx-kv;
@@ -38,11 +38,11 @@ let .lookup(ctx: FContext, k: CString, kt: Type, sloc: AST, hard: U64): Fragment
          } else { ctx = remainder; }
       );
    }};
-   if not(non-zero(found)) && hard {
+   if not(non-zero(found)) and hard {
       print("Context::lookup \{k} : \{kt}\nCandidates:\n");
       while non-zero(original-ctx) { match original-ctx {
-         FCtxBind { remainder=remainder, ctx-k=k, ctx-kt=kt } => (
-            if k==ctx-k { print("\{k} : \{ctx-kt}\n"); };
+         FCtxBind { remainder=remainder, ctx-k2=k, ctx-kt=kt } => (
+            if k==ctx-k2 { print("\{k} : \{ctx-kt}\n"); };
             original-ctx = remainder;
          );
       }};

--- a/LM23COMMON/backend-fragment-get.lsts
+++ b/LM23COMMON/backend-fragment-get.lsts
@@ -3,7 +3,7 @@ let .get(e: Fragment, k: CString): S = (
    let r = SNil();
    let found = false;
    for kv in open(e.keyvals) {
-      if not(found) && kv.first==k { r = kv.second; found = true; };
+      if not(found) and kv.first==k { r = kv.second; found = true; };
    };
    r
 );

--- a/LM23COMMON/backend-mk-fragment.lsts
+++ b/LM23COMMON/backend-mk-fragment.lsts
@@ -2,10 +2,10 @@
 let mk-fragment(): Fragment = (
    Fragment (
       mk-eof(), close([] : List<Tuple<CString,S>>),
-      ta, close(mk-fctx()), ([] : List<Fragment[]>)
+      ta, close(mk-fctx()), ([] : List<OwnedData<Fragment>[]>)
    )
 );
 
-let non-zero(f: Fragment): U64 = (
+let non-zero(f: Fragment): Bool = (
    non-zero(open(f.keyvals))
 );

--- a/LM23COMMON/index.lsts
+++ b/LM23COMMON/index.lsts
@@ -8,3 +8,5 @@ import LM23COMMON/unit-ascript-core.lsts;
 import LM23COMMON/unit-typecheck-core.lsts;
 import LM23COMMON/unit-backend-core.lsts;
 import LM23COMMON/unit-main-core.lsts;
+
+import PLUGINS/FRONTEND/LSTS/index.lsts;

--- a/LM23COMMON/typecheck-interface-index.lsts
+++ b/LM23COMMON/typecheck-interface-index.lsts
@@ -1,9 +1,9 @@
 
-let interface-index = {} : Hashtable<(CString,U64),U64>;
+let interface-index = {} : Hashtable<(CString,U64),Bool>;
 
 # TODO: remove this lookup
 # ((CString,U64),U64) needed to be reified, but the compiler should infer that
-interface-index.lookup((c"",0_u64),0_u64);
+interface-index.lookup((c"",0_u64),false);
 
 let interface-shape-index = {} : Hashtable<(CString,U64),List<(CString,Type,Type)>>;
 

--- a/LM23COMMON/unit-backend-core.lsts
+++ b/LM23COMMON/unit-backend-core.lsts
@@ -1,4 +1,6 @@
 
+import LM23COMMON/unit-typecheck-core.lsts;
+
 import LM23COMMON/backend-fragment-definition.lsts;
 import LM23COMMON/backend-mk-fragment.lsts;
 import LM23COMMON/backend-mk-expression.lsts;

--- a/LM23COMMON/unit-main-core.lsts
+++ b/LM23COMMON/unit-main-core.lsts
@@ -18,9 +18,9 @@ let print-toks-json(fp: CString): Nil = (
       print("{\n \"key\":\"");
       print(tok.key);
       print("\",\n \"line\": ");
-      print(tok.location.line);
+      print("\{tok.location.line}");
       print(",\n \"column\": ");
-      print(tok.location.column);
+      print("\{tok.location.column}");
       print("\n}");
    };
    print("]");
@@ -29,12 +29,12 @@ let print-toks-json(fp: CString): Nil = (
 let show-alloc-count = false;
 
 let main(argc: C_int, argv: CString[]): Nil = (
-   let argi = 1_u64;
+   let argi = 1_sz;
    let input = [] : List<CString>;
    let highlight = false;
    let dump-tokens = false;
    let has-args = false;
-   while argi < (argc as U64) {
+   while argi < (argc as USize) {
       has-args = true;
       match argv[argi] {
          c"--typecheck" => config-mode = ModeTypecheck();

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = clang
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	time lm tests/promises/lm-typecheck/direct-inference.lsts
+	time lm tests/promises/lm-main/main.lsts
 	gcc tmp.c
 	./a.out
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = clang
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	time lm tests/promises/lm-backend/backend.lsts
+	time lm tests/promises/lm-main/main.lsts
 	gcc tmp.c
 	./a.out
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = clang
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	time lm tests/promises/lm-main/main.lsts
+	time lm tests/promises/lm-backend/backend.lsts
 	gcc tmp.c
 	./a.out
 

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -1184,7 +1184,7 @@ let lsts-parse-small-expression(tokens: List<Token>): Tuple<AST,List<Token>> = (
          };
          let f = mk-nil();
          if lsts-parse-head(tokens)==c";" and lsts-parse-head(tail(tokens))==c"else" then tokens = tail(tokens);
-         if lsts-parse-head(tokens) == "else" {
+         if lsts-parse-head(tokens) == c"else" {
             lsts-parse-expect(c"else", tokens); tokens = tail(tokens);
             f = if lsts-parse-head(tokens) == c"{" {
                lsts-parse-expect(c"{", tokens); tokens = tail(tokens);
@@ -1406,7 +1406,7 @@ let lsts-parse-match2-lhs(tokens: List<Token>): Tuple<AST,List<Token>> = (
    };
    let prefixes = mk-vector(type(AST));
    let suffixes = mk-vector(type(AST));
-   let starti = 0_u64;
+   let starti = 0_sz;
    let endi = presufs.length - 1;
    while starti < endi and presufs[starti].is-constant or presufs[starti].is-assign-lit {
       prefixes = prefixes.push(presufs[starti]);
@@ -1424,7 +1424,7 @@ let lsts-parse-match2-lhs(tokens: List<Token>): Tuple<AST,List<Token>> = (
       lhs = mk-app(mk-var(c"macro::lhs-prefix"), mk-cons(p, lhs));
    };
    while suffixes.length > 0 {
-      (let p, suffixes) = suffixes.pop();
+      (let p, suffixes) = suffixes.pop-backwards-compatible();
       lhs = mk-app(mk-var(c"macro::lhs-suffix"), mk-cons(p, lhs));
    };
    if lsts-parse-head(tokens)==c"where" {
@@ -1522,7 +1522,7 @@ let lsts-parse-assign(tokens: List<Token>): Tuple<AST,List<Token>> = (
 
          let i = 0_u64;
          for lhs in lefts {
-            let fieldstr = c"." + to-string(i+1);
+            let fieldstr = c"." + (i+1).into(type(CString));
             let rexpr = mk-app(
                Var( fieldstr, with-location(mk-token(fieldstr),loc) ),
                rhs-tmp

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -8,7 +8,7 @@ let lsts-parse-head(tokens: List<Token>): CString = (
 
 let lsts-unwrap-identifier(ident: CString): CString = (
    if ident.has-prefix(c"$") {
-      ident.remove-prefix(c"$\"").remove-suffix(c"\"")
+      ident.remove-prefix(c"$\"").get-or(c"").remove-suffix(c"\"").get-or(c"")
    } else ident
 );
 
@@ -24,7 +24,7 @@ let lsts-parse-expect(expect: CString, tokens: List<Token>): Nil = (
    }; ();
 );
 
-let lsts-parse-expect(expect: CString, b: U64, tokens: List<Token>): Nil = (
+let lsts-parse-expect(expect: CString, b: Bool, tokens: List<Token>): Nil = (
    if not(b) {
       fail("Parse Error: Expected \{expect} at \{tokens.formatted-location}\n")
    }; ();
@@ -35,7 +35,7 @@ let lsts-parse-identifier(tokens: List<Token>): Tuple<CString, List<Token>> = (
    if lsts-parse-head(tokens)==c"." { name = c"."; tokens = tail(tokens); };
    lsts-parse-expect(c"Identifier", lsts-is-ident-head(lsts-parse-head(tokens)), tokens);
    name = name + lsts-unwrap-identifier(lsts-parse-head(tokens)); tokens = tail(tokens);
-   while lsts-parse-head(tokens)==c":" && lsts-parse-head(tail(tokens))==c":" && lsts-is-ident-head(lsts-parse-head(tail(tail(tokens)))) {
+   while lsts-parse-head(tokens)==c":" and lsts-parse-head(tail(tokens))==c":" and lsts-is-ident-head(lsts-parse-head(tail(tail(tokens)))) {
       name = name + c"::"; tokens = tail(tokens); tokens = tail(tokens);
       lsts-parse-expect(c"Identifier", lsts-is-ident-head(lsts-parse-head(tokens)), tokens);
       name = name + lsts-unwrap-identifier(lsts-parse-head(tokens)); tokens = tail(tokens);
@@ -55,8 +55,8 @@ let lsts-parse-doc-wordf(tokens: List<Token>, begin: CString, end: CString): Tup
       };
       let h = lsts-parse-head(tokens);
       while non-zero(h) {
-         text = text.push(head-string(h));
-         h = tail-string(h);
+         text = text.push(head(h));
+         h = tail(h);
       };
       tokens = tail(tokens);
    };
@@ -169,27 +169,27 @@ let lsts-has-assign(tokens: List<Token>): U64 = (
 
 let lsts-substitute-type-aliases(s: CString): CString = (
    if s.has-suffix(c"_ss") then untern(intern(s)[:-3_i64]) else
-   s.remove-suffix(c"_u64")
-    .remove-suffix(c"_u32")
-    .remove-suffix(c"_u16")
-    .remove-suffix(c"_u8")
-    .remove-suffix(c"_i64")
-    .remove-suffix(c"_i32")
-    .remove-suffix(c"_i16")
-    .remove-suffix(c"_i8")
+   s.remove-suffix(c"_u64").get-or(c"")
+    .remove-suffix(c"_u32").get-or(c"")
+    .remove-suffix(c"_u16").get-or(c"")
+    .remove-suffix(c"_u8").get-or(c"")
+    .remove-suffix(c"_i64").get-or(c"")
+    .remove-suffix(c"_i32").get-or(c"")
+    .remove-suffix(c"_i16").get-or(c"")
+    .remove-suffix(c"_i8").get-or(c"")
 );
 
-let lsts-is-type-tag(s: CString): U64 = (
+let lsts-is-type-tag(s: CString): Bool = (
       s.has-suffix(c"_ss")
-   || s.has-suffix(c"_u64")
-   || s.has-suffix(c"_u32")
-   || s.has-suffix(c"_u16")
-   || s.has-suffix(c"_u8")
-   || s.has-suffix(c"_i64")
-   || s.has-suffix(c"_i32")
-   || s.has-suffix(c"_i16")
-   || s.has-suffix(c"_i8")
-   || lsts-is-lit-head(s) 
+   or s.has-suffix(c"_u64")
+   or s.has-suffix(c"_u32")
+   or s.has-suffix(c"_u16")
+   or s.has-suffix(c"_u8")
+   or s.has-suffix(c"_i64")
+   or s.has-suffix(c"_i32")
+   or s.has-suffix(c"_i16")
+   or s.has-suffix(c"_i8")
+   or lsts-is-lit-head(s) 
 );
 
 let lsts-parse(tokens: List<Token>): Nil = (
@@ -223,7 +223,7 @@ let lsts-parse(tokens: List<Token>): Nil = (
          [ Token{key:c"import"}.. rest] => (
             tokens = rest;
             let path = SNil();
-            while non-zero(tokens) && lsts-parse-head(tokens) != c";" {
+            while non-zero(tokens) and lsts-parse-head(tokens) != c";" {
                path = path + SAtom ( lsts-unwrap-identifier(lsts-parse-head(tokens)) );
                tokens = tail(tokens);
             };
@@ -287,9 +287,9 @@ let lsts-parse-typed-macro(tokens: List<Token>): (AST, List<Token>) = (
 
 let lsts-parse-type(tokens: List<Token>): Tuple<Type,List<Token>> = (
    (let base-type, tokens) = lsts-parse-type-conjugate(tokens);
-   while (lsts-parse-head(tokens)==c"-" && lsts-parse-head(tail(tokens))==c">") ||
-         (lsts-parse-head(tokens)==c"~" && lsts-parse-head(tail(tokens))==c">") {
-      if lsts-parse-head(tokens)==c"-" && lsts-parse-head(tail(tokens))==c">" {
+   while (lsts-parse-head(tokens)==c"-" and lsts-parse-head(tail(tokens))==c">") or
+         (lsts-parse-head(tokens)==c"~" and lsts-parse-head(tail(tokens))==c">") {
+      if lsts-parse-head(tokens)==c"-" and lsts-parse-head(tail(tokens))==c">" {
          lsts-parse-expect(c"-", tokens); tokens = tail(tokens);
          lsts-parse-expect(c">", tokens); tokens = tail(tokens);
          (let tail-type, tokens) = lsts-parse-type-conjugate(tokens);
@@ -324,11 +324,11 @@ let lsts-parse-type-conjugate(tokens: List<Token>): Tuple<Type,List<Token>> = (
    } else if lsts-parse-head(tokens)==c"_" {
       lsts-parse-expect(c"_", tokens); tokens = tail(tokens);
       ta
-   } else if lsts-parse-head(tokens).has-prefix(c"'") && not(lsts-parse-head(tokens).has-suffix(c"'")) {
+   } else if lsts-parse-head(tokens).has-prefix(c"'") and not(lsts-parse-head(tokens).has-suffix(c"'")) {
       let new-tt = t1(c"Linear",t0(c"Phi::Live"));
       tokens = tail(tokens);
       new-tt
-   } else if lsts-is-ident-head(lsts-parse-head(tokens)) && not(lsts-is-type-tag(lsts-parse-head(tokens))) {
+   } else if lsts-is-ident-head(lsts-parse-head(tokens)) and not(lsts-is-type-tag(lsts-parse-head(tokens))) {
       (let varname, tokens) = lsts-parse-identifier(tokens);
       TVar ( varname )
    } else {
@@ -337,11 +337,11 @@ let lsts-parse-type-conjugate(tokens: List<Token>): Tuple<Type,List<Token>> = (
       };
       let base = lsts-substitute-type-aliases(lsts-parse-head(tokens)); tokens = tail(tokens);
       if not(config-v3) and base==c"Hashtable" then base = c"HashtableEq";
-      while non-zero(tokens) && lsts-parse-head(tokens)==c":" && lsts-parse-head(tail(tokens))==c":" {
+      while non-zero(tokens) and lsts-parse-head(tokens)==c":" and lsts-parse-head(tail(tokens))==c":" {
          lsts-parse-expect(c":", tokens); tokens = tail(tokens);
          lsts-parse-expect(c":", tokens); tokens = tail(tokens);
          lsts-parse-expect(c"Type", non-zero(tokens), tokens);
-         if not(lsts-is-type-tag(lsts-parse-head(tokens))) && not(lsts-is-ident-head(lsts-parse-head(tokens))) {
+         if not(lsts-is-type-tag(lsts-parse-head(tokens))) and not(lsts-is-ident-head(lsts-parse-head(tokens))) {
             lsts-parse-expect(c"[Type Tag or Variable]", tokens);
          };
          base = base + c"::" + lsts-substitute-type-aliases(lsts-parse-head(tokens));
@@ -365,7 +365,7 @@ let lsts-parse-type-conjugate(tokens: List<Token>): Tuple<Type,List<Token>> = (
          head(args);
       } else TGround ( base, close(args) );
    };
-   while lsts-parse-head(tokens) == c"[" || lsts-parse-head(tokens)==c"?" {
+   while lsts-parse-head(tokens) == c"[" or lsts-parse-head(tokens)==c"?" {
       if lsts-parse-head(tokens)==c"[" {
          lsts-parse-expect(c"[", tokens); tokens = tail(tokens);
          let index = if lsts-parse-head(tokens) != c"]" {
@@ -418,7 +418,7 @@ let lsts-parse-expression(tokens: List<Token>): Tuple<AST,List<Token>> = (
    tokens = base-rest.second;
    while lsts-parse-head(tokens) == c";" {
       tokens = tail(tokens);
-      if lsts-parse-head(tokens)!=c")" && lsts-parse-head(tokens)!=c"}" {
+      if lsts-parse-head(tokens)!=c")" and lsts-parse-head(tokens)!=c"}" {
          base-rest = lsts-parse-small-expression(tokens);
          base = mk-cons(base, base-rest.first);
          tokens = base-rest.second;
@@ -439,7 +439,7 @@ let lsts-parse-lhs-list(tokens: List<Token>): Tuple<AST,List<Token>> = (
       base = base-rest.first;
       tokens = base-rest.second;
       let bases = [base];
-      while non-zero(tokens) && lsts-parse-head(tokens)==c"." {
+      while non-zero(tokens) and lsts-parse-head(tokens)==c"." {
          lsts-parse-expect(c".", tokens); tokens = tail(tokens);
          lsts-parse-expect(c".", tokens); tokens = tail(tokens);
          if lsts-parse-head(tokens)==c"]" {
@@ -483,7 +483,7 @@ let lsts-parse-lhs(tokens: List<Token>): Tuple<AST,List<Token>> = (
          base-rest.first;         
       );
    };
-   while non-zero(tokens) && (lsts-parse-head(tokens)==c"." || lsts-parse-head(tokens)=="[") {
+   while non-zero(tokens) and (lsts-parse-head(tokens)==c"." or lsts-parse-head(tokens)=="[") {
       match tokens {
          [Token{key:c"."}.. Token{key:c"."}.. rest] => (
             let loc = head(tokens).location;
@@ -541,10 +541,10 @@ let lsts-make-maybe-var(tokens: List<Token>): Tuple<AST,List<Token>> = (
    }
 );
 
-let lsts-is-lit(s: CString): U64 = (
-   let r = 0_u64;
+let lsts-is-lit(s: CString): Bool = (
+   let r = false;
    for Tuple { sfxs=first } in parse-suffixes {
-      r = r || s.has-suffix(sfxs);
+      r = r or s.has-suffix(sfxs);
    }; r;
 );
 
@@ -552,7 +552,7 @@ let lsts-parse-add(tokens: List<Token>): Tuple<AST,List<Token>> = (
    let term-rest = lsts-parse-mul(tokens);
    let term = term-rest.first;
    tokens = term-rest.second;
-   while lsts-parse-head(tokens)==c"+" || lsts-parse-head(tokens)==c"-" {
+   while lsts-parse-head(tokens)==c"+" or lsts-parse-head(tokens)==c"-" {
       let op-t = head(tokens); let op = op-t.key; tokens = tail(tokens);
       let term2-rest = lsts-parse-mul(tokens);
       tokens = term2-rest.second;
@@ -568,7 +568,7 @@ let lsts-parse-bitwise(tokens: List<Token>): Tuple<AST,List<Token>> = (
    let term-rest = lsts-parse-add(tokens);
    let term = term-rest.first;
    tokens = term-rest.second;
-   while lsts-parse-head(tokens)==c"&" || lsts-parse-head(tokens)==c"|" || lsts-parse-head(tokens)==c"^" {
+   while lsts-parse-head(tokens)==c"&" or lsts-parse-head(tokens)==c"|" or lsts-parse-head(tokens)==c"^" {
       let op-t = head(tokens); let op = op-t.key; tokens = tail(tokens);
       let term2-rest = lsts-parse-add(tokens);
       tokens = term2-rest.second;
@@ -584,13 +584,13 @@ let lsts-parse-cmp(tokens: List<Token>): Tuple<AST,List<Token>> = (
    let term-rest = lsts-parse-bitwise(tokens);
    let term = term-rest.first;
    tokens = term-rest.second;
-   while lsts-parse-head(tokens)==c"==" || lsts-parse-head(tokens)==c"!=" ||
-         lsts-parse-head(tokens)==c"<" || lsts-parse-head(tokens)==c"<=" ||
-         lsts-parse-head(tokens)==c">" || lsts-parse-head(tokens)==c">=" ||
+   while lsts-parse-head(tokens)==c"==" or lsts-parse-head(tokens)==c"!=" or
+         lsts-parse-head(tokens)==c"<" or lsts-parse-head(tokens)==c"<=" or
+         lsts-parse-head(tokens)==c">" or lsts-parse-head(tokens)==c">=" or
          lsts-parse-head(tokens)==c"<:" {
       let op-t = head(tokens); let op = op-t.key; tokens = tail(tokens);
-      if (op==c"<" && lsts-parse-head(tokens)==c"<") ||
-         (op==c">" && lsts-parse-head(tokens)==c">") {
+      if (op==c"<" and lsts-parse-head(tokens)==c"<") or
+         (op==c">" and lsts-parse-head(tokens)==c">") {
          op = op + op; op-t = with-key(op-t, op); tokens = tail(tokens);
       };
       let term2-rest = lsts-parse-bitwise(tokens);
@@ -605,7 +605,7 @@ let lsts-parse-cmp(tokens: List<Token>): Tuple<AST,List<Token>> = (
 
 let lsts-parse-ascript(tokens: List<Token>): Tuple<AST,List<Token>> = (
    (let term, tokens) = lsts-parse-andor(tokens);
-   while lsts-parse-head(tokens)==c":" && non-zero(tokens) && lsts-parse-head(tail(tokens)) != c":" {
+   while lsts-parse-head(tokens)==c":" and non-zero(tokens) and lsts-parse-head(tail(tokens)) != c":" {
       tokens = tail(tokens);
       (let tt, tokens) = lsts-parse-type(tokens);
       if tt.is-t(c"L",0) then tt = tt && t0(c"Literal");
@@ -624,8 +624,8 @@ let lsts-parse-andor(tokens: List<Token>): Tuple<AST,List<Token>> = (
    let term-rest = lsts-parse-cmp(tokens);
    let term = term-rest.first;
    tokens = term-rest.second;
-   while lsts-parse-head(tokens)==c"&&" || lsts-parse-head(tokens)==c"||"
-      || lsts-parse-head(tokens)==c"and" || lsts-parse-head(tokens)==c"or" || lsts-parse-head(tokens)==c"xor" {
+   while lsts-parse-head(tokens)==c"&&" or lsts-parse-head(tokens)==c"||"
+      or lsts-parse-head(tokens)==c"and" or lsts-parse-head(tokens)==c"or" or lsts-parse-head(tokens)==c"xor" {
       let op-t = head(tokens); let op = op-t.key; tokens = tail(tokens);
       let term2-rest = lsts-parse-cmp(tokens);
       tokens = term2-rest.second;
@@ -641,7 +641,7 @@ let lsts-parse-mul(tokens: List<Token>): Tuple<AST,List<Token>> = (
    let term-rest = lsts-parse-atom(tokens);
    let term = term-rest.first;
    tokens = term-rest.second;
-   while lsts-parse-head(tokens)==c"*" || lsts-parse-head(tokens)==c"/" || lsts-parse-head(tokens)==c"%" {
+   while lsts-parse-head(tokens)==c"*" or lsts-parse-head(tokens)==c"/" or lsts-parse-head(tokens)==c"%" {
       let op-t = head(tokens); let op = op-t.key; tokens = tail(tokens);
       let term2-rest = lsts-parse-atom(tokens);
       tokens = term2-rest.second;
@@ -662,11 +662,11 @@ let lsts-parse-map(tokens: List<Token>): Tuple<AST,List<Token>> = (
       fail("TODO map comprehension at \{loc}\n")
    } else {
       if lsts-parse-head(tokens) != c"}" {
-         while non-zero(tokens) && lsts-parse-head(tokens)!=c"}" {
+         while non-zero(tokens) and lsts-parse-head(tokens)!=c"}" {
             let item-rest = lsts-parse-andor(tokens);
             let item = item-rest.first;
             tokens = item-rest.second;
-            let mapped = if non-zero(tokens) && lsts-parse-head(tokens)==c":" {
+            let mapped = if non-zero(tokens) and lsts-parse-head(tokens)==c":" {
                lsts-parse-expect(c":", tokens); tokens = tail(tokens);
                let mapped-rest = lsts-parse-expression(tokens);
                tokens = mapped-rest.second;
@@ -678,7 +678,7 @@ let lsts-parse-map(tokens: List<Token>): Tuple<AST,List<Token>> = (
                Var( c"map::cons", with-location(mk-token("map::cons"),loc) ),
                mk-cons(mk-cons(item, mapped), term)
             );
-            if non-zero(tokens) && lsts-parse-head(tokens)!=c"}" {
+            if non-zero(tokens) and lsts-parse-head(tokens)!=c"}" {
                lsts-parse-expect(c",", tokens); tokens = tail(tokens);
             }
          };
@@ -714,11 +714,11 @@ let lsts-parse-list(tokens: List<Token>): Tuple<AST,List<Token>> = (
    } else {
       if lsts-parse-head(tokens)!=c"]" {
          let add-items = [] : List<AST>;
-         while non-zero(tokens) && lsts-parse-head(tokens)!=c"]" {
+         while non-zero(tokens) and lsts-parse-head(tokens)!=c"]" {
             let item-rest = lsts-parse-expression(tokens);
             tokens = item-rest.second;
             add-items = cons( item-rest.first, add-items );
-            if non-zero(tokens) && lsts-parse-head(tokens)!=c"]" {
+            if non-zero(tokens) and lsts-parse-head(tokens)!=c"]" {
                lsts-parse-expect(c",", tokens); tokens = tail(tokens);
             }
          };
@@ -753,7 +753,7 @@ let lsts-parse-interface(tokens: List<Token>): List<Token> = (
    while lsts-parse-head(tokens) == c"let" {
       lsts-parse-expect(c"let", tokens); let loc = head(tokens).location; tokens = tail(tokens);
 
-      lsts-parse-expect(c"Identifier", lsts-is-ident-head(lsts-parse-head(tokens)) || lsts-parse-head(tokens)==c".", tokens);
+      lsts-parse-expect(c"Identifier", lsts-is-ident-head(lsts-parse-head(tokens)) or lsts-parse-head(tokens)==c".", tokens);
       let name = lsts-unwrap-identifier(lsts-parse-head(tokens)); tokens = tail(tokens);
       if name == c"." {
          lsts-parse-expect(c"Identifier", lsts-is-ident-head(lsts-parse-head(tokens)), tokens);
@@ -802,14 +802,14 @@ let lsts-parse-typedef(tokens: List<Token>): (AST, List<Token>) = (
       lsts-parse-expect(c"phi", tokens); tokens = tail(tokens);
       misc-type = misc-type && t0(c"Phi");
    };
-   lsts-parse-expect(c"[Typename]", lsts-is-enum-head(lsts-parse-head(tokens)) || lsts-parse-head(tokens).has-suffix(c"_ss"), tokens);
+   lsts-parse-expect(c"[Typename]", lsts-is-enum-head(lsts-parse-head(tokens)) or lsts-parse-head(tokens).has-suffix(c"_ss"), tokens);
    let typename = lsts-parse-head(tokens); tokens = tail(tokens);
-   if typename.has-suffix(c"_ss") then typename = typename.remove-suffix(c"_ss");
+   if typename.has-suffix(c"_ss") then typename = typename.remove-suffix(c"_ss").get-or(c"");
    let lhs-type = if lsts-parse-head(tokens)==c"<" {
       let pars = [] : List<Type>;
       lsts-parse-expect(c"<", tokens); tokens = tail(tokens);
       let pt = ta;
-      if lsts-is-enum-head(lsts-parse-head(tokens)) || lsts-parse-head(tokens).has-suffix(c"_ss") {
+      if lsts-is-enum-head(lsts-parse-head(tokens)) or lsts-parse-head(tokens).has-suffix(c"_ss") {
          pt = tv(uuid());
          (let vt, tokens) = lsts-parse-type(tokens);
          pt = pt && vt;
@@ -825,7 +825,7 @@ let lsts-parse-typedef(tokens: List<Token>): (AST, List<Token>) = (
       pars = cons(pt, pars);
       while lsts-parse-head(tokens)==c"," {
          lsts-parse-expect(c",", tokens); tokens = tail(tokens);
-         if lsts-is-enum-head(lsts-parse-head(tokens)) || lsts-parse-head(tokens).has-suffix(c"_ss") {
+         if lsts-is-enum-head(lsts-parse-head(tokens)) or lsts-parse-head(tokens).has-suffix(c"_ss") {
             pt = tv(uuid());
             (let vt, tokens) = lsts-parse-type(tokens);
             pt = pt && vt;
@@ -847,11 +847,11 @@ let lsts-parse-typedef(tokens: List<Token>): (AST, List<Token>) = (
    let impls = mk-vector(type(Type));
    let size = ta;
    let implied-phi = ta;
-   while lsts-parse-head(tokens)==c":" || lsts-parse-head(tokens)==c"implies"
-      || lsts-parse-head(tokens)==c"implements" || lsts-parse-head(tokens)==c"size"
-      || lsts-parse-head(tokens)==c"suffix" || lsts-parse-head(tokens)==c"zero"
-      || (lsts-parse-head(tokens)==c"implied" && lsts-parse-head(tail(tokens))==c"phi") {
-      if (lsts-parse-head(tokens)==c"implied" && lsts-parse-head(tail(tokens))==c"phi") {
+   while lsts-parse-head(tokens)==c":" or lsts-parse-head(tokens)==c"implies"
+      or lsts-parse-head(tokens)==c"implements" or lsts-parse-head(tokens)==c"size"
+      or lsts-parse-head(tokens)==c"suffix" or lsts-parse-head(tokens)==c"zero"
+      or (lsts-parse-head(tokens)==c"implied" and lsts-parse-head(tail(tokens))==c"phi") {
+      if (lsts-parse-head(tokens)==c"implied" and lsts-parse-head(tail(tokens))==c"phi") {
          lsts-parse-expect(c"implied", tokens); tokens = tail(tokens);
          lsts-parse-expect(c"phi", tokens); tokens = tail(tokens);
          (let mt, tokens) = lsts-parse-type(tokens);
@@ -871,7 +871,7 @@ let lsts-parse-typedef(tokens: List<Token>): (AST, List<Token>) = (
       };
       if lsts-parse-head(tokens)==c"zero" {
          lsts-parse-expect(c"zero", tokens); tokens = tail(tokens);
-         if not(non-zero(tokens)) || not(lsts-is-lit-head(lsts-parse-head(tokens))) {
+         if not(non-zero(tokens)) or not(lsts-is-lit-head(lsts-parse-head(tokens))) {
             lsts-parse-expect(c"[Type Constructor]", tokens);
          };
          let constructor = head(tokens); tokens = tail(tokens);
@@ -889,10 +889,10 @@ let lsts-parse-typedef(tokens: List<Token>): (AST, List<Token>) = (
       if lsts-parse-head(tokens)==c"size" {
          lsts-parse-expect(c"size", tokens); tokens = tail(tokens);
          lsts-parse-expect(c"[Size]", lsts-parse-head(tokens).has-suffix(c"_B")
-                                   || lsts-parse-head(tokens).has-suffix(c"_b"), tokens);
+                                   or lsts-parse-head(tokens).has-suffix(c"_b"), tokens);
          let sz = lsts-parse-head(tokens); tokens = tail(tokens);
-         if sz.has-suffix(c"_B") then size = t1(c"Bytes", t0(sz.remove-suffix(c"_B")))
-                                 else size = t1(c"Bits", t0(sz.remove-suffix(c"_b")));
+         if sz.has-suffix(c"_B") then size = t1(c"Bytes", t0(sz.remove-suffix(c"_B").get-or(c"")))
+                                 else size = t1(c"Bits", t0(sz.remove-suffix(c"_b").get-or(c"")));
       };
       if lsts-parse-head(tokens)==c"implements" {
          lsts-parse-expect(c"implements", tokens); tokens = tail(tokens);
@@ -918,7 +918,7 @@ let lsts-parse-typedef(tokens: List<Token>): (AST, List<Token>) = (
       };
    };
    for i in infers {
-      if i.is-t(c"MustRelease",0) && not(implied-phi.slot(c"MustRelease::ToRelease",1).l1.is-t(c"Linear",1))
+      if i.is-t(c"MustRelease",0) and not(implied-phi.slot(c"MustRelease::ToRelease",1).l1.is-t(c"Linear",1))
       then {
          let mt = t1(c"MustRelease::ToRelease",t1(c"Linear",t0(c"Phi::Live")));
          implied-phi = implied-phi && mt;
@@ -994,7 +994,7 @@ let lsts-parse-function-signature(fname: CString, tokens: List<Token>, loc: Sour
 
    lsts-parse-expect(c"(", tokens); tokens = tail(tokens);
    out.args-type = t0(c"Nil");
-   while non-zero(tokens) && lsts-parse-head(tokens)!=c")" {
+   while non-zero(tokens) and lsts-parse-head(tokens)!=c")" {
       lsts-parse-expect(c"Identifier", lsts-is-ident-head(lsts-parse-head(tokens)), tokens);
       let arg-name = head(tokens); tokens = tail(tokens);
       let had-type = false;
@@ -1045,7 +1045,7 @@ let lsts-parse-let(tokens: List<Token>): (AST, List<Token>) = (
       lsts-parse-expect(c":", tokens); tokens = tail(tokens);
       (misc-tt, tokens) = lsts-parse-type(tokens);
    };
-   lsts-parse-expect(c"Identifier", lsts-is-ident-head(lsts-parse-head(tokens)) || lsts-parse-head(tokens)==c".", tokens);
+   lsts-parse-expect(c"Identifier", lsts-is-ident-head(lsts-parse-head(tokens)) or lsts-parse-head(tokens)==c".", tokens);
    let name = lsts-unwrap-identifier(lsts-parse-head(tokens)); tokens = tail(tokens);
    if name == c"." {
       lsts-parse-expect(c"Identifier", lsts-is-ident-head(lsts-parse-head(tokens)), tokens);
@@ -1127,7 +1127,7 @@ let lsts-parse-small-expression(tokens: List<Token>): Tuple<AST,List<Token>> = (
                matched-rest;
             }
          };
-         if lsts-parse-head(tokens)==c";" && lsts-parse-head(tail(tokens))==c"else" then tokens = tail(tokens);
+         if lsts-parse-head(tokens)==c";" and lsts-parse-head(tail(tokens))==c"else" then tokens = tail(tokens);
          let default-rest = if lsts-parse-head(tokens) == c"else" {
             lsts-parse-expect(c"else", tokens); tokens = tail(tokens);
             if lsts-parse-head(tokens) == c"{" {
@@ -1183,7 +1183,7 @@ let lsts-parse-small-expression(tokens: List<Token>): Tuple<AST,List<Token>> = (
             t-rest.first;
          };
          let f = mk-nil();
-         if lsts-parse-head(tokens)==c";" && lsts-parse-head(tail(tokens))==c"else" then tokens = tail(tokens);
+         if lsts-parse-head(tokens)==c";" and lsts-parse-head(tail(tokens))==c"else" then tokens = tail(tokens);
          if lsts-parse-head(tokens) == "else" {
             lsts-parse-expect(c"else", tokens); tokens = tail(tokens);
             f = if lsts-parse-head(tokens) == c"{" {
@@ -1246,9 +1246,9 @@ let lsts-parse-match2-lhs-one(tokens: List<Token>): Tuple<AST,List<Token>> = (
       lsts-parse-expect(c"[", tokens); tokens = tail(tokens);
       expr = mk-app(mk-var(c"macro::lhs-tail").with-location(loc), mk-nil());
       let seq = [] : List<AST>;
-      while non-zero(tokens) && lsts-parse-head(tokens)!=c"]" {
+      while non-zero(tokens) and lsts-parse-head(tokens)!=c"]" {
          (let head, tokens) = lsts-parse-match2-lhs-one-bind(tokens);
-         if lsts-parse-head(tokens)==c"." && lsts-parse-head(tail(tokens))==c"." {
+         if lsts-parse-head(tokens)==c"." and lsts-parse-head(tail(tokens))==c"." {
             lsts-parse-expect(c".", tokens); tokens = tail(tokens);
             lsts-parse-expect(c".", tokens); tokens = tail(tokens);
             seq = cons(head, seq);
@@ -1274,13 +1274,13 @@ let lsts-parse-match2-lhs-one(tokens: List<Token>): Tuple<AST,List<Token>> = (
       expr = mk-app( mk-var(c"uuid").with-location(loc), mk-var(name).with-location(loc) );
    } else if lsts-parse-head(tokens).is-lsts-constant {
       expr = lsts-make-lit(head(tokens)); tokens = tail(tokens);
-   } else if lsts-is-enum-head(lsts-parse-head(tokens)) || (lsts-parse-head(tokens)==c"_" && lsts-parse-head(tail(tokens))==c"{") {
+   } else if lsts-is-enum-head(lsts-parse-head(tokens)) or (lsts-parse-head(tokens)==c"_" and lsts-parse-head(tail(tokens))==c"{") {
       let loc = head(tokens).location;
       let tag = lsts-parse-head(tokens); tokens = tail(tokens);
       let suffix-condition = mk-var(c"_").with-location(loc);
       if lsts-parse-head(tokens)==c"{" {
          lsts-parse-expect(c"{", tokens); tokens = tail(tokens);
-         while non-zero(tokens) && lsts-parse-head(tokens)!=c"}" {
+         while non-zero(tokens) and lsts-parse-head(tokens)!=c"}" {
             let mode = c"macro::let-name";
             if lsts-parse-head(tokens)==c"set" { mode = c"macro::set-name"; tokens = tail(tokens) }
             else if lsts-parse-head(tokens)==c"let" { mode = c"macro::let-name"; tokens = tail(tokens) };
@@ -1358,7 +1358,7 @@ let lsts-parse-match2-lhs-one-bind(tokens: List<Token>): Tuple<AST,List<Token>> 
    }
 );
 
-let .is-assign-lit(t: AST): U64 = (
+let .is-assign-lit(t: AST): Bool = (
    match t {
       App{ left:Var{key:c"macro::let-bind"} } => true;
       App{ left:Var{key:c"macro::set-bind"} } => true;
@@ -1366,21 +1366,21 @@ let .is-assign-lit(t: AST): U64 = (
    }
 );
 
-let .is-lsts-constant(key: CString): U64 = (
+let .is-lsts-constant(key: CString): Bool = (
       key.has-suffix(c"_ss")
-   || key.has-suffix(c"_s")
-   || key.has-suffix(c"_rgx")
-   || key.has-suffix(c"_u8")
-   || key.has-suffix(c"_u16")
-   || key.has-suffix(c"_u32")
-   || key.has-suffix(c"_u64")
-   || key.has-suffix(c"_i8")
-   || key.has-suffix(c"_i16")
-   || key.has-suffix(c"_i32")
-   || key.has-suffix(c"_i64");
+   or key.has-suffix(c"_s")
+   or key.has-suffix(c"_rgx")
+   or key.has-suffix(c"_u8")
+   or key.has-suffix(c"_u16")
+   or key.has-suffix(c"_u32")
+   or key.has-suffix(c"_u64")
+   or key.has-suffix(c"_i8")
+   or key.has-suffix(c"_i16")
+   or key.has-suffix(c"_i32")
+   or key.has-suffix(c"_i64");
 );
 
-let .is-constant(t: AST): U64 = (
+let .is-constant(t: AST): Bool = (
    match t {
       App{ left:Lit{key:c":"}, right:App{ left:Lit{}, right:AType{} } } => true;
       Lit{key=key} => key.is-lsts-constant;
@@ -1398,7 +1398,7 @@ let lsts-parse-match2-lhs(tokens: List<Token>): Tuple<AST,List<Token>> = (
    let original-tokens = tokens;
    (let lhs, tokens) = lsts-parse-match2-lhs-one-bind(tokens);
    let presufs = mk-vector(type(AST)).push(lhs);
-   while lsts-parse-head(tokens)==c"." && lsts-parse-head(tail(tokens))==c"." {
+   while lsts-parse-head(tokens)==c"." and lsts-parse-head(tail(tokens))==c"." {
       lsts-parse-expect(c".", tokens); tokens = tail(tokens);
       lsts-parse-expect(c".", tokens); tokens = tail(tokens);
       (lhs, tokens) = lsts-parse-match2-lhs-one-bind(tokens);
@@ -1408,11 +1408,11 @@ let lsts-parse-match2-lhs(tokens: List<Token>): Tuple<AST,List<Token>> = (
    let suffixes = mk-vector(type(AST));
    let starti = 0_u64;
    let endi = presufs.length - 1;
-   while starti < endi && presufs[starti].is-constant || presufs[starti].is-assign-lit {
+   while starti < endi and presufs[starti].is-constant or presufs[starti].is-assign-lit {
       prefixes = prefixes.push(presufs[starti]);
       starti = starti + 1;
    };
-   while starti < endi &&  presufs[endi].is-constant || presufs[endi].is-assign-lit {
+   while starti < endi and  presufs[endi].is-constant or presufs[endi].is-assign-lit {
       suffixes = suffixes.push(presufs[endi]);
       endi = endi - 1;
    };
@@ -1447,7 +1447,7 @@ let lsts-parse-match2(tokens: List<Token>): Tuple<AST,List<Token>> = (
    ));
    lsts-parse-expect(c"{", tokens); tokens = tail(tokens);
    let cases = [] : List<(AST,AST)>;
-   while non-zero(tokens) && lsts-parse-head(tokens)!=c"}" {
+   while non-zero(tokens) and lsts-parse-head(tokens)!=c"}" {
       (let lhs, tokens) = lsts-parse-match2-lhs(tokens);
       lsts-parse-expect(c"=", tokens); tokens = tail(tokens);
       lsts-parse-expect(c">", tokens); tokens = tail(tokens);
@@ -1574,11 +1574,11 @@ let lsts-parse-assign(tokens: List<Token>): Tuple<AST,List<Token>> = (
 let lsts-make-lit(t: Token): AST = (
    let loc = t.location;
    let base = Lit ( t.key, t );
-   if t.key.has-suffix(c"_ss") && t.key.contains(c"\\{") {
+   if t.key.has-suffix(c"_ss") and t.key.contains(c"\\{") {
       let s = t.key;
       base = mk-eof();
       let buffer = SNil();
-      while non-zero(s) && s != c"_ss" {
+      while non-zero(s) and s != c"_ss" {
          if s.has-prefix(c"\\{") {
             if non-zero(buffer) {
                let be = mk-lit(with-location(mk-token(clone-rope(buffer)),loc)).ascript(t0(c"String") && t0(c"Literal"));
@@ -1591,14 +1591,14 @@ let lsts-make-lit(t: Token): AST = (
                buffer = SNil();
             };
 
-            s = s.remove-prefix(c"\\{");
+            s = s.remove-prefix(c"\\{").get-or(c"");
             let t-buffer = SNil();
-            while non-zero(s) && not(s.has-prefix(c"}")) {
-               t-buffer = t-buffer + SAtom(clone-rope(head-string(s)));
-               s = tail-string(s);
+            while non-zero(s) and not(s.has-prefix(c"}")) {
+               t-buffer = t-buffer + SAtom(clone-rope(head(s)));
+               s = tail(s);
             };
-            if non-zero(s) && s.has-prefix(c"}") {
-               s = tail-string(s);
+            if non-zero(s) and s.has-prefix(c"}") {
+               s = tail(s);
             };
             let sub-tokens = lsts-tokenize-string(c"[Format String]", clone-rope(t-buffer));
             let se-rest = lsts-parse-expression(sub-tokens);
@@ -1621,8 +1621,8 @@ let lsts-make-lit(t: Token): AST = (
                lsts-parse-expect(c"[EOF]", se-rest.second);
             }
          } else {
-            buffer = buffer + SAtom (clone-rope(head-string(s)));
-            s = tail-string(s);
+            buffer = buffer + SAtom (clone-rope(head(s)));
+            s = tail(s);
          }
       };
       if non-zero(buffer) {
@@ -1637,7 +1637,7 @@ let lsts-make-lit(t: Token): AST = (
          };
       };
    } else if t.key.has-suffix(c"_ss") {
-      base = mk-lit(t.key.remove-suffix(c"_ss")).with-location(loc).ascript(t0(c"String") && t0(c"Literal"));
+      base = mk-lit(t.key.remove-suffix(c"_ss").get-or(c"")).with-location(loc).ascript(t0(c"String") && t0(c"Literal"));
    };
    base
 );
@@ -1666,16 +1666,16 @@ let lsts-parse-lhs-one(tokens: List<Token>): Tuple<AST,List<Token>> = (
       let base-rest = lsts-parse-lit(tokens);
       tokens = base-rest.second;
       base-rest.first;
-   } else if non-zero(tokens) && lsts-parse-head(tokens)==c"[" {
+   } else if non-zero(tokens) and lsts-parse-head(tokens)==c"[" {
       let base-rest = lsts-parse-lhs-list(tokens);
       tokens = base-rest.second;
       base-rest.first; 
-   } else if non-zero(tokens) && lsts-parse-head(tail(tokens))==c"{" {
+   } else if non-zero(tokens) and lsts-parse-head(tail(tokens))==c"{" {
       let loc = head(tokens).location;
       let tag = lsts-parse-head(tokens); tokens = tail(tokens);
       lsts-parse-expect(c"{", tokens); tokens = tail(tokens);
       let des-args = mk-eof();
-      while non-zero(tokens) && lsts-parse-head(tokens)!=c"}" {
+      while non-zero(tokens) and lsts-parse-head(tokens)!=c"}" {
          let attr-loc = head(tokens).location;
          let binding = c"";
          let attr-key = c"";
@@ -1701,7 +1701,7 @@ let lsts-parse-lhs-one(tokens: List<Token>): Tuple<AST,List<Token>> = (
             tokens = val-rest.second;
             val-rest.first;
          } else { mk-eof() };
-         if not(non-zero(val)) && not(non-zero(binding)) && not(non-zero(attr-key)) {
+         if not(non-zero(val)) and not(non-zero(binding)) and not(non-zero(attr-key)) {
             lsts-parse-expect(c"[Struct LHS]", tokens); tokens = tail(tokens);
          };
          if not(non-zero(val)) {
@@ -1877,7 +1877,7 @@ let lsts-parse-atom-without-tail(tokens: List<Token>): Tuple<AST,List<Token>> = 
       };
       let pats = mk-nil();
       lsts-parse-expect(c"{", tokens); tokens = tail(tokens);
-      while non-zero(tokens) && lsts-parse-head(tokens)!=c"}" {
+      while non-zero(tokens) and lsts-parse-head(tokens)!=c"}" {
          let lhs-rest = lsts-parse-lhs(tokens);
          tokens = lhs-rest.second;
          lsts-parse-expect(c"=", tokens); tokens = tail(tokens);
@@ -1901,7 +1901,7 @@ let lsts-parse-atom-without-tail(tokens: List<Token>): Tuple<AST,List<Token>> = 
    } else if lsts-parse-head(tokens).has-suffix(c"_ss") {
       (term, tokens) = lsts-parse-lit(tokens);
    } else if lsts-parse-head(tokens).has-suffix(c"_rl") {
-      term = mk-lit(lsts-parse-head(tokens).remove-suffix(c"_rl"));
+      term = mk-lit(lsts-parse-head(tokens).remove-suffix(c"_rl").get-or(c""));
       tokens = tail(tokens);
    } else if lsts-parse-head(tokens)==c"unsafe" {
       let loc = head(tokens).location;
@@ -1962,7 +1962,7 @@ let lsts-parse-atom-without-tail(tokens: List<Token>): Tuple<AST,List<Token>> = 
       let term-rest = lsts-make-maybe-var(tokens);
       tokens = term-rest.second;
       term = term-rest.first;
-   } else if lsts-parse-head(tokens)==c"." && lsts-is-ident-head(lsts-parse-head(tail(tokens))) {
+   } else if lsts-parse-head(tokens)==c"." and lsts-is-ident-head(lsts-parse-head(tail(tokens))) {
       let t = head(tokens).key + head(tail(tokens)).key;
       tokens = tail(tokens); tokens = tail(tokens);
       Tuple( Var( t, mk-token(t) ), tokens )
@@ -1997,7 +1997,7 @@ let lsts-parse-atom-without-tail(tokens: List<Token>): Tuple<AST,List<Token>> = 
          if lsts-is-enum-head(lsts-parse-head(tokens)) {
             let tag = head(tokens); tokens = tail(tokens);
             term = Lit ( tag.key, tag );
-            if not(tag.key.contains(c"_")) && tag.key!=c"LEOF" && tag.key!=c"HashtableEqEOF" {
+            if not(tag.key.contains(c"_")) and tag.key!=c"LEOF" and tag.key!=c"HashtableEqEOF" {
                term = mk-app(term, mk-nil());
             };
          } else {
@@ -2014,9 +2014,9 @@ let lsts-parse-atom(tokens: List<Token>): Tuple<AST,List<Token>> = (
 );
 
 let lsts-parse-atom-tail(base: AST, tokens: List<Token>): Tuple<AST,List<Token>> = (
-   while lsts-parse-head(tokens) == c"[" ||
-         lsts-parse-head(tokens) == c"(" ||
-         lsts-parse-head(tokens) == c"." ||
+   while lsts-parse-head(tokens) == c"[" or
+         lsts-parse-head(tokens) == c"(" or
+         lsts-parse-head(tokens) == c"." or
          lsts-parse-head(tokens) == c"as" {
       let loc = head(tokens).location;
       match tokens {
@@ -2026,10 +2026,10 @@ let lsts-parse-atom-tail(base: AST, tokens: List<Token>): Tuple<AST,List<Token>>
             let method = c"." + head(tokens).key; tokens = tail(tokens);
             if lsts-parse-head(tokens) == c"(" {
                lsts-parse-expect( c"(", tokens ); tokens = tail(tokens);
-               while non-zero(tokens) && lsts-parse-head(tokens)!=c")" {
+               while non-zero(tokens) and lsts-parse-head(tokens)!=c")" {
                   let next-rest = lsts-parse-expression(tokens);
                   tokens = next-rest.second;
-                  if non-zero(tokens) && lsts-parse-head(tokens)==c"," {
+                  if non-zero(tokens) and lsts-parse-head(tokens)==c"," {
                      tokens = tail(tokens);
                   } else {
                      lsts-parse-expect( c")", tokens );

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -2020,7 +2020,7 @@ let lsts-parse-atom-tail(base: AST, tokens: List<Token>): Tuple<AST,List<Token>>
          lsts-parse-head(tokens) == c"as" {
       let loc = head(tokens).location;
       match tokens {
-         [Token{key:"."}.. rest] => (
+         [Token{key:c"."}.. rest] => (
             tokens = rest;
             lsts-parse-expect( c"[Identifier]", lsts-is-ident-head(lsts-parse-head(tokens)), tokens );
             let method = c"." + head(tokens).key; tokens = tail(tokens);
@@ -2043,7 +2043,7 @@ let lsts-parse-atom-tail(base: AST, tokens: List<Token>): Tuple<AST,List<Token>>
                base
             );
          );
-         [Token{key:"as"}.. rest] => (
+         [Token{key:c"as"}.. rest] => (
             tokens = rest;
             let type-rest = lsts-parse-type(tokens); 
             tokens = type-rest.second;
@@ -2052,7 +2052,7 @@ let lsts-parse-atom-tail(base: AST, tokens: List<Token>): Tuple<AST,List<Token>>
                mk-cons(base, mk-atype(phi-as-state(type-rest.first)))
             );
          );
-         [Token{key:"["}.. rest] => (
+         [Token{key:c"["}.. rest] => (
             tokens = rest;
             let term1 = if lsts-parse-head(tokens)==c":" {
                Lit( c"0_i64", with-location(mk-token("0_i64"),loc) )
@@ -2085,7 +2085,7 @@ let lsts-parse-atom-tail(base: AST, tokens: List<Token>): Tuple<AST,List<Token>>
             };
             lsts-parse-expect( c"]", tokens ); tokens = tail(tokens);
          );
-         [Token{key:"("}.. rest] => (
+         [Token{key:c"("}.. rest] => (
             tokens = rest;
             let args = if lsts-parse-head(tokens) == c")" {
                mk-nil();

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -48,7 +48,7 @@ let lsts-parse-doc-wordf(tokens: List<Token>, begin: CString, end: CString): Tup
    let text = mk-vector(type(U8), 16);
    while lsts-parse-head(tokens) != end {
       if lsts-parse-head(tokens) == c"\n" {
-         lsts-parse-expect(end, 0, tokens);
+         lsts-parse-expect(end, false, tokens);
       };
       if text.length > 0 {
          text = text.push(32_u8);
@@ -60,7 +60,7 @@ let lsts-parse-doc-wordf(tokens: List<Token>, begin: CString, end: CString): Tup
       };
       tokens = tail(tokens);
    };
-   Tuple ( text.into(type(CString)), tokens )
+   Tuple ( text.buffer-into-string.into(type(CString)), tokens )
 );
 
 let lsts-parse-doc-expr(tokens: List<Token>): Tuple<AST, List<(CString, AST)>, List<Token>> = (
@@ -168,7 +168,7 @@ let lsts-has-assign(tokens: List<Token>): U64 = (
 );
 
 let lsts-substitute-type-aliases(s: CString): CString = (
-   if s.has-suffix(c"_ss") then untern(intern(s)[:-3_i64]) else
+   if s.has-suffix(c"_ss") then intern(s)[:-3_i64].into(type(CString)) else
    s.remove-suffix(c"_u64").get-or(c"")
     .remove-suffix(c"_u32").get-or(c"")
     .remove-suffix(c"_u16").get-or(c"")
@@ -213,7 +213,7 @@ let lsts-parse(tokens: List<Token>): Nil = (
             (let mlhs, tokens) = lsts-parse-atom-without-tail(rst);
             let mrhs = ASTNil;
             lsts-parse-expect(c"(",tokens); tokens = tail(tokens);
-            if lsts-parse-head(tokens)=="let" then (mrhs, tokens) = lsts-parse-let(tokens)
+            if lsts-parse-head(tokens)==c"let" then (mrhs, tokens) = lsts-parse-let(tokens)
             else (mrhs, tokens) = lsts-parse-atom(tokens);
             lsts-parse-expect(c")",tokens); tokens = tail(tokens);
             preprocess-macros = MSeq( close(preprocess-macros), Macro(mlhs.without-location, mrhs.without-location) );
@@ -483,7 +483,7 @@ let lsts-parse-lhs(tokens: List<Token>): Tuple<AST,List<Token>> = (
          base-rest.first;         
       );
    };
-   while non-zero(tokens) and (lsts-parse-head(tokens)==c"." or lsts-parse-head(tokens)=="[") {
+   while non-zero(tokens) and (lsts-parse-head(tokens)==c"." or lsts-parse-head(tokens)==c"[") {
       match tokens {
          [Token{key:c"."}.. Token{key:c"."}.. rest] => (
             let loc = head(tokens).location;

--- a/PLUGINS/FRONTEND/LSTS/lsts-smart-tokenize.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-smart-tokenize.lsts
@@ -97,11 +97,11 @@ let lsts-tokenize-string(file-path: String, text: String): List<Token> = (
       );
 
       #rest => fail("Unexpected Character during LSTS Tokenization: "
-      #             "'\{rest[0_u64]}' "
+      #             "'\{rest[0_sz]}' "
       #             "in File \{rest.file-name-of-token}, "
       #             "Line \{rest.line-of-token}, "
       #             "Column \{rest.column-of-token}.");
-      rest => ( fail("Unrecognized Token in File \{file-path}: \{clone-rope(rest[0_u64])}"); );
+      rest => ( fail("Unrecognized Token in File \{file-path}: \{clone-rope(rest[0_sz])}"); );
    }; };
 
    let internal-tokens = [] : List<Token>;

--- a/PLUGINS/FRONTEND/LSTS/lsts-tokenize.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-tokenize.lsts
@@ -1,40 +1,40 @@
 
 let lsts-tokenize(fp: CString): List<Token> = lsts-tokenize-string(fp, read-file(fp));
 
-let lsts-is-reserved-word(text: CString): U64 = (
-   text == c"if" ||
-   text == c"then" ||
-   text == c"else" ||
-   text == c"let" ||
-   text == c"while" ||
-   text == c"for" ||
-   text == c"type" ||
-   text == c"interface" ||
-   text == c"raw" ||
+let lsts-is-reserved-word(text: CString): Bool = (
+   text == c"if" or
+   text == c"then" or
+   text == c"else" or
+   text == c"let" or
+   text == c"while" or
+   text == c"for" or
+   text == c"type" or
+   text == c"interface" or
+   text == c"raw" or
    text == c"match"
 );
 
-let lsts-is-ident-head(text: CString): U64 = (
-   ( head-string(text) >= 48 && head-string(text) <= 57 ) ||   # 0-9
-   ( head-string(text) >= 97 && head-string(text) <= 122 ) ||  # a-z
-   ( head-string(text) == 95 ) ||  # _
-   ( head-string(text) == 36 )     # $
+let lsts-is-ident-head(text: CString): Bool = (
+   ( head(text) >= 48 and head(text) <= 57 ) or   # 0-9
+   ( head(text) >= 97 and head(text) <= 122 ) or  # a-z
+   ( head(text) == 95 ) or  # _
+   ( head(text) == 36 )     # $
 );
 
-let lsts-is-ident-body(text: CString): U64 = (
-   ( head-string(text) >= 48 && head-string(text) <= 57 ) ||   # 0-9
-   ( head-string(text) >= 97 && head-string(text) <= 122 ) ||  # a-z
-   ( head-string(text) >= 65 && head-string(text) <= 90 ) ||   # A-Z
-   ( head-string(text) == 95 ) ||  # _
-   ( head-string(text) == 45 ) ||  # -
-   ( head-string(text) == 36 )     # $
+let lsts-is-ident-body(text: CString): Bool = (
+   ( head(text) >= 48 and head(text) <= 57 ) or   # 0-9
+   ( head(text) >= 97 and head(text) <= 122 ) or  # a-z
+   ( head(text) >= 65 and head(text) <= 90 ) or   # A-Z
+   ( head(text) == 95 ) or  # _
+   ( head(text) == 45 ) or  # -
+   ( head(text) == 36 )     # $
 );
 
-let lsts-is-lit-head(text: CString): U64 = (
-   ( head-string(text) >= 48 && head-string(text) <= 57 ) ||   # 0-9
-   ( head-string(text) >= 65 && head-string(text) <= 90 )      # A-Z
+let lsts-is-lit-head(text: CString): Bool = (
+   ( head(text) >= 48 and head(text) <= 57 ) or   # 0-9
+   ( head(text) >= 65 and head(text) <= 90 )      # A-Z
 );
 
-let lsts-is-enum-head(text: CString): U64 = (
-   ( head-string(text) >= 65 && head-string(text) <= 90 )      # A-Z
+let lsts-is-enum-head(text: CString): Bool = (
+   ( head(text) >= 65 and head(text) <= 90 )      # A-Z
 );

--- a/PLUGINS/FRONTEND/LSTS/mk-lsts-token.lsts
+++ b/PLUGINS/FRONTEND/LSTS/mk-lsts-token.lsts
@@ -1,7 +1,7 @@
 
 let mk-lsts-token(s: String): Token = (
    let us = untern(s);
-   if us.is-digit || (us.has-prefix(c"-") && tail-string(us).is-digit) {
+   if us.is-digit or (us.has-prefix(c"-") and tail(us).is-digit) {
       let ds = us;
       let is-negative = false;
       let order = 64_u64;
@@ -9,12 +9,12 @@ let mk-lsts-token(s: String): Token = (
       else {
          if ds.has-prefix(c"-") {
             is-negative = true;
-            ds = tail-string(ds);
+            ds = tail(ds);
          };
          let magnitude = to-u64(ds);
-         if (is-negative && magnitude <= 128) || magnitude <= 255 then order = 8
-         else if (is-negative && magnitude <= 32768) || magnitude <= 65535 then order = 16
-         else if (is-negative && magnitude <= 2147483648) || magnitude <= 4294967295 then order = 32;
+         if (is-negative and magnitude <= 128) or magnitude <= 255 then order = 8
+         else if (is-negative and magnitude <= 32768) or magnitude <= 65535 then order = 16
+         else if (is-negative and magnitude <= 2147483648) or magnitude <= 4294967295 then order = 32;
       };
       match (is-negative, order) {
          Tuple{ first:0_u64, second:8_u64 } => us = us + c"_u8";
@@ -28,32 +28,32 @@ let mk-lsts-token(s: String): Token = (
       };
    };
    if s.has-prefix("r/") {
-      us = us.remove-prefix(c"r/")
-             .remove-suffix(c"/")
+      us = us.remove-prefix(c"r/").get-or(c"")
+             .remove-suffix(c"/").get-or(c"")
              .replace(c"\\/", c"/")
              + c"_rgx";
    };
    if s.has-prefix("\"") {
-      us = us.remove-prefix(c"\"")
-             .remove-suffix(c"\"")
+      us = us.remove-prefix(c"\"").get-or(c"")
+             .remove-suffix(c"\"").get-or(c"")
              .replace(c"\\\"", c"\"")
              + c"_ss";
    };
    if s.has-prefix("c\"") {
-      us = us.remove-prefix(c"c\"")
-             .remove-suffix(c"\"")
+      us = us.remove-prefix(c"c\"").get-or(c"")
+             .remove-suffix(c"\"").get-or(c"")
              .replace(c"\\\"", c"\"")
              + c"_s";
    };
    if s.has-prefix("l\"") {
-      us = us.remove-prefix(c"l\"")
-             .remove-suffix(c"\"")
+      us = us.remove-prefix(c"l\"").get-or(c"")
+             .remove-suffix(c"\"").get-or(c"")
              .replace(c"\\\"", c"\"")
              + c"_l";
    };
    if s.has-prefix("rl\"") {
-      us = us.remove-prefix(c"rl\"")
-             .remove-suffix(c"\"")
+      us = us.remove-prefix(c"rl\"").get-or(c"")
+             .remove-suffix(c"\"").get-or(c"")
              .replace(c"\\\"", c"\"")
              + c"_rl";
    };

--- a/PLUGINS/FRONTEND/LSTS/mk-lsts-token.lsts
+++ b/PLUGINS/FRONTEND/LSTS/mk-lsts-token.lsts
@@ -1,6 +1,6 @@
 
 let mk-lsts-token(s: String): Token = (
-   let us = untern(s);
+   let us = s.into(type(CString));
    if us.is-digit or (us.has-prefix(c"-") and tail(us).is-digit) {
       let ds = us;
       let is-negative = false;
@@ -16,7 +16,7 @@ let mk-lsts-token(s: String): Token = (
          else if (is-negative and magnitude <= 32768) or magnitude <= 65535 then order = 16
          else if (is-negative and magnitude <= 2147483648) or magnitude <= 4294967295 then order = 32;
       };
-      match (is-negative, order) {
+      match (is-negative as U64, order) {
          Tuple{ first:0_u64, second:8_u64 } => us = us + c"_u8";
          Tuple{ first:1_u64, second:8_u64 } => us = us + c"_i8";
          Tuple{ first:0_u64, second:16_u64 } => us = us + c"_u16";

--- a/SRC/index.lsts
+++ b/SRC/index.lsts
@@ -4,7 +4,4 @@ import std/minimal.lsts;
 import LM23COMMON/index.lsts;
 
 import PLUGINS/BACKEND/C/index.lsts;
-import PLUGINS/BACKEND/BLOB/index.lsts;
-
-import PLUGINS/FRONTEND/LSTS/index.lsts;
 import PLUGINS/FRONTEND/C/index.lsts;

--- a/lib/std/vector.lsts
+++ b/lib/std/vector.lsts
@@ -107,6 +107,8 @@ let .pop-front(v: Vector<t>): Tuple<t, Vector<t>> = (
     Tuple ( x, v )
 );
 
+let .pop-backwards-compatible(v: Vector<t>): Tuple<t, Vector<t>> = v.pop;
+
 ## INPUT VECTOR GETS POISONED
 let .pop(v: Vector<t>): Tuple<t, Vector<t>> = (
    if v.length() == 0 {

--- a/lib/std/vector.lsts
+++ b/lib/std/vector.lsts
@@ -274,3 +274,7 @@ let deep-hash(ts: Vector<t>): U64 = (
    for vector t0 in ts { return = return + deep-hash(t0); };
    return;
 );
+
+# ignore, don't port to lib2
+# for compatibility in lmcommon
+let .buffer-into-string(c: Vector<U8>): Vector<U8> = c;

--- a/lib2/core/baremetal-into.lsts
+++ b/lib2/core/baremetal-into.lsts
@@ -88,3 +88,9 @@ let .to-hex(i: U64): String = (
    buff.buffer-into-string
 );
 
+let clone-rope(s: U8): CString = (
+   let x = safe-alloc(2, type(U8));
+   x[0] = s;
+   x[1] = 0_u8;
+   x as CString;
+);

--- a/lib2/core/baremetal.lsts
+++ b/lib2/core/baremetal.lsts
@@ -3,6 +3,7 @@ import stdint.h;
 import stdio.h;
 import stdlib.h;
 import string.h;
+import regex.h;
 
 import lib2/core/l.lsts;
 import lib2/core/phi.lsts;

--- a/lib2/core/bedrock.lsts
+++ b/lib2/core/bedrock.lsts
@@ -13,6 +13,7 @@ import lib2/core/maybe.lsts;
 import lib2/core/list.lsts;
 import lib2/core/s.lsts;
 import lib2/core/hashtable.lsts;
+import lib2/core/regex.lsts;
 
 # TODO: remove after V3 release
 let deep-hash(x: t): U64 = hash(x);

--- a/lib2/core/cstring.lsts
+++ b/lib2/core/cstring.lsts
@@ -120,3 +120,29 @@ let .file-extension(path: CString): CString = (
    };
    path
 );
+
+let .is-digit(base: CString): Bool = (
+   if non-zero(base) {
+      let r = true;
+      while head(base) != 0_u8 and r {
+         r = 48_u8 <= head(base) and head(base) <= 57_u8;
+         base = tail(base);
+      };
+      r
+   } else false
+);
+
+# TODO: optimize, this is really inefficient
+let .replace(base: CString, pat: CString, n: CString): CString = (
+   let r = SNil;
+   while head(base)!=0 {
+      if base.has-prefix(pat) {
+         base = base.remove-prefix(pat);
+         r = r + SAtom(n);
+      } else {
+         r = r + SAtom(clone-rope(head(base)));
+         base = tail(base);
+      }
+   };
+   clone-rope(r);
+);

--- a/lib2/core/io.lsts
+++ b/lib2/core/io.lsts
@@ -12,3 +12,27 @@ let file-exists(fp: CString): Bool = (
    };
    exists
 );
+
+let read-binary-file-to(out: Vector<U8>, path: CString): Vector<U8> = (
+   let fp = fopen(path as C<"char">[], c"rb");
+   if (fp as U64) == 0_u64 {
+      fail("Unable to read from file: \{path}");
+   };
+   let buffer = mk-vector(type(U8), 1024 as USize);
+   let bytes-read = 1_sz;
+   while bytes-read > 0 {
+      bytes-read = fread(buffer.data.data as C<"void">[], 1 as USize, 1024 as USize, fp);
+      let bi = 0_sz;
+      while bi < (bytes-read as USize) {
+         out = out.push(buffer.data.data[bi]);
+         bi = bi + 1;
+      };
+   };
+   fclose(fp);
+   out
+);
+
+let read-file(fp: CString): CString = (
+   let v = read-binary-file-to(mk-vector(type(U8)), fp);
+   v.buffer-into-string.into(type(CString))
+);

--- a/lib2/core/regex.lsts
+++ b/lib2/core/regex.lsts
@@ -1,0 +1,83 @@
+
+type Regex suffix _rgx;
+
+let :Blob .rm_so(t: C<"regmatch_t">): U64 = (
+   $":frame"( $":frame"(t) );
+   $":expression"( l"("; $":expression"(t); l".rm_so)"; );
+);
+let :Blob .rm_eo(t: C<"regmatch_t">): U64 = (
+   $":frame"( $":frame"(t) );
+   $":expression"( l"("; $":expression"(t); l".rm_eo)"; );
+);
+
+let .has-prefix(text: String, rgx: Regex): Bool = (
+   # TODO: fix this mess. The preprocessor is unpacking these erroneously
+   # macros 2.0 doesn't have this problem, but this code still needs to be updated after swapping
+   let a1 = &rgx as C<"regex_t">[];
+   let a2 = text.data.data as C<"char">[];
+   let a3 = 0 as C<"size_t">;
+   let a4 = 0 as C<"regmatch_t">[];
+   let a5 = 0 as C<"int">;
+   let status = regexec(
+      a1,
+      a2,
+      a3,
+      a4,
+      a5
+   );
+   (status as U64) == 0
+);
+
+let $"=="(text: CString, rgx: Regex): Bool = (
+   let matches = () : C<"regmatch_t">[1];
+   let a1 = &rgx as C<"regex_t">[];
+   let a2 = text as C<"char">[];
+   let a3 = 1 as C<"size_t">;
+   let a4 = matches as C<"regmatch_t">[];
+   let a5 = 0 as C<"int">;
+   let status = regexec(
+      a1,
+      a2,
+      a3,
+      a4,
+      a5
+   );
+   (status as U64)==0 and matches[0].rm_so==0 and matches[0].rm_eo==text.length
+);
+
+# TODO remove (this method name is a misnomer), correct name is ".get-prefix"
+let .remove-prefix(text: String, rgx: Regex): String = (
+   let matches = () : C<"regmatch_t">[1];
+   let a1 = &rgx as C<"regex_t">[];
+   let a2 = text.data.data as C<"char">[];
+   let a3 = 1 as C<"size_t">;
+   let a4 = matches as C<"regmatch_t">[];
+   let a5 = 0 as C<"int">;
+   let status = regexec(
+      a1,
+      a2,
+      a3,
+      a4,
+      a5
+   );
+   if matches[0].rm_so != 0 then fail(".remove-prefix regex did not match the prefix");
+   text[0_i64 : matches[0].rm_eo as I64]
+);
+
+let .get-prefix(text: String, rgx: Regex): String = (
+   let matches = () : C<"regmatch_t">[1];
+   let a1 = &rgx as C<"regex_t">[];
+   let a2 = text.data.data as C<"char">[];
+   let a3 = 1 as C<"size_t">;
+   let a4 = matches as C<"regmatch_t">[];
+   let a5 = 0 as C<"int">;
+   let status = regexec(
+      a1,
+      a2,
+      a3,
+      a4,
+      a5
+   );
+   if matches[0].rm_so != 0 then fail(".get-prefix regex did not match the prefix");
+   text[0_i64 : matches[0].rm_eo as I64]
+);

--- a/lib2/core/s.lsts
+++ b/lib2/core/s.lsts
@@ -34,3 +34,26 @@ let clone-rope-impl(s: S, out: Vector<U8>): Vector<U8> = (
    };
    out
 );
+
+let $"+"(l: S, r: S): S = (
+   if non-zero(r) then (
+      if non-zero(l)
+      then (l = SCons(close(l), close(r)))
+      else (l = r);
+   ); l
+);
+
+let $"=="(ls: S, rs: S): Bool = (
+   match (Tuple( ls, rs )) {
+      Tuple { first:SNil{}, second:SNil{} } => true;
+      Tuple { first:SAtom{ lc=atom }, second:SAtom{ rc=atom } } => lc == rc;
+      Tuple { first:SCons{ l1=left, l2=right },
+              second:SCons{ r1=left, r2=right } } => l1==r1 and l2==r2;
+      Tuple { first:SPointer{ lc=pointer },
+              second:SPointer{ rc=pointer } } => (lc as U8) == (rc as U8);
+      _ => false;
+   }
+);
+
+let $"!="(ls: S, rs: S): Bool = not(ls == rs);
+let $"||"(ls: S, rs: S): S = if non-zero(ls) then ls else rs;

--- a/lib2/core/s.lsts
+++ b/lib2/core/s.lsts
@@ -3,3 +3,6 @@ type S zero SNil = SNil
                  | SAtom { atom: String }
                  | SCons { left: OwnedData<S>[], right: OwnedData<S>[] }
                  | SPointer { pointer: Nil[] };
+
+# TODO: remove after GC enabled, this is for compatibility of constructors
+let $"SAtom"(key: CString): S = SAtom(key.into(type(String)));

--- a/lib2/core/s.lsts
+++ b/lib2/core/s.lsts
@@ -6,3 +6,31 @@ type S zero SNil = SNil
 
 # TODO: remove after GC enabled, this is for compatibility of constructors
 let $"SAtom"(key: CString): S = SAtom(key.into(type(String)));
+
+let clone-rope(s: S): CString = (
+   let out = mk-vector(type(U8));
+   out = clone-rope-impl(s, out);
+   out.buffer-into-string.into(type(CString))
+);
+
+let clone-rope-impl(s: S, out: Vector<U8>): Vector<U8> = (
+   match s {
+      SNil {} => ();
+
+      SCons { l=left, r=right } => (
+         out = clone-rope-impl(l, out);
+         out = clone-rope-impl(r, out);
+      );
+
+      SAtom { a=atom } => (
+         let si = 0_sz;
+         while si < a.length {
+            out = out.push(a[si]);
+            si = si + 1;
+         };
+      );
+
+      r => ();
+   };
+   out
+);

--- a/lib2/core/string.lsts
+++ b/lib2/core/string.lsts
@@ -94,6 +94,10 @@ let .into(s: String, tt: Type<CString>): CString = (
    s.data.data as CString
 );
 
+let $"[:]"(x: String, low: U64, hi: U64): String = x[low as I64 : hi as I64];
+let $"[:]"(x: String, low: I64, hi: U64): String = x[low : hi as I64];
+let $"[:]"(x: String, low: U64, hi: I64): String = x[low as I64 : hi];
+
 # new allocations = 0
 let $"[:]"(s: String, begin: I64, end: I64): String = (
    let s-length = s.length as I64;
@@ -161,3 +165,25 @@ let hash(key: String): U64 = (
 
 # new allocations = 1
 let .into(tt: Type<t>, dst: Type<String>): String = type(t).into(type(CString)).into(type(String));
+
+let .has-suffix(base: String, sfx: String): Bool = (
+   base.length >= sfx.length and
+   base[ (base.length - sfx.length) as I64 : base.length as I64 ] == sfx
+);
+
+let .remove-suffix(base: String, sfx: String): String = (
+   if base.has-suffix(sfx)
+   then base[ 0_i64 : (base.length - sfx.length) as I64 ]
+   else base
+);
+
+let .has-prefix(base: String, pfx: String): Bool = (
+   base.length >= pfx.length and
+   base[ 0_i64 : pfx.length as I64 ] == pfx
+);
+
+let .remove-prefix(base: String, pfx: String): String = (
+   if base.has-prefix(pfx)
+   then base[ pfx.length as I64 : minimum-I64 ]
+   else base
+);

--- a/lib2/core/string.lsts
+++ b/lib2/core/string.lsts
@@ -142,7 +142,14 @@ let $"+"(l: String, r: String): String = (
 
 # new allocations = 0
 let fail(msg: String): Never = (
-   fwrite((msg.data.data + msg.start-offset) as C<"void">[], sizeof(USize) as USize, msg.length, stderr);
+   fwrite((msg.data.data + msg.start-offset) as C<"void">[], sizeof(U8) as USize, msg.length, stderr);
+   exit(1) as Never;
+);
+
+let fail(msg: String, loc: String): Never = (
+   fwrite((msg.data.data + msg.start-offset) as C<"void">[], sizeof(U8) as USize, msg.length, stderr);
+   fwrite(c" at " as C<"void">[], sizeof(U8) as USize, c" at ".length, stderr);
+   fwrite((loc.data.data + loc.start-offset) as C<"void">[], sizeof(U8) as USize, loc.length, stderr);
    exit(1) as Never;
 );
 

--- a/lib2/core/u64.lsts
+++ b/lib2/core/u64.lsts
@@ -36,3 +36,25 @@ let cmp(l: U64, r: U64): Ord = (
 );
 
 let hash(x: U64): U64 = x as U64;
+
+let to-u64(s: CString): U64 = (
+   let i = 0_u64;
+   while head(s) != 0 {
+      i = i * 10;
+      match head(s) {
+         48_u8 => i = i + 0_u64;
+         49_u8 => i = i + 1_u64;
+         50_u8 => i = i + 2_u64;
+         51_u8 => i = i + 3_u64;
+         52_u8 => i = i + 4_u64;
+         53_u8 => i = i + 5_u64;
+         54_u8 => i = i + 6_u64;
+         55_u8 => i = i + 7_u64;
+         56_u8 => i = i + 8_u64;
+         57_u8 => i = i + 9_u64;
+         _ => ();
+      };
+      s = tail(s);
+   };
+   i
+);

--- a/lib2/core/vector.lsts
+++ b/lib2/core/vector.lsts
@@ -76,6 +76,21 @@ let .push(v: Vector<t>, i: t): Vector<t> = (
    v
 );
 
+# Note: this *reduces* the size of the vector, so it *never* resizes
+# There is no need to return the original vector because it never gets modified
+let .pop(v: Vector<t>): t = (
+   if v.length == 0 {
+      fail("Tried to pop from empty Vector.");
+   };
+   v.data.pop
+);
+
+# TODO: remove after dumping lib1
+let .pop-backwards-compatible(v: Vector<t>): (t, Vector<t>) = (
+   let e = v.pop();
+   (e, v)
+);
+
 # new allocations = 0
 let cmp(x: Vector<x>, y: Vector<x>): Ord = (
    let r = Equal;

--- a/tests/promises/lm-backend/backend.lsts
+++ b/tests/promises/lm-backend/backend.lsts
@@ -1,0 +1,2 @@
+
+import LM23COMMON/unit-backend-core.lsts;

--- a/tests/promises/lm-main/main.lsts
+++ b/tests/promises/lm-main/main.lsts
@@ -1,0 +1,2 @@
+
+import LM23COMMON/index.lsts;


### PR DESCRIPTION
## Describe your changes
Features:
* backend lmcommon compiling now
* LSTS frontend plugin is nearly working BUT it is running out of memory
* need to drop another like 50% memory to compile the whole project with GC
   * options:
   * find some more optimizations (holistically profile memory usage?)
   * start GC some things, gradual partial transition

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed an AI-assisted self-review of my code.
```
Can you review my pull request and provide some suggestions?
https://patch-diff.githubusercontent.com/raw/Lambda-Mountain-Compiler-Backend/lambda-mountain/pull/1926.diff
```
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
