### PR TITLE
Lib1 lib2 equilibrium uuuuuo

### DIFF
--- a/LM23COMMON/ast-misc-globals.lsts
+++ b/LM23COMMON/ast-misc-globals.lsts
@@ -31,3 +31,4 @@ non-zero(parse-suffixes); # TODO remove
 
 let config-v3 = true;
 let config-v1 = false;
+let config-v0 = false;

--- a/LM23COMMON/unit-main-core.lsts
+++ b/LM23COMMON/unit-main-core.lsts
@@ -40,7 +40,7 @@ let main(argc: C_int, argv: CString[]): Nil = (
          c"--typecheck" => config-mode = ModeTypecheck();
          c"--parse" => config-mode = ModeParse();
          c"--compile" => config-mode = ModeCompile();
-         c"--v1" => (config-v3 = false; config-v0 = true;);
+         c"--v0" => (config-v3 = false; config-v0 = true;);
          c"--v1" => (config-v3 = false; config-v1 = true;);
          c"--v2" => config-v3 = false;
          c"--v3" => config-v3 = true;

--- a/LM23COMMON/unit-main-core.lsts
+++ b/LM23COMMON/unit-main-core.lsts
@@ -40,6 +40,7 @@ let main(argc: C_int, argv: CString[]): Nil = (
          c"--typecheck" => config-mode = ModeTypecheck();
          c"--parse" => config-mode = ModeParse();
          c"--compile" => config-mode = ModeCompile();
+         c"--v1" => (config-v3 = false; config-v0 = true;);
          c"--v1" => (config-v3 = false; config-v1 = true;);
          c"--v2" => config-v3 = false;
          c"--v3" => config-v3 = true;

--- a/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
@@ -99,7 +99,7 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
             f = f.set(c"expression", v.get(c"expression") + SAtom(c":"));
          } else {
             (let pre, let post) = std-c-mangle-declaration(lt, t);
-            if config-v3 {
+            if config-v3 or config-v1 {
                f = f.set(c"frame",
                          f.get(c"frame") + pre + SAtom(c" ")
                        + v.get(c"expression")

--- a/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
@@ -99,7 +99,7 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
             f = f.set(c"expression", v.get(c"expression") + SAtom(c":"));
          } else {
             (let pre, let post) = std-c-mangle-declaration(lt, t);
-            if config-v3 or config-v1 {
+            if config-v3 or config-v1 or config-v0 {
                f = f.set(c"frame",
                          f.get(c"frame") + pre + SAtom(c" ")
                        + v.get(c"expression")

--- a/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
@@ -105,7 +105,7 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
                        + v.get(c"expression")
                        + SAtom(c" ") + post + SAtom(c";")
                        + SAtom(c"memset(&") + v.get(c"expression")
-                       + SAtom(c",0,sizeof ") + v.get(c"expression") + SAtom(c");")
+                       + SAtom(c",0,sizeof(") + v.get(c"expression") + SAtom(c"));")
                );
             } else {
                f = f.set(c"frame",

--- a/tests/regress.rs
+++ b/tests/regress.rs
@@ -30,15 +30,15 @@ fn compile_bootstrap() {
    };
 }
 
-fn run_bootstrap(target: &str, leave_tmp: bool, is_v1: bool) -> String {
+fn run_bootstrap(target: &str, leave_tmp: bool, is_v3: bool) -> String {
    if !leave_tmp { rm("tmp.c"); };
    rm("a.out");
    
-   let exit = if is_v1 {
+   let exit = if is_v3 {
       Command::new("./bootstrap.exe")
               .stdout(std::process::Stdio::piped())
               .stderr(std::process::Stdio::piped())
-              .arg("--v1")
+              .arg("--v3")
               .arg("-o")
               .arg("tmp.c")
               .arg(target)

--- a/tests/regress.rs
+++ b/tests/regress.rs
@@ -30,15 +30,15 @@ fn compile_bootstrap() {
    };
 }
 
-fn run_bootstrap(target: &str, leave_tmp: bool, is_v3: bool) -> String {
+fn run_bootstrap(target: &str, leave_tmp: bool, is_v1: bool) -> String {
    if !leave_tmp { rm("tmp.c"); };
    rm("a.out");
    
-   let exit = if is_v3 {
+   let exit = if is_v1 {
       Command::new("./bootstrap.exe")
               .stdout(std::process::Stdio::piped())
               .stderr(std::process::Stdio::piped())
-              .arg("--v3")
+              .arg("--v1")
               .arg("-o")
               .arg("tmp.c")
               .arg(target)


### PR DESCRIPTION
## Describe your changes
Features:
* this change was suggested by Claude
* I am a bit stumped here so I am trying out the new frontier models to analyze and scrub the codebase
* This suggestion is a minor correction: moving C code from `sizeof x` (type or variable) to `sizeof(x)` (variable only)
* It didn't fix anything, but it introduces an increased level of paranoia that is welcome

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed an AI-assisted self-review of my code.
```
Can you review my pull request and provide some suggestions?
https://patch-diff.githubusercontent.com/raw/Lambda-Mountain-Compiler-Backend/lambda-mountain/pull/1926.diff
```
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
