### PR TITLE
Gradual patch lib2 without gc dfisiisi

### DIFF
--- a/LM23COMMON/typecheck-infer-type-definition.lsts
+++ b/LM23COMMON/typecheck-infer-type-definition.lsts
@@ -1,6 +1,6 @@
 
 let type-ast-inserts = mk-vector(type(AST));
-let complex-type-index = {} : Hashtable<(CString,U64),U64>;
+let complex-type-index = {} : Hashtable<(CString,U64),Bool>;
 
 let visit-field-template(field-name: CString, base-type: Type, field-type: Type, blame: AST, field-ordinal: U64, case-number: U64): Nil = (
    let mangled-field-name = case-number.into(type(CString)) + c"_" + field-name;
@@ -83,7 +83,7 @@ let infer-type-definition(term: AST): Nil = (
 
       let case-number = 0_u64;
       for vector Tuple{ case-tag2=first, case-fields=second } in cases {
-         complex-type-index = complex-type-index.bind( lhs-type.ground-tag-and-arity, 1_u64 );
+         complex-type-index = complex-type-index.bind( lhs-type.ground-tag-and-arity, true );
          datatype-index = datatype-index.bind( lhs-type.ground-tag-and-arity, true );
          let field-ordinal = 0_u64;
          for vector Tuple{ field-name3=first, field-type=second } in case-fields {

--- a/LM23COMMON/unit-main-core.lsts
+++ b/LM23COMMON/unit-main-core.lsts
@@ -61,10 +61,10 @@ let main(argc: C_int, argv: CString[]): Nil = (
             argi = argi + 1;
             config-target = argv[argi];
          );
-         fp => (
-            if plugins-backends-index.has(fp) {
-               plugin-current-backend = plugins-backends-index.lookup(fp,&plugin-null-backend);
-            } else { input = cons(fp, input); };
+         fp1 => (
+            if plugins-backends-index.has(fp1) {
+               plugin-current-backend = plugins-backends-index.lookup(fp1,&plugin-null-backend);
+            } else { input = cons(fp1, input); };
          );
       };
       argi = argi + 1;
@@ -77,22 +77,22 @@ let main(argc: C_int, argv: CString[]): Nil = (
          } else {
             print("{");
             let first-outer = true;
-            for list fp in input {
+            for list fp2 in input {
                if first-outer {
                   first-outer = false;
                } else {
                   print(",\n");
                };
-               print-toks-json(fp);
+               print-toks-json(fp2);
             };
             print("\n}\n");
          };
       );
       ModeParse{} => (
-         for list fp in input.reverse { frontend(fp); };
+         for list fp3 in input.reverse { frontend(fp3); };
       );
       _ => (
-         for list fp in input.reverse { frontend(fp); };
+         for list fp4 in input.reverse { frontend(fp4); };
          match config-mode {
             ModeTypecheck{} => (preprocess(); typecheck(););
             ModeCompile{} => (preprocess(); typecheck(); plugin-current-backend(); );

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@ CC = clang
 CFLAGS = -w -O2 -march=native -mtune=native
 
 dev: install-production
-	time lm --v23 tests/promises/lm-ascript/ascript-integrated.lsts
+	time lm --v2 tests/promises/lm-ascript/ascript-integrated.lsts
 	gcc tmp.c
 	./a.out
 
 build: compile-production
-	time ./production --v23 --c -o deploy1.c SRC/index.lsts
+	time ./production --v2 --c -o deploy1.c SRC/index.lsts
 	$(CC) $(CFLAGS) deploy1.c -o deploy1
-	time ./deploy1 --v23 --c -o deploy2.c SRC/index.lsts
+	time ./deploy1 --v2 --c -o deploy2.c SRC/index.lsts
 	diff deploy1.c deploy2.c
 	mv deploy1.c BOOTSTRAP/cli.c
 	rm -f deploy1 deploy1.c deploy2.c
@@ -19,7 +19,7 @@ deploy: build smoke-test
 deploy-lite: build smoke-test-lite
 
 valgrind: install-bootstrap
-	valgrind --tool=callgrind lm --v23 SRC/index.lsts
+	valgrind --tool=callgrind lm --v2 SRC/index.lsts
 
 valgrind-view:
 	callgrind_annotate callgrind.out.18778
@@ -35,7 +35,7 @@ gprof-view-call-graph:
 	gprof -q bootstrap.exe gmon.out
 
 profile: install-bootstrap
-	perf record lm --v23 SRC/index.lsts
+	perf record lm --v2 SRC/index.lsts
 	./report.sh
 
 compile-bootstrap:

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ dev: install-production
 	./a.out
 
 build: compile-production
-	time ./production --v2 --c -o deploy1.c SRC/index.lsts
+	time ./production --v23 --c -o deploy1.c SRC/index.lsts
 	$(CC) $(CFLAGS) deploy1.c -o deploy1
-	time ./deploy1 --v2 --c -o deploy2.c SRC/index.lsts
+	time ./deploy1 --v23 --c -o deploy2.c SRC/index.lsts
 	diff deploy1.c deploy2.c
 	mv deploy1.c BOOTSTRAP/cli.c
 	rm -f deploy1 deploy1.c deploy2.c
@@ -19,7 +19,7 @@ deploy: build smoke-test
 deploy-lite: build smoke-test-lite
 
 valgrind: install-bootstrap
-	valgrind --tool=callgrind lm --v2 SRC/index.lsts
+	valgrind --tool=callgrind lm --v23 SRC/index.lsts
 
 valgrind-view:
 	callgrind_annotate callgrind.out.18778
@@ -35,7 +35,7 @@ gprof-view-call-graph:
 	gprof -q bootstrap.exe gmon.out
 
 profile: install-bootstrap
-	perf record lm --v2 SRC/index.lsts
+	perf record lm --v23 SRC/index.lsts
 	./report.sh
 
 compile-bootstrap:

--- a/PLUGINS/BACKEND/C/blob-render.lsts
+++ b/PLUGINS/BACKEND/C/blob-render.lsts
@@ -4,8 +4,8 @@ let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContex
    match term {
       ASTNil{} => ();
       ASTEOF{} => ();
-      Var{key=key} => r = ctx.lookup(key, typeof-term(term), term).get(context-key);
-      Lit{key=key} => r = SAtom(key);
+      Var{key1=key} => r = ctx.lookup(key1, typeof-term(term), term).get(context-key);
+      Lit{key2=key} => r = SAtom(key2);
       App{ left:Lit{key:c":"}, right:App{ t=left, right:AType{tt=tt} } } => r = blob-render-simple(ctx, context-key, t).second;
       App{ left:Lit{key:c"as"}, right:App{ t=left, right:AType{tt=tt} } } => r = blob-render-simple(ctx, context-key, t).second;
       App{ left:Lit{key:c"scope"}, t=right } => r = blob-render-simple(ctx, context-key, t).second;
@@ -13,7 +13,7 @@ let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContex
          left:App{ left:Lit{key:c":"}, right:App{ left:Lit{key:c"for-arg"}, right:AType{} } },
          right:App{
             left:App{
-               left:Abs{ lhs-t=lhs:Var{lhs=key}, rhs:ASTNil{} },
+               left:Abs{ lhs-t=lhs:Var{lhs1=key}, rhs:ASTNil{} },
                right:App{ left:Var{key:c"for-arg-i"}, right:Var{vsk=key} }
             }, iter=right
          }
@@ -21,7 +21,7 @@ let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContex
          let vs = ctx.lookup-soft(vsk, ta, mk-eof());
          for list vi in vs.vararg {
             std-c-fragment-context = std-c-fragment-context.bind(lhs-t, vi);
-            let inner-ctx = ctx.bind(lhs, vs.type, vi);
+            let inner-ctx = ctx.bind(lhs1, vs.type, vi);
             r = r + blob-render-simple(inner-ctx, context-key, iter).second;
          };
       );
@@ -29,7 +29,7 @@ let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContex
          left:App{ left:Lit{key:c":"}, right:App{ left:Lit{key:c"for-atom"}, right:AType{} } },
          right:App{
             left:App{
-               left:Abs{ lhs-t=lhs:Var{lhs=key}, rhs:ASTNil{} },
+               left:Abs{ lhs-t=lhs:Var{lhs2=key}, rhs:ASTNil{} },
                rng=right
             }, iter=right
          }
@@ -38,7 +38,7 @@ let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContex
          while non-zero(rngs) { match rngs {
             SCons{ a=left, rst=right } => (
                let f = mk-expression(a);
-               let inner-ctx = ctx.bind(lhs, t0(c"L"), f);
+               let inner-ctx = ctx.bind(lhs2, t0(c"L"), f);
                std-c-fragment-context = std-c-fragment-context.bind(lhs-t,f);
                r = r + blob-render-simple(inner-ctx, context-key, iter).second;
                rngs = rst;
@@ -62,10 +62,10 @@ let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContex
          r = std-c-mangle-declaration-internal(tt.l1.normalize.rewrite-opaque-type-alias.without-any-phi, term).first;
       );
       App{ left:Var{key:c"mangle-post"}, right:AType{tt=tt} } => r = std-c-mangle-declaration-internal(tt.l1.normalize.rewrite-opaque-type-alias.without-any-phi, term).second;
-      App{ left:Abs{ lhs-t=lhs:Var{lhs=key}, rhs:ASTNil{}, tlt=tt }, rhs=right } => (
+      App{ left:Abs{ lhs-t=lhs:Var{lhs3=key}, rhs:ASTNil{}, tlt=tt }, rhs=right } => (
          let s = blob-render-simple(ctx, context-key, rhs).second;
          let f = mk-fragment().set(context-key,s).set(c"expression",s);
-         ctx = ctx.bind(lhs, typeof-term(rhs), f);
+         ctx = ctx.bind(lhs3, typeof-term(rhs), f);
          std-c-fragment-context = std-c-fragment-context.bind(lhs-t, f);
       );
       App{ f=left, a=right } => (
@@ -95,16 +95,16 @@ let blob-render-simple(ctx: FContext, context-key: CString, term: AST): (FContex
 let blob-render(ctx: FContext, term: AST, f: Fragment): Fragment = (
    match term {
       App{ left:Lit{key:c":"}, right:App{ t=left, right:AType{} } } => blob-render(ctx, t, f);
-      App{ left:Var{k=key}, a=right } => (
-         if k.has-prefix(c":")
-         then f.set(tail(k), blob-render-simple(ctx, tail(k), a).second)
-         else f.set(c"expression", blob-render-simple(ctx, tail(k), a).second)
+      App{ left:Var{k1=key}, a=right } => (
+         if k1.has-prefix(c":")
+         then f.set(tail(k1), blob-render-simple(ctx, tail(k1), a).second)
+         else f.set(c"expression", blob-render-simple(ctx, tail(k1), a).second)
       );
-      App{ rst=left, right:App{ left:Var{k=key}, a=right } } => (
+      App{ rst=left, right:App{ left:Var{k2=key}, a=right } } => (
          f = blob-render(ctx, rst, f);
-         if k.has-prefix(c":")
-         then f.set(tail(k), blob-render-simple(ctx, tail(k), a).second)
-         else f.set(c"expression", blob-render-simple(ctx, tail(k), a).second)
+         if k2.has-prefix(c":")
+         then f.set(tail(k2), blob-render-simple(ctx, tail(k2), a).second)
+         else f.set(c"expression", blob-render-simple(ctx, tail(k2), a).second)
       );
       _ => f.set(c"expression", blob-render-simple(ctx,c"expression",term).second);
    }

--- a/PLUGINS/BACKEND/C/escape-as-cstring.lsts
+++ b/PLUGINS/BACKEND/C/escape-as-cstring.lsts
@@ -2,21 +2,21 @@
 let .escape-as-cstring(in: CString): S = (
    let out = (SNil());
    while non-zero(in) { match in {
-      c"\""..  rest => (out = out + SAtom(c"\\\\\""); in = rest;);
-      c"\\:"..  rest => (out = out + SAtom(c";"); in = rest;);
-      c"\\["..  rest => (out = out + SAtom(c"("); in = rest;);
-      c"\\]"..  rest => (out = out + SAtom(c")"); in = rest;);
-      c"\\\\".. rest => (out = out + SAtom(c"\\\\\\\\"); in = rest;);
-      c"\\`"..  rest => (out = out + SAtom(c"'"); in = rest;);
-      c"\\l"..  rest => (out = out + SAtom(c"λ"); in = rest;);
-      c"\\n"..  rest => (out = out + SAtom(c"\\\\n"); in = rest;);
-      c"\\o"..  rest => (out = out + SAtom(c"#"); in = rest;);
-      c"\\s"..  rest => (out = out + SAtom(c" "); in = rest;);
-      c"\\t"..  rest => (out = out + SAtom(c"\\\\t"); in = rest;);
-      c"\\"..   rest => fail("Illegal Escape Character: \{head(rest)}");
-      rest => (
-         out = out + SAtom(clone-rope(head(rest)));
-         in = tail(rest);
+      c"\""..  rest1 => (out = out + SAtom(c"\\\\\""); in = rest1;);
+      c"\\:"..  rest2 => (out = out + SAtom(c";"); in = rest2;);
+      c"\\["..  rest3 => (out = out + SAtom(c"("); in = rest3;);
+      c"\\]"..  rest4 => (out = out + SAtom(c")"); in = rest4;);
+      c"\\\\".. rest5 => (out = out + SAtom(c"\\\\\\\\"); in = rest5;);
+      c"\\`"..  rest6 => (out = out + SAtom(c"'"); in = rest6;);
+      c"\\l"..  rest7 => (out = out + SAtom(c"λ"); in = rest7;);
+      c"\\n"..  rest8 => (out = out + SAtom(c"\\\\n"); in = rest8;);
+      c"\\o"..  rest9 => (out = out + SAtom(c"#"); in = rest9;);
+      c"\\s"..  rest10 => (out = out + SAtom(c" "); in = rest10;);
+      c"\\t"..  rest11 => (out = out + SAtom(c"\\\\t"); in = rest11;);
+      c"\\"..   rest12 => fail("Illegal Escape Character: \{head(rest12)}");
+      rest13 => (
+         out = out + SAtom(clone-rope(head(rest13)));
+         in = tail(rest13);
       );
    }};
    SAtom(c"\"") + out + SAtom(c"\"")

--- a/PLUGINS/BACKEND/C/escape-string.lsts
+++ b/PLUGINS/BACKEND/C/escape-string.lsts
@@ -1,7 +1,7 @@
 
 let escape-string(s: CString): CString = (
    let e = SNil;
-   while head(s) {
+   while head(s) != 0 {
       if head(s) == 92 {
          s = tail(s);
          match head(s) {
@@ -27,7 +27,7 @@ let escape-string(s: CString): CString = (
 
 let escape-string(s: S): S = (
    match s {
-      SAtom{atom=atom} => SAtom(escape-string(atom));
+      SAtom{atom=atom} => SAtom(escape-string(atom.into(type(CString))));
       SCons{left=left, right=right} => escape-string(left) + escape-string(right);
       _ => SNil;
    }

--- a/PLUGINS/BACKEND/C/std-c-compile-args.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-args.lsts
@@ -2,7 +2,7 @@
 
 let std-c-compile-args(callee-ctx: FContext, caller-ctx: FContext, lhs: AST, rhs: AST, f: Fragment): Tuple<Fragment,FContext,FContext> = (
    match lhs {
-      App{lhs-rst=left, right:App{ left:Lit{key:c":"}, right:App{left-lhs=left:Var{k=key}, right:AType{kt=tt}} }} => (
+      App{lhs-rst=left, right:App{ left:Lit{key:c":"}, right:App{left-lhs=left:Var{k1=key}, right:AType{kt=tt}} }} => (
          if typeof-term(rhs).is-t(c"Cons",2) {
             match rhs {
                App{le=left, re=right} => (
@@ -12,7 +12,7 @@ let std-c-compile-args(callee-ctx: FContext, caller-ctx: FContext, lhs: AST, rhs
                         if kt.is-open { callee-ctx = union(callee-ctx, unify(kt, typeof-term(re), rhs)); };
                         let c1 = std-c-compile-expr(caller-ctx, re, false);
                         caller-ctx = open(c1.context);
-                        callee-ctx = bind-vararg(callee-ctx, k, kt, c1);
+                        callee-ctx = bind-vararg(callee-ctx, k1, kt, c1);
                         (f, callee-ctx, caller-ctx) = std-c-compile-args(callee-ctx, caller-ctx, lhs, le, f);
                         f = f.set(c"frame", f.get(c"frame") + c1.get(c"frame"));
                      } else {
@@ -22,7 +22,7 @@ let std-c-compile-args(callee-ctx: FContext, caller-ctx: FContext, lhs: AST, rhs
                      if kt.is-open { callee-ctx = union(callee-ctx, unify(kt, typeof-term(re), rhs)); };
                      let c1 = std-c-compile-expr(caller-ctx, re, false);
                      caller-ctx = open(c1.context);
-                     callee-ctx = callee-ctx.bind(k, kt, c1);
+                     callee-ctx = callee-ctx.bind(k1, kt, c1);
                      std-c-fragment-context = std-c-fragment-context.bind( left-lhs, c1 );
                      (f, callee-ctx, caller-ctx) = std-c-compile-args(callee-ctx, caller-ctx, lhs-rst, le, f);
                      f = f.set(c"frame", f.get(c"frame") + c1.get(c"frame"));
@@ -37,7 +37,7 @@ let std-c-compile-args(callee-ctx: FContext, caller-ctx: FContext, lhs: AST, rhs
                   let c1 = std-c-compile-expr(caller-ctx, rhs, false);
                   f = f.set(c"frame", f.get(c"frame") + c1.get(c"frame"));
                   caller-ctx = open(c1.context);
-                  callee-ctx = bind-vararg(callee-ctx, k, kt, c1);
+                  callee-ctx = bind-vararg(callee-ctx, k1, kt, c1);
                } else {
                   (f, callee-ctx, caller-ctx) = std-c-compile-args(callee-ctx, caller-ctx, lhs-rst, rhs, f);  
                }
@@ -46,13 +46,13 @@ let std-c-compile-args(callee-ctx: FContext, caller-ctx: FContext, lhs: AST, rhs
                let c1 = std-c-compile-expr(caller-ctx, rhs, false);
                caller-ctx = open(c1.context);
                std-c-fragment-context = std-c-fragment-context.bind( left-lhs, c1 );
-               callee-ctx = callee-ctx.bind(k, kt, c1);
+               callee-ctx = callee-ctx.bind(k1, kt, c1);
                f = f.set(c"frame", f.get(c"frame") + c1.get(c"frame"));
             }
          };
          (f, callee-ctx, caller-ctx)
       );
-      App{ left:Lit{key:c":"}, right:App{left-lhs=left:Var{k=key}, right:AType{kt=tt}} } => (
+      App{ left:Lit{key:c":"}, right:App{left-lhs=left:Var{k2=key}, right:AType{kt=tt}} } => (
          if typeof-term(rhs).is-t(c"Cons",2) {
             match rhs {
                App{le=left, re=right} => (
@@ -61,7 +61,7 @@ let std-c-compile-args(callee-ctx: FContext, caller-ctx: FContext, lhs: AST, rhs
                      if kt.is-open { callee-ctx = union(callee-ctx, unify(kt, typeof-term(re), rhs)); };
                      let c1 = std-c-compile-expr(caller-ctx, re, false);
                      caller-ctx = open(c1.context);
-                     callee-ctx = bind-vararg(callee-ctx, k, kt, c1);
+                     callee-ctx = bind-vararg(callee-ctx, k2, kt, c1);
                      (f, callee-ctx, caller-ctx) = std-c-compile-args(callee-ctx, caller-ctx, lhs, le, f);
                      f = f.set(c"frame", f.get(c"frame") + c1.get(c"frame"));
                   } else {
@@ -76,7 +76,7 @@ let std-c-compile-args(callee-ctx: FContext, caller-ctx: FContext, lhs: AST, rhs
                   if kt.is-open { callee-ctx = union(callee-ctx, unify(kt, typeof-term(rhs), rhs)); };
                   let c1 = std-c-compile-expr(caller-ctx, rhs, false);
                   caller-ctx = open(c1.context);
-                  callee-ctx = bind-vararg(callee-ctx, k, kt, c1);
+                  callee-ctx = bind-vararg(callee-ctx, k2, kt, c1);
                   f = f.set(c"frame", f.get(c"frame") + c1.get(c"frame"));
                } else {
                   (f, callee-ctx, caller-ctx) = std-c-compile-args(callee-ctx, caller-ctx, lhs, rhs, f);
@@ -86,7 +86,7 @@ let std-c-compile-args(callee-ctx: FContext, caller-ctx: FContext, lhs: AST, rhs
                let c1 = std-c-compile-expr(caller-ctx, rhs, false);
                caller-ctx = open(c1.context);
                std-c-fragment-context = std-c-fragment-context.bind( left-lhs, c1 );
-               callee-ctx = callee-ctx.bind(k, kt, c1);
+               callee-ctx = callee-ctx.bind(k2, kt, c1);
                f = f.set(c"frame", f.get(c"frame") + c1.get(c"frame"));
             }
          };

--- a/PLUGINS/BACKEND/C/std-c-compile-call.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-call.lsts
@@ -3,7 +3,7 @@ let std-c-compile-call(ctx: FContext, fname: CString, args: AST): Fragment = std
 
 let std-c-compile-call(ctx: FContext, fname: CString, return-hint-if-constructor: Type, args: AST): Fragment = (
    let fterm = Some(mk-tctx()).maybe-find-callable(fname, typeof-term(args), args, return-hint-if-constructor)
-                              .expect("std-c-compile-call Function \{fname} was null\nArguments: \{typeof-term(args)}, Return Hint \{return-hint-if-constructor}\n").blame-or-zero;
+                              .expect("std-c-compile-call Function \{fname} was null\nArguments: \{typeof-term(args)}, Return Hint \{return-hint-if-constructor}\nAt \{args.location}\n").blame-or-zero;
    if typeof-term(fterm).is-t(c"Blob",0) {
       if typeof-term(fterm).is-open and fname!=c"open" and fname!=c"mov" then {
          for list tr in Some(mk-tctx()).lookups(fname) {

--- a/PLUGINS/BACKEND/C/std-c-compile-destructure-args.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-destructure-args.lsts
@@ -1,19 +1,19 @@
 
 let std-c-compile-destructure-args(ctx: FContext, lhs: AST, is-fragment: Bool): FContext = (
    match lhs {
-      App{ rst=left, right:App{ left:Lit{key:c":"}, right:App{ lhs-v=left:Var{k=key}, right:AType{kt=tt} } } } => (
+      App{ rst=left, right:App{ left:Lit{key:c":"}, right:App{ lhs-v=left:Var{k1=key}, right:AType{kt=tt} } } } => (
          ctx = std-c-compile-destructure-args(ctx, rst, is-fragment);
          if is-fragment then { kt = denormalize(kt); }
          else { kt = kt.normalize && t0(c"LocalVariable"); };
-         let fragment = if std-c-is-ctype(kt) then mk-expression(k.replace(c"-",c"_").rewrite-if-reserved) else mk-expression(uuid());
-         ctx = ctx.bind(k, kt, fragment);
+         let fragment = if std-c-is-ctype(kt) then mk-expression(k1.replace(c"-",c"_").rewrite-if-reserved) else mk-expression(uuid());
+         ctx = ctx.bind(k1, kt, fragment);
          std-c-fragment-context = std-c-fragment-context.bind(lhs-v, fragment);
       );
-      App{ left:Lit{key:c":"}, right:App{ lhs-v=left:Var{k=key}, right:AType{kt=tt} } } => (
+      App{ left:Lit{key:c":"}, right:App{ lhs-v=left:Var{k2=key}, right:AType{kt=tt} } } => (
          if is-fragment then { kt = denormalize(kt); }
          else { kt = kt.normalize && t0(c"LocalVariable"); };
-         let fragment = if std-c-is-ctype(kt) then mk-expression(k.replace(c"-",c"_").rewrite-if-reserved) else mk-expression(uuid());
-         ctx = ctx.bind(k, kt, fragment);
+         let fragment = if std-c-is-ctype(kt) then mk-expression(k2.replace(c"-",c"_").rewrite-if-reserved) else mk-expression(uuid());
+         ctx = ctx.bind(k2, kt, fragment);
          std-c-fragment-context = std-c-fragment-context.bind(lhs-v, fragment);
       );
       _ => ();

--- a/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
@@ -76,7 +76,7 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
             let def = var-to-def(t);
             let e = std-c-fragment-context.lookup(def, mk-fragment());
             if not(non-zero(e)) {
-               exit-error( untern("Unable to Find Variable Fragment in Context: \{key}"), t );
+               exit-error("Unable to Find Variable Fragment in Context: \{key}", t );
             }; e
          }
       );

--- a/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
@@ -241,7 +241,7 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
       App{ is-cons=is-cons, left=left, right=right } => (
           if not(is-cons) and typeof-term(left).is-arrow {
              match left {
-                Var{fname=key:c"<:"} => (
+                Var{fname1=key:c"<:"} => (
                    match right {
                       App{ lt=left, rt=right } => (
                          let lt-tt = typeof-term(lt);
@@ -253,12 +253,12 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
                             if can-unify( rt-val, lt-val )
                             then mk-expression(c"1")
                             else mk-expression(c"0")
-                         ) else std-c-compile-call(ctx, fname, right);
+                         ) else std-c-compile-call(ctx, fname1, right);
                       );
-                      _ => std-c-compile-call(ctx, fname, right);
+                      _ => std-c-compile-call(ctx, fname1, right);
                    }
                 );
-                Var{fname=key:c".into"} => (
+                Var{fname2=key:c".into"} => (
                    match right {
                       App{ lt=left, rt=right } => (
                          let lt-tt = typeof-term(lt);
@@ -267,28 +267,28 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
                          then (
                             let lt-val = lt-tt.slot(c"Type",1).l1.into(type(String)).into(type(CString));
                             mk-expression(lt-val.escape-as-cstring)
-                         ) else std-c-compile-call(ctx, fname, right);
+                         ) else std-c-compile-call(ctx, fname2, right);
                       );
-                      _ => std-c-compile-call(ctx, fname, right);
+                      _ => std-c-compile-call(ctx, fname2, right);
                    }
                 );
-                Var{fname=key} => (
+                Var{fname3=key} => (
                    let return-hint = ta;
-                   if fname==c"mk-hashtable" then return-hint = typeof-term(t).normalize;
-                   std-c-compile-call(ctx, fname, return-hint, right);
+                   if fname3==c"mk-hashtable" then return-hint = typeof-term(t).normalize;
+                   std-c-compile-call(ctx, fname3, return-hint, right);
                 );
-                App{ left:Lit{key:c":"}, right:App{ left:Var{fname=key}, right:AType{tt=tt} } } => (
+                App{ left:Lit{key:c":"}, right:App{ left:Var{fname4=key}, right:AType{tt=tt} } } => (
                    let return-hint = ta;
-                   if fname==c"mk-hashtable" then return-hint = typeof-term(t).normalize;
-                   std-c-compile-call(ctx, fname, return-hint, right);
+                   if fname4==c"mk-hashtable" then return-hint = typeof-term(t).normalize;
+                   std-c-compile-call(ctx, fname4, return-hint, right);
                 );
-                Lit{fname=key} => (
+                Lit{fname5=key} => (
                    let return-type = typeof-term(t).normalize;
-                   std-c-compile-call(ctx, fname, return-type, right);
+                   std-c-compile-call(ctx, fname5, return-type, right);
                 );
-                App{ left:Lit{key:c":"}, right:App{ left:Lit{fname=key}, right:AType{tt=tt} } } => (
+                App{ left:Lit{key:c":"}, right:App{ left:Lit{fname6=key}, right:AType{tt=tt} } } => (
                    let return-type = typeof-term(t).normalize;
-                   std-c-compile-call(ctx, fname, return-type, right);
+                   std-c-compile-call(ctx, fname6, return-type, right);
                 );
                 _ => (
                   let call = std-c-compile-expr(ctx, left, false);

--- a/PLUGINS/BACKEND/C/std-c-compile-function-args.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-function-args.lsts
@@ -1,7 +1,7 @@
 
 let std-c-compile-function-args(ctx: FContext, lhs: AST): S = (
    match lhs {
-      App{ rest=left, right:App{ left:Lit{key:c":"}, right:App{ v-t=left:Var{k=key}, right:AType{kt=tt} } } } => (
+      App{ rest=left, right:App{ left:Lit{key:c":"}, right:App{ v-t=left:Var{k1=key}, right:AType{kt=tt} } } } => (
          let decl = std-c-mangle-declaration(kt, lhs);
          let text = std-c-compile-function-args(ctx, rest);
          text = text + SAtom(c",");
@@ -18,7 +18,7 @@ let std-c-compile-function-args(ctx: FContext, lhs: AST): S = (
          };
          text
       );
-      App{ left:Lit{key:c":"}, right:App{ v-t=left:Var{k=key}, right:AType{kt=tt} } } => (
+      App{ left:Lit{key:c":"}, right:App{ v-t=left:Var{k2=key}, right:AType{kt=tt} } } => (
          let decl = std-c-mangle-declaration(kt, lhs);
          let text = SNil();
          if can-unify( t1(c"C",t0(c"...")), kt ) {

--- a/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
@@ -45,7 +45,7 @@ let std-c-compile-type-typedef-concrete(tctx: Maybe<TypeContext>, concrete-type:
       continue-compile-c-typedefs-concrete = cons( (tctx, concrete-type), continue-compile-c-typedefs-concrete );
    } else {
       concrete-typedef-compiled-index = concrete-typedef-compiled-index.bind(concrete-type, true);
-      is-cstruct-hard-compiled-index = is-cstruct-hard-compiled-index.bind(concrete-type, 1_u64);
+      is-cstruct-hard-compiled-index = is-cstruct-hard-compiled-index.bind(concrete-type, true);
 
       assemble-header-section = assemble-header-section + SAtom(c"typedef struct ") + std-c-mangle-type(concrete-type, td)
                               + SAtom(c" ") + std-c-mangle-type(concrete-type, td) + SAtom(c";\n");
@@ -120,18 +120,18 @@ let std-c-compile-type-typedef-concrete(tctx: Maybe<TypeContext>, concrete-type:
    };
 );
 
-let is-incomplete-typedef(tt: Type): U64 = is-incomplete-typedef(tt, tt.is-t(c"FlexibleArrayMember",0));
-let is-incomplete-typedef(tt: Type, is-flexible-array-member: U64): U64 = (
+let is-incomplete-typedef(tt: Type): Bool = is-incomplete-typedef(tt, tt.is-t(c"FlexibleArrayMember",0));
+let is-incomplete-typedef(tt: Type, is-flexible-array-member: Bool): Bool = (
    match tt {
       TAnd{conjugate=conjugate} => (
-         let r = 0_u64;
+         let r = false;
          for vector c in conjugate { r = r or is-incomplete-typedef(c, is-flexible-array-member) };
          r
       );
       TAny{} => false;
       TVar{} => false;
-      TGround{tag:"Sized",parameters:[st..]} => is-incomplete-typedef(st);
-      TGround{tag:"Array",parameters:[_..base-type..]} => if is-flexible-array-member then is-incomplete-typedef(base-type) else false;
+      TGround{tag:c"Sized",parameters:[st..]} => is-incomplete-typedef(st);
+      TGround{tag:c"Array",parameters:[_..base-type..]} => if is-flexible-array-member then is-incomplete-typedef(base-type) else false;
       TGround{} => complex-type-index.lookup(tt.ground-tag-and-arity,false)
                 and not(is-cstruct-hard-compiled-index.lookup(tt, false));
    }
@@ -139,7 +139,7 @@ let is-incomplete-typedef(tt: Type, is-flexible-array-member: U64): U64 = (
 
 let continue-compile-c-typedefs-concrete = [] : List<(TypeContext?,Type)>;
 let continue-compile-c-typedefs-count = 0_u64;
-let is-cstruct-hard-compiled-index = {} : Hashtable<Type,U64>;
+let is-cstruct-hard-compiled-index = {} : Hashtable<Type,Bool>;
 
 let try-continue-compile-c-typedefs(): Nil = (
    let continue = continue-compile-c-typedefs-concrete;

--- a/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
@@ -32,8 +32,8 @@ let std-c-compile-type-typedef-concrete(tctx: Maybe<TypeContext>, concrete-type:
    let cases = (td as Tag::Typedef).cases;
 
    let is-incomplete = false;
-   for vector Tuple{case-tag=first, case-fields=second} in cases {
-      for vector Tuple{field-name=first, field-type=second} in case-fields {
+   for vector Tuple{case-tag1=first, case-fields=second} in cases {
+      for vector Tuple{field-name1=first, field-type=second} in case-fields {
          field-type = tctx.substitute(field-type).rewrite-type-alias;
          if is-incomplete-typedef(field-type) {
             is-incomplete = true;
@@ -53,10 +53,10 @@ let std-c-compile-type-typedef-concrete(tctx: Maybe<TypeContext>, concrete-type:
       assemble-types-section = assemble-types-section + SAtom(c"struct ") + std-c-mangle-type(concrete-type, td) + SAtom(c"{\n");
       
       let has-cases = false;
-      for vector Tuple{case-tag=first, case-fields=second} in cases {
-         if case-tag==c"" {
-            for vector Tuple{field-name=first, field-type=second} in case-fields {
-               let mangled-field-name = c"0_" + field-name;
+      for vector Tuple{case-tag2=first, case-fields=second} in cases {
+         if case-tag2==c"" {
+            for vector Tuple{field-name2=first, field-type=second} in case-fields {
+               let mangled-field-name = c"0_" + field-name2;
                field-type = tctx.substitute(field-type);
                (let pre-tt, let post-tt) = std-c-mangle-declaration(field-type, td);
                assemble-types-section = assemble-types-section + SAtom(c"  ") + pre-tt + SAtom(c" ") + mangle-identifier(mangled-field-name) + post-tt + SAtom(c";\n");
@@ -69,11 +69,11 @@ let std-c-compile-type-typedef-concrete(tctx: Maybe<TypeContext>, concrete-type:
 
          assemble-types-section = assemble-types-section + SAtom(c"  union {\n");
          let case-number = 0_u64;
-         for vector Tuple{case-tag=first, case-fields=second} in cases {
-            if case-tag!=c"" and case-fields.length > 0 {
+         for vector Tuple{case-tag3=first, case-fields=second} in cases {
+            if case-tag3!=c"" and case-fields.length > 0 {
                assemble-types-section = assemble-types-section + SAtom(c"    struct {\n");
-               for vector Tuple{field-name=first, field-type=second} in case-fields {
-                  let mangled-field-name = case-number.into(type(CString)) + c"_" + field-name;
+               for vector Tuple{field-name3=first, field-type=second} in case-fields {
+                  let mangled-field-name = case-number.into(type(CString)) + c"_" + field-name3;
                   field-type = tctx.substitute(field-type);
                   (let pre-tt, let post-tt) = std-c-mangle-declaration(field-type, td);
                   assemble-types-section = assemble-types-section + SAtom(c"      ") + pre-tt + SAtom(c" ") + mangle-identifier(mangled-field-name) + post-tt + SAtom(c";\n");
@@ -86,8 +86,8 @@ let std-c-compile-type-typedef-concrete(tctx: Maybe<TypeContext>, concrete-type:
       };
       assemble-types-section = assemble-types-section + SAtom(c"};\n");
 
-      for vector Tuple{case-tag=first, case-fields=second} in cases {
-         for vector Tuple{field-name=first, field-type=second} in case-fields {
+      for vector Tuple{case-tag4=first, case-fields=second} in cases {
+         for vector Tuple{field-name4=first, field-type=second} in case-fields {
             let closed-field-type = tctx.substitute(field-type);
 
             match closed-field-type {

--- a/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-type-typedef.lsts
@@ -56,10 +56,10 @@ let std-c-compile-type-typedef-concrete(tctx: Maybe<TypeContext>, concrete-type:
       for vector Tuple{case-tag2=first, case-fields=second} in cases {
          if case-tag2==c"" {
             for vector Tuple{field-name2=first, field-type=second} in case-fields {
-               let mangled-field-name = c"0_" + field-name2;
+               let mangled-field-name1 = c"0_" + field-name2;
                field-type = tctx.substitute(field-type);
                (let pre-tt, let post-tt) = std-c-mangle-declaration(field-type, td);
-               assemble-types-section = assemble-types-section + SAtom(c"  ") + pre-tt + SAtom(c" ") + mangle-identifier(mangled-field-name) + post-tt + SAtom(c";\n");
+               assemble-types-section = assemble-types-section + SAtom(c"  ") + pre-tt + SAtom(c" ") + mangle-identifier(mangled-field-name1) + post-tt + SAtom(c";\n");
             }
          } else has-cases = true;
       };
@@ -73,10 +73,10 @@ let std-c-compile-type-typedef-concrete(tctx: Maybe<TypeContext>, concrete-type:
             if case-tag3!=c"" and case-fields.length > 0 {
                assemble-types-section = assemble-types-section + SAtom(c"    struct {\n");
                for vector Tuple{field-name3=first, field-type=second} in case-fields {
-                  let mangled-field-name = case-number.into(type(CString)) + c"_" + field-name3;
+                  let mangled-field-name2 = case-number.into(type(CString)) + c"_" + field-name3;
                   field-type = tctx.substitute(field-type);
                   (let pre-tt, let post-tt) = std-c-mangle-declaration(field-type, td);
-                  assemble-types-section = assemble-types-section + SAtom(c"      ") + pre-tt + SAtom(c" ") + mangle-identifier(mangled-field-name) + post-tt + SAtom(c";\n");
+                  assemble-types-section = assemble-types-section + SAtom(c"      ") + pre-tt + SAtom(c" ") + mangle-identifier(mangled-field-name2) + post-tt + SAtom(c";\n");
                };
                assemble-types-section = assemble-types-section + SAtom(c"    };\n");
             };

--- a/PLUGINS/BACKEND/C/std-c-is-ctype.lsts
+++ b/PLUGINS/BACKEND/C/std-c-is-ctype.lsts
@@ -1,10 +1,10 @@
 
-let std-c-is-ctype(tt: Type): U64 = (
+let std-c-is-ctype(tt: Type): Bool = (
    match tt {
       TGround{tag:c"C"} => true;
       TGround{tag:c"Array", parameters:[_.. base-type..]} => std-c-is-ctype(base-type);
       TAnd{ conjugate=conjugate } => (
-         let result = false as U64;
+         let result = false;
          for vector c in conjugate { result = result or std-c-is-ctype(c) };
          result
       );

--- a/PLUGINS/BACKEND/C/std-c-mangle-declaration.lsts
+++ b/PLUGINS/BACKEND/C/std-c-mangle-declaration.lsts
@@ -19,13 +19,13 @@ let std-c-mangle-declaration-internal(tt: Type, is-flexible-array-member: Bool, 
          let rest = std-c-mangle-declaration-internal(array-base, false, blame);
          ( rest.first, rest.second + SAtom(c"[]") )
       );
-      TGround{tag:c"Array", parameters:[ TGround{tag:c"C",parameters:[TGround{width=tag}..]}.. array-base.. ]} => (
+      TGround{tag:c"Array", parameters:[ TGround{tag:c"C",parameters:[TGround{width1=tag}..]}.. array-base.. ]} => (
          let rest = std-c-mangle-declaration-internal(array-base, false, blame);
-         ( rest.first, rest.second + SAtom(c"[") + SAtom(width) + SAtom(c"]") )
+         ( rest.first, rest.second + SAtom(c"[") + SAtom(width1) + SAtom(c"]") )
       );
-      TGround{tag:c"Array", parameters:[ TGround{width=tag}.. array-base.. ]} => (
+      TGround{tag:c"Array", parameters:[ TGround{width2=tag}.. array-base.. ]} => (
          let rest = std-c-mangle-declaration-internal(array-base, false, blame);
-         ( rest.first, rest.second + SAtom(c"[") + SAtom(width) + SAtom(c"]") )
+         ( rest.first, rest.second + SAtom(c"[") + SAtom(width2) + SAtom(c"]") )
       );
       TGround{tag:c"Array", parameters:[ TAny{}.. array-base.. ]} => (
          if is-flexible-array-member {

--- a/PLUGINS/BACKEND/C/std-c-mangle-declaration.lsts
+++ b/PLUGINS/BACKEND/C/std-c-mangle-declaration.lsts
@@ -13,7 +13,7 @@ let std-c-mangle-declaration(tt: Type, blame: AST): Tuple<S,S> = (
 
 let std-c-mangle-declaration-internal(tt: Type, blame: AST): Tuple<S,S> = std-c-mangle-declaration-internal(tt, false, blame);
 
-let std-c-mangle-declaration-internal(tt: Type, is-flexible-array-member: U64, blame: AST): Tuple<S,S> = (
+let std-c-mangle-declaration-internal(tt: Type, is-flexible-array-member: Bool, blame: AST): Tuple<S,S> = (
    match tt {
       TGround{tag:c"Array", parameters:[ TGround{tag:c"CONST"}.. array-base.. ]} => (
          let rest = std-c-mangle-declaration-internal(array-base, false, blame);

--- a/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
+++ b/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
@@ -8,9 +8,9 @@ let std-c-declare(t: CTerm): Nil = (
          (let return-type, let misc-types) = std-c-type-of-specifiers(spec);
          return-type = return-type && t0(c"C-FFI");
          for list init in inits { match init {
-            CBinaryOp{op:"=", arg1:CIdentifier{name=value}, value=arg2} => (
+            CBinaryOp{op:"=", arg1:CIdentifier{name1=value}, value=arg2} => (
                ast-parsed-program = ast-parsed-program + Glb(
-                  mk-token(name), close(App( false,
+                  mk-token(name1), close(App( false,
                      close(Lit(c":", mk-token(c":"))),
                      close(App( false,
                         close(std-c-expr-of-statement(value)),
@@ -19,13 +19,13 @@ let std-c-declare(t: CTerm): Nil = (
                   ))
                );
             );
-            CIdentifier{name=value} => (if not(std-c-declare-dedup-index.has(name)) {
-               std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name, true);
+            CIdentifier{name2=value} => (if not(std-c-declare-dedup-index.has(name2)) {
+               std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name2, true);
                if can-unify( t1(c"C",t0(c"typedef")), return-type ) {
-                  std-c-typedef-name-index = std-c-typedef-name-index.bind(name, true);
+                  std-c-typedef-name-index = std-c-typedef-name-index.bind(name2, true);
                };
                ast-parsed-program = ast-parsed-program + Glb(
-                  mk-token(name), close(App( false,
+                  mk-token(name2), close(App( false,
                      close(Lit(c":", mk-token(c":"))),
                      close(App( false,
                         close(mk-nil()),
@@ -35,51 +35,51 @@ let std-c-declare(t: CTerm): Nil = (
                );
             });
             CUnaryPrefix{op:"Declarator(", arg=arg} => (
-               (let name, let body) = std-c-sig-of-declarator(return-type, arg, ta, (None : Maybe<CTerm>)());
-               if not(std-c-declare-dedup-index.has(name.into(type(String)))) {
-                  std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name.into(type(String)), true);
+               (let name3, let body) = std-c-sig-of-declarator(return-type, arg, ta, (None : Maybe<CTerm>)());
+               if not(std-c-declare-dedup-index.has(name3.into(type(String)))) {
+                  std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name3.into(type(String)), true);
                   if can-unify( t1(c"C",t0(c"typedef")), return-type ) {
-                     std-c-typedef-name-index = std-c-typedef-name-index.bind(name.into(type(String)), true);
+                     std-c-typedef-name-index = std-c-typedef-name-index.bind(name3.into(type(String)), true);
                   };
                   ast-parsed-program = ast-parsed-program + Glb(
-                     mk-token(name), close(body)
+                     mk-token(name3), close(body)
                   );
                }
             );
             CBinaryOp{op:"Declarator(", arg1=arg1, arg2=arg2 } => (
-               (let name, let body) = std-c-sig-of-declarator(return-type, arg1, ta, Some(arg2));
-               if not(std-c-declare-dedup-index.has(name.into(type(String)))) {
-                  std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name.into(type(String)), true);
+               (let name4, let body) = std-c-sig-of-declarator(return-type, arg1, ta, Some(arg2));
+               if not(std-c-declare-dedup-index.has(name4.into(type(String)))) {
+                  std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name4.into(type(String)), true);
                   if can-unify( t1(c"C",t0(c"typedef")), return-type ) {
-                     std-c-typedef-name-index = std-c-typedef-name-index.bind(name.into(type(String)), true);
+                     std-c-typedef-name-index = std-c-typedef-name-index.bind(name4.into(type(String)), true);
                   };
                   ast-parsed-program = ast-parsed-program + Glb(
-                     mk-token(name), close(body)
+                     mk-token(name4), close(body)
                   );
                }
             );
             CBinaryOp{op:"Declarator*", ptr=arg1, arg2:CBinaryOp{op:"Declarator(", arg1=arg1, arg2=arg2 } } => (
                return-type = std-c-decorate-pointer(return-type, ptr);
-               (let name, let body) = std-c-sig-of-declarator(return-type, arg1, ta, Some(arg2));
-               if not(std-c-declare-dedup-index.has(name.into(type(String)))) {
-                  std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name.into(type(String)), true);
+               (let name5, let body) = std-c-sig-of-declarator(return-type, arg1, ta, Some(arg2));
+               if not(std-c-declare-dedup-index.has(name5.into(type(String)))) {
+                  std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name5.into(type(String)), true);
                   if can-unify( t1(c"C",t0(c"typedef")), return-type ) {
-                     std-c-typedef-name-index = std-c-typedef-name-index.bind(name.into(type(String)), true);
+                     std-c-typedef-name-index = std-c-typedef-name-index.bind(name5.into(type(String)), true);
                   };
                   ast-parsed-program = ast-parsed-program + Glb(
-                     mk-token(name), close(body)
+                     mk-token(name5), close(body)
                   );
                }
             );
-            CBinaryOp{op:"Declarator*", ptr=arg1, arg2:CIdentifier{name=value} } => (
-               if not(std-c-declare-dedup-index.has(name)) {
-                  std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name, true);
+            CBinaryOp{op:"Declarator*", ptr=arg1, arg2:CIdentifier{name6=value} } => (
+               if not(std-c-declare-dedup-index.has(name6)) {
+                  std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name6, true);
                   if can-unify( t1(c"C",t0(c"typedef")), return-type ) {
-                     std-c-typedef-name-index = std-c-typedef-name-index.bind(name, true);
+                     std-c-typedef-name-index = std-c-typedef-name-index.bind(name6, true);
                   };
                   return-type = std-c-decorate-pointer(return-type, ptr);
                   ast-parsed-program = ast-parsed-program + Glb(
-                     mk-token(name), close(App( false,
+                     mk-token(name6), close(App( false,
                         close(Lit(c":", mk-token(c":"))),
                         close(App( false,
                            close(mk-nil()),
@@ -296,44 +296,44 @@ let std-c-type-of-specifiers(specifiers: CTerm): Tuple<Type,Type> = (
       CList{value=value} => std-c-type-of-specifiers(value);
       CType1{value=value} => ( t1(c"C",t0(value.into(type(CString)))), ta );
       CBinaryOp{op:"struct", arg1:CIdentifier{name=value}, decl=arg2} => (
-         let cname = if name=="" then uuid() else name.into(type(CString));
-         if cname == c"_G_fpos_t" then ()
-         else if cname == c"_G_fpos64_t" then ()
-         else if cname == c"_IO_FILE" then ()
-         else if cname == c"re_pattern_buffer" then ()
+         let cname1 = if name=="" then uuid() else name.into(type(CString));
+         if cname1 == c"_G_fpos_t" then ()
+         else if cname1 == c"_G_fpos64_t" then ()
+         else if cname1 == c"_IO_FILE" then ()
+         else if cname1 == c"re_pattern_buffer" then ()
          else match decl {
             CMaybe{value:None{}} => ();
             CMaybe{value:Some{def=content}} => (
                ast-parsed-program = ast-parsed-program + Glb(
                   mk-token(uuid()), close(
-                     mk-lit(c"struct " + cname + c"{\n" + std-c-fragment-of-struct-definition-body(def) + c"};\n").ascript(
+                     mk-lit(c"struct " + cname1 + c"{\n" + std-c-fragment-of-struct-definition-body(def) + c"};\n").ascript(
                         t0(c"C-Fragment") && t0(c"C-FFI") && t0(c"Literal")
                      )
                   )
                );
             );
          };
-         (t1(c"C",t0(c"struct " + cname)), ta)
+         (t1(c"C",t0(c"struct " + cname1)), ta)
       );
       CBinaryOp{op:"union", arg1:CIdentifier{name=value}, decl=arg2} => (
-         let cname = if name=="" then uuid() else name.into(type(CString));
+         let cname2 = if name=="" then uuid() else name.into(type(CString));
          match decl {
             CMaybe{value:None{}} => ();
             CMaybe{value:Some{def=content}} => (
                ast-parsed-program = ast-parsed-program + Glb(
                   mk-token(uuid()), close(
-                     mk-lit(c"union " + cname + c"{\n" + std-c-fragment-of-struct-definition-body(def) + c"};\n").ascript(
+                     mk-lit(c"union " + cname2 + c"{\n" + std-c-fragment-of-struct-definition-body(def) + c"};\n").ascript(
                         t0(c"C-Fragment") && t0(c"C-FFI") && t0(c"Literal")
                      )
                   )
                );
             );
          };
-         (t1(c"C",t0(c"union " + cname)), ta)
+         (t1(c"C",t0(c"union " + cname2)), ta)
       );
       CBinaryOp{op:"enum", arg1:CIdentifier{name=value}, decl=arg2} => (
-         let cname = if name=="" then uuid() else name.into(type(CString));
-         (t1(c"C",t0(c"enum " + cname)), ta)
+         let cname3 = if name=="" then uuid() else name.into(type(CString));
+         (t1(c"C",t0(c"enum " + cname3)), ta)
       );
       _ => fail("Unsupported C Specifiers:\n\{specifiers}\n");
    };

--- a/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
+++ b/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
@@ -461,7 +461,7 @@ let std-c-expr-of-statement(t: CTerm): AST = (
             ))
          )
       );
-      CBinaryOp{op:c"Declaration", spec=arg1, arg2:CMaybe{value:Some{content:CList{decls=value}}} } => (
+      CBinaryOp{op:"Declaration", spec=arg1, arg2:CMaybe{value:Some{content:CList{decls=value}}} } => (
          (let return-type, let misc-types) = std-c-type-of-specifiers(spec);
          let expr = mk-eof();
          for list decl in decls {match decl {
@@ -483,7 +483,7 @@ let std-c-expr-of-statement(t: CTerm): AST = (
                   expr = App( close(expr), close(d) );
                } else expr = d;
             );
-            CBinaryOp{op:c"=", arg1:CIdentifier{name=value}, value=arg2 } => (
+            CBinaryOp{op:"=", arg1:CIdentifier{name=value}, value=arg2 } => (
                let d = App(
                   close(App(
                      close(Var( c"let", mk-token(c"let") )),
@@ -501,7 +501,7 @@ let std-c-expr-of-statement(t: CTerm): AST = (
                   expr = App( close(expr), close(d) );
                } else expr = d;
             );
-            CBinaryOp{op:c"Declarator*", ptr=arg1, arg2:CIdentifier{name=value}} => (
+            CBinaryOp{op:"Declarator*", ptr=arg1, arg2:CIdentifier{name=value}} => (
                return-type = std-c-decorate-pointer(return-type, ptr);
                let d = App(
                   close(App(
@@ -538,7 +538,7 @@ let std-c-expr-of-statement(t: CTerm): AST = (
             ))
          );
       );
-      CBinaryOp{op:c"TypeName", arg1=arg1, arg2=arg2 } => (
+      CBinaryOp{op:"TypeName", arg1=arg1, arg2=arg2 } => (
          (let rt, let mt) = std-c-type-of-specifiers(arg1);
          AType(rt)
       );

--- a/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
+++ b/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
@@ -4,11 +4,11 @@ let std-c-declare-dedup-index = {} : Hashtable<String,Bool>;
 let std-c-declare(t: CTerm): Nil = (
    match t {
       CFunctionDefinition{spec=specifiers,decl=declarator,dl=declaration-list,stmt=statement} => std-c-declare-function(spec, decl, dl, stmt);
-      CBinaryOp{op:c"Declaration",spec=arg1,arg2:CMaybe{value:Some{content:CList{inits=value}}}} => (
+      CBinaryOp{op:"Declaration",spec=arg1,arg2:CMaybe{value:Some{content:CList{inits=value}}}} => (
          (let return-type, let misc-types) = std-c-type-of-specifiers(spec);
          return-type = return-type && t0(c"C-FFI");
          for list init in inits { match init {
-            CBinaryOp{op:c"=", arg1:CIdentifier{name=value}, value=arg2} => (
+            CBinaryOp{op:"=", arg1:CIdentifier{name=value}, value=arg2} => (
                ast-parsed-program = ast-parsed-program + Glb(
                   mk-token(name), close(App( false,
                      close(Lit(c":", mk-token(c":"))),
@@ -34,7 +34,7 @@ let std-c-declare(t: CTerm): Nil = (
                   ))
                );
             });
-            CUnaryPrefix{op:c"Declarator(", arg=arg} => (
+            CUnaryPrefix{op:"Declarator(", arg=arg} => (
                (let name, let body) = std-c-sig-of-declarator(return-type, arg, ta, (None : Maybe<CTerm>)());
                if not(std-c-declare-dedup-index.has(name.into(type(String)))) {
                   std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name.into(type(String)), true);
@@ -46,7 +46,7 @@ let std-c-declare(t: CTerm): Nil = (
                   );
                }
             );
-            CBinaryOp{op:c"Declarator(", arg1=arg1, arg2=arg2 } => (
+            CBinaryOp{op:"Declarator(", arg1=arg1, arg2=arg2 } => (
                (let name, let body) = std-c-sig-of-declarator(return-type, arg1, ta, Some(arg2));
                if not(std-c-declare-dedup-index.has(name.into(type(String)))) {
                   std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name.into(type(String)), true);
@@ -58,7 +58,7 @@ let std-c-declare(t: CTerm): Nil = (
                   );
                }
             );
-            CBinaryOp{op:c"Declarator*", ptr=arg1, arg2:CBinaryOp{op:c"Declarator(", arg1=arg1, arg2=arg2 } } => (
+            CBinaryOp{op:"Declarator*", ptr=arg1, arg2:CBinaryOp{op:"Declarator(", arg1=arg1, arg2=arg2 } } => (
                return-type = std-c-decorate-pointer(return-type, ptr);
                (let name, let body) = std-c-sig-of-declarator(return-type, arg1, ta, Some(arg2));
                if not(std-c-declare-dedup-index.has(name.into(type(String)))) {
@@ -71,7 +71,7 @@ let std-c-declare(t: CTerm): Nil = (
                   );
                }
             );
-            CBinaryOp{op:c"Declarator*", ptr=arg1, arg2:CIdentifier{name=value} } => (
+            CBinaryOp{op:"Declarator*", ptr=arg1, arg2:CIdentifier{name=value} } => (
                if not(std-c-declare-dedup-index.has(name)) {
                   std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name, true);
                   if can-unify( t1(c"C",t0(c"typedef")), return-type ) {
@@ -99,30 +99,30 @@ let std-c-declare(t: CTerm): Nil = (
 let std-c-nametypes-of-params-list(params: List<CTerm>, is-vararg: Bool): List<(CString,Type)> = (
    let nametypes = [] : List<(CString,Type)>;
    for list p in params { match p {
-      CBinaryOp{op:c"ParameterDeclaration", spec=arg1, arg2:CIdentifier{name=value}} => (
+      CBinaryOp{op:"ParameterDeclaration", spec=arg1, arg2:CIdentifier{name=value}} => (
          (let return-type, let misc-types) = std-c-type-of-specifiers(spec);
          nametypes = cons((name.into(type(CString)), return-type), nametypes);
       );
-      CBinaryOp{op:c"ParameterDeclaration", spec=arg1, arg2:CBinaryOp{op:c"Declarator*",ptr=arg1,arg2:CIdentifier{name=value}}} => (
+      CBinaryOp{op:"ParameterDeclaration", spec=arg1, arg2:CBinaryOp{op:"Declarator*",ptr=arg1,arg2:CIdentifier{name=value}}} => (
          name = name + "_" + uuid().into(type(String)); # C names can end with _s or other literal type suffixes
          (let return-type, let misc-types) = std-c-type-of-specifiers(spec);
          return-type = std-c-decorate-pointer(return-type, ptr);
          nametypes = cons((name.into(type(CString)), return-type), nametypes);
       );
-      CBinaryOp{op:c"ParameterDeclaration", spec=arg1, arg2:CTernaryOp{op:c"Declarator[",arg1:CIdentifier{name=value}}} => (
+      CBinaryOp{op:"ParameterDeclaration", spec=arg1, arg2:CTernaryOp{op:"Declarator[",arg1:CIdentifier{name=value}}} => (
          name = name + "_" + uuid().into(type(String)); # C names can end with _s or other literal type suffixes
          (let return-type, let misc-types) = std-c-type-of-specifiers(spec);
          return-type = t2(c"Array", return-type, ta);
          nametypes = cons((name.into(type(CString)), return-type), nametypes);
       );
-      CBinaryOp{op:c"ParameterDeclaration", spec=arg1, arg2:CBinaryOp{op:c"Declarator[",arg1:CIdentifier{name=value},sz=arg2}} => (
+      CBinaryOp{op:"ParameterDeclaration", spec=arg1, arg2:CBinaryOp{op:"Declarator[",arg1:CIdentifier{name=value},sz=arg2}} => (
          name = name + "_" + uuid().into(type(String)); # C names can end with _s or other literal type suffixes
          (let return-type, let misc-types) = std-c-type-of-specifiers(spec);
          let sz-t = t1(c"C",t0(std-c-fragment-of-struct-definition-body(sz)));
          return-type = t2(c"Array", return-type, sz-t);
          nametypes = cons((name.into(type(CString)), return-type), nametypes);
       );
-      CBinaryOp{op:c"ParameterDeclaration", spec=arg1, arg2:CBinaryOp{op:c"Declarator(",decl=arg1,arg2:CList{dparams=value}}} => (
+      CBinaryOp{op:"ParameterDeclaration", spec=arg1, arg2:CBinaryOp{op:"Declarator(",decl=arg1,arg2:CList{dparams=value}}} => (
          (let name, let base-arrow-type) = std-c-type-of-arrow(spec, decl, dparams);
          name = name + c"_" + uuid(); # C names can end with _s or other literal type suffixes
          nametypes = cons((name, base-arrow-type), nametypes);
@@ -173,7 +173,7 @@ let std-c-type-of-arrow(spec: CTerm, decl: CTerm, params: List<CTerm>): (CString
 let std-c-nametype-of-decl(base-type: Type, decl: CTerm): (CString, Type) = (
    match decl {
       CIdentifier{value=value} => (value.into(type(CString)), base-type);
-      CBinaryOp{op:c"Declarator*",ptr=arg1,arg2:CIdentifier{value=value}} => (value.into(type(CString)), std-c-decorate-pointer(base-type, ptr));
+      CBinaryOp{op:"Declarator*",ptr=arg1,arg2:CIdentifier{value=value}} => (value.into(type(CString)), std-c-decorate-pointer(base-type, ptr));
       _ => (fail("Unexpected std-c-nametype-of-decl \{decl}\n"); (c"", ta));
    }
 );
@@ -186,9 +186,9 @@ let std-c-sig-of-declarator(return-type: Type, declarator: CTerm, misc-type: Typ
       Some{content=content} => (print("std-c-sig-of-declarator unrecognized params \{content}\n"); mk-nil());
    };
    match declarator {
-      CBinaryOp{op:c"Declarator*", ptr=arg1, arg2:CIdentifier{name=value}} => (
+      CBinaryOp{op:"Declarator*", ptr=arg1, arg2:CIdentifier{name=value}} => (
          misc-type = std-c-decorate-pointer(misc-type, ptr);
-         (untern(name), Abs( close(params), close(App( false,
+         (name.into(type(CString)), Abs( close(params), close(App( false,
                close(Lit(c":", mk-token(c":"))),
                close(App( false,
                   close(mk-nil()),
@@ -198,7 +198,7 @@ let std-c-sig-of-declarator(return-type: Type, declarator: CTerm, misc-type: Typ
          ))
       );
       CIdentifier{name=value} => (
-         (untern(name), Abs( close(params), close(App( false,
+         (name.into(type(CString)), Abs( close(params), close(App( false,
                close(Lit(c":", mk-token(c":"))),
                close(App( false,
                   close(mk-nil()),
@@ -237,42 +237,42 @@ let std-c-declare-function(specifiers: CTerm, declarator: CTerm, declaration-lis
 
 let std-c-fragment-of-struct-definition-body(body: CTerm): CString = (
    match body {
-      CUnaryPrefix{op:c"StructDeclarator", arg=arg} => (
+      CUnaryPrefix{op:"StructDeclarator", arg=arg} => (
          std-c-fragment-of-struct-definition-body(arg)
       );
-      CUnaryPrefix{op:c"sizeof", arg=arg} => (
+      CUnaryPrefix{op:"sizeof", arg=arg} => (
          c"sizeof(" + std-c-fragment-of-struct-definition-body(arg) + c")"
       );
-      CBinaryOp{op:c"Declarator[", arg1:CIdentifier{id=value}, arg2=arg2} => (
+      CBinaryOp{op:"Declarator[", arg1:CIdentifier{id=value}, arg2=arg2} => (
          id.into(type(CString)) + c"[" + std-c-fragment-of-struct-definition-body(arg2) + c"]"
       );
-      CBinaryOp{op:c"Declarator*", arg2=arg2} => (
+      CBinaryOp{op:"Declarator*", arg2=arg2} => (
          c"*" + std-c-fragment-of-struct-definition-body(arg2)
       );
-      CBinaryOp{op:c"TypeName", spec=arg1, arg2=arg2} => (
+      CBinaryOp{op:"TypeName", spec=arg1, arg2=arg2} => (
          (let return-type, let misc-type) = std-c-type-of-specifiers(spec);
          clone-rope(std-c-mangle-type(return-type, mk-eof()))
       );
-      CBinaryOp{op:c"-", arg1=arg1, arg2=arg2} => (
+      CBinaryOp{op:"-", arg1=arg1, arg2=arg2} => (
          c"(" + std-c-fragment-of-struct-definition-body(arg1) + c"-" + std-c-fragment-of-struct-definition-body(arg2) + c")"
       );
-      CBinaryOp{op:c"+", arg1=arg1, arg2=arg2} => (
+      CBinaryOp{op:"+", arg1=arg1, arg2=arg2} => (
          c"(" + std-c-fragment-of-struct-definition-body(arg1) + c"+" + std-c-fragment-of-struct-definition-body(arg2) + c")"
       );
-      CBinaryOp{op:c"*", arg1=arg1, arg2=arg2} => (
+      CBinaryOp{op:"*", arg1=arg1, arg2=arg2} => (
          c"(" + std-c-fragment-of-struct-definition-body(arg1) + c"*" + std-c-fragment-of-struct-definition-body(arg2) + c")"
       );
-      CBinaryOp{op:c"/", arg1=arg1, arg2=arg2} => (
+      CBinaryOp{op:"/", arg1=arg1, arg2=arg2} => (
          c"(" + std-c-fragment-of-struct-definition-body(arg1) + c"/" + std-c-fragment-of-struct-definition-body(arg2) + c")"
       );
-      CBinaryOp{op:c"%", arg1=arg1, arg2=arg2} => (
+      CBinaryOp{op:"%", arg1=arg1, arg2=arg2} => (
          c"(" + std-c-fragment-of-struct-definition-body(arg1) + c"%" + std-c-fragment-of-struct-definition-body(arg2) + c")"
       );
-      CBinaryOp{op:c"StructDeclaration", spec=arg1, decl=arg2} => (
+      CBinaryOp{op:"StructDeclaration", spec=arg1, decl=arg2} => (
          (let return-type, let misc-type) = std-c-type-of-specifiers(spec);
          c"\t" + clone-rope(std-c-mangle-type(return-type, mk-eof())) + c" " + std-c-fragment-of-struct-definition-body(decl) + c";\n"
       );
-      CBinaryOp{op:c"StructDeclarator:", arg1=arg1, arg2=arg2} => (
+      CBinaryOp{op:"StructDeclarator:", arg1=arg1, arg2=arg2} => (
          std-c-fragment-of-struct-definition-body(arg1) + c" : " + std-c-fragment-of-struct-definition-body(arg2)
       );
       CInteger{value=value} => value.into(type(CString));
@@ -294,8 +294,8 @@ let std-c-type-of-specifiers(specifiers: CTerm): Tuple<Type,Type> = (
    match specifiers {
       CMaybe{value:Some{content=content}} => std-c-type-of-specifiers(content);
       CList{value=value} => std-c-type-of-specifiers(value);
-      CType1{value=value} => ( t1(c"C",t0(untern(value))), ta );
-      CBinaryOp{op:c"struct", arg1:CIdentifier{name=value}, decl=arg2} => (
+      CType1{value=value} => ( t1(c"C",t0(value.into(type(CString)))), ta );
+      CBinaryOp{op:"struct", arg1:CIdentifier{name=value}, decl=arg2} => (
          let cname = if name=="" then uuid() else name.into(type(CString));
          if cname == c"_G_fpos_t" then ()
          else if cname == c"_G_fpos64_t" then ()
@@ -315,7 +315,7 @@ let std-c-type-of-specifiers(specifiers: CTerm): Tuple<Type,Type> = (
          };
          (t1(c"C",t0(c"struct " + cname)), ta)
       );
-      CBinaryOp{op:c"union", arg1:CIdentifier{name=value}, decl=arg2} => (
+      CBinaryOp{op:"union", arg1:CIdentifier{name=value}, decl=arg2} => (
          let cname = if name=="" then uuid() else name.into(type(CString));
          match decl {
             CMaybe{value:None{}} => ();
@@ -331,7 +331,7 @@ let std-c-type-of-specifiers(specifiers: CTerm): Tuple<Type,Type> = (
          };
          (t1(c"C",t0(c"union " + cname)), ta)
       );
-      CBinaryOp{op:c"enum", arg1:CIdentifier{name=value}, decl=arg2} => (
+      CBinaryOp{op:"enum", arg1:CIdentifier{name=value}, decl=arg2} => (
          let cname = if name=="" then uuid() else name.into(type(CString));
          (t1(c"C",t0(c"enum " + cname)), ta)
       );
@@ -368,7 +368,7 @@ let std-c-lhs-of-parameter-list(declaration-list: CTerm): AST = (
 let std-c-lift-lhs(rhs: AST): (AST, AST) = (
     let lhs = mk-eof();
     match rhs {
-       App{ is-cons:1_u8, left=left, right=right } => (
+       App{ is-cons:true, left=left, right=right } => (
           (lhs, rhs) = std-c-lift-lhs(left);
           (let new-lhs, let new-rhs) = std-c-lift-lhs(right);
           if is(lhs, mk-eof()) then (lhs = new-lhs) else (lhs = App( true, close(lhs), close(new-lhs) ));
@@ -450,13 +450,13 @@ let std-c-expr-of-statement(t: CTerm): AST = (
          )
       );
       CIdentifier{value=value} => (
-         Var( untern(value), mk-token(value) )
+         Var( value.into(type(CString)), mk-token(value) )
       );
       CInteger{value=value} => (
          App(
             close(Lit(c":", mk-token(c":"))),
             close(App(
-               close(Lit( untern(value), mk-token(value) )),
+               close(Lit( value.into(type(CString)), mk-token(value) )),
                close(AType( std-c-type-of-integer(value) ))
             ))
          )
@@ -469,7 +469,7 @@ let std-c-expr-of-statement(t: CTerm): AST = (
                let d = App(
                   close(App(
                      close(Var( c"let", mk-token(c"let") )),
-                     close(Var( untern(name), mk-token(name) ))
+                     close(Var( name.into(type(CString)), mk-token(name) ))
                   )),
                   close(App(
                      close(Lit( c":", mk-token(c":") )),
@@ -487,7 +487,7 @@ let std-c-expr-of-statement(t: CTerm): AST = (
                let d = App(
                   close(App(
                      close(Var( c"let", mk-token(c"let") )),
-                     close(Var( untern(name), mk-token(name) ))
+                     close(Var( name.into(type(CString)), mk-token(name) ))
                   )),
                   close(App(
                      close(Lit( c":", mk-token(c":") )),
@@ -506,7 +506,7 @@ let std-c-expr-of-statement(t: CTerm): AST = (
                let d = App(
                   close(App(
                      close(Var( c"let", mk-token(c"let") )),
-                     close(Var( untern(name), mk-token(name) ))
+                     close(Var( name.into(type(CString)), mk-token(name) ))
                   )),
                   close(App(
                      close(Lit( c":", mk-token(c":") )),
@@ -526,7 +526,7 @@ let std-c-expr-of-statement(t: CTerm): AST = (
       );
       CTernaryOp{op=op, arg1=arg1, arg2=arg2, arg3=arg3 } => (
          App(
-            close(Var( untern(op), mk-token(op) )),
+            close(Var( op.into(type(CString)), mk-token(op) )),
             close(App(
                true,
                close(App(
@@ -544,7 +544,7 @@ let std-c-expr-of-statement(t: CTerm): AST = (
       );
       CBinaryOp{op=op, arg1=arg1, arg2=arg2 } => (
          App(
-            close(Var( untern(op), mk-token(op) )),
+            close(Var( op.into(type(CString)), mk-token(op) )),
             close(App(
                true,
                close(std-c-expr-of-statement(arg1)),
@@ -554,19 +554,19 @@ let std-c-expr-of-statement(t: CTerm): AST = (
       );
       CUnaryPrefix{op=op, arg=arg } => (
          App(
-            close(Var( c"prefix:" + untern(op), mk-token("prefix:" + op) )),
+            close(Var( c"prefix:" + op.into(type(CString)), mk-token("prefix:" + op) )),
             close(std-c-expr-of-statement(arg))
          );
       );
       CUnaryPostfix{op=op, arg=arg } => (
          App(
-            close(Var( c"postfix:" + untern(op), mk-token("postfix:" + op) )),
+            close(Var( c"postfix:" + op.into(type(CString)), mk-token("postfix:" + op) )),
             close(std-c-expr-of-statement(arg))
          );
       );
       CZOp{op=op} => (
          App(
-            close(Var( untern("c::" + op), mk-token("c::" + op) )),
+            close(Var( ("c::" + op).into(type(CString)), mk-token("c::" + op) )),
             close(mk-nil())
          );
       );
@@ -608,13 +608,13 @@ let std-c-decorate-pointer(tt: Type, ptr: CTerm): Type = (
 
 let std-c-type-of-integer(i: String): Type = (
    if i.has-prefix("-") {
-      let n = to-u64(untern(tail(i)));
+      let n = to-u64(tail(i).into(type(CString)));
       if n <= 128 then t1(c"C",t0(c"uint8_t")) else
       if n <= 32768 then t1(c"C",t0(c"uint06_t")) else
       if n <= 2147483648 then t1(c"C",t0(c"uint22_t")) else
       t1(c"C",t0(c"uint64_t"))
    } else {
-      let n = to-u64(untern(i));
+      let n = to-u64(i.into(type(CString)));
       if n <= 255 then t1(c"C",t0(c"int8_t")) else
       if n <= 65535 then t1(c"C",t0(c"int06_t")) else
       if n <= 4294967295 then t1(c"C",t0(c"int22_t")) else

--- a/PLUGINS/FRONTEND/C/c-frontend.lsts
+++ b/PLUGINS/FRONTEND/C/c-frontend.lsts
@@ -11,7 +11,7 @@ let c-frontend(fp: CString): Nil = (
    cmd = cmd + c" -D__LM__";
    cmd = cmd + c" -include \"" + fp + c"\"";
 
-   if system(cmd) != 0 {
+   if system(cmd) as U64 != 0_u64 {
       fail(c"cpp failed. command: \"" + cmd + c"\"");
    };
 

--- a/PLUGINS/FRONTEND/C/c-frontend.lsts
+++ b/PLUGINS/FRONTEND/C/c-frontend.lsts
@@ -1,17 +1,21 @@
 
 let c-frontend(fp: CString): Nil = (
-   let tmp = intern(mktemp(untern("/tmp/lm.tmp.XXXXXX") as U8[]) as CString);
-   let cmd = "cpp /dev/null -o " + tmp;
-   cmd = cmd + " -U__USE_MISC";
-   cmd = cmd + " -D__STRICT_ANSI__";
-   cmd = cmd + " -D__LM__";
-   cmd = cmd + " -include \"" + intern(fp) + "\"";
+   # mktemp modifies this buffer, so it can't be a string constant
+   # string concatenation is used to create a dynamic string
+   let tmpfile = c"/tmp/lm.tmp.XXXXXX" + c"";
+   let tmp = mktemp(tmpfile as U8[]) as CString;
 
-   if system(untern(cmd) as U8[]) != 0 {
-      fail("cpp failed. command: \"" + cmd + "\"");
+   let cmd = c"cpp /dev/null -o " + tmp;
+   cmd = cmd + c" -U__USE_MISC";
+   cmd = cmd + c" -D__STRICT_ANSI__";
+   cmd = cmd + c" -D__LM__";
+   cmd = cmd + c" -include \"" + fp + c"\"";
+
+   if system(cmd) != 0 {
+      fail(c"cpp failed. command: \"" + cmd + c"\"");
    };
 
-   let file-contents = read-file(untern(tmp));
+   let file-contents = read-file(tmp);
    let tokens = std-c-tokenize-string(fp, file-contents);
    std-c-parse(tokens);
 );

--- a/PLUGINS/FRONTEND/C/c-parse.lsts
+++ b/PLUGINS/FRONTEND/C/c-parse.lsts
@@ -13,21 +13,21 @@ type CTerm = CInteger{value:String}
             | CString{value:String}
             | CIdentifier{value:String}
             | CType1{value:String}
-            | CList{value:List<CTerm>[]}
-            | CIList{value:List<String>[]}
-            | CMaybe{value:Maybe<CTerm>[]}
+            | CList{value:OwnedData<List<CTerm>>[]}
+            | CIList{value:OwnedData<List<String>>[]}
+            | CMaybe{value:OwnedData<Maybe<CTerm>>[]}
             | CZOp{op:String}
-            | CCompound{terms:List<CTerm>[]}
-            | CPointer{qualifiers:Maybe<List<CTerm>>[], next:Maybe<CTerm>[]}
-            | CInitializer{designator:List<CTerm>[], initializer:CTerm[]}
-            | CInitializerList{terms:List<CTerm>[]}
-            | CUnaryPostfix{op:String, arg:CTerm[]}
-            | CUnaryPrefix{op:String, arg:CTerm[]}
-            | CBinaryOp{op:String, arg1:CTerm[], arg2:CTerm[]}
-            | CTernaryOp{op:String, arg1:CTerm[], arg2:CTerm[], arg3: CTerm[]}
-            | CFor{op:String, arg1:Maybe<CTerm>[], arg2:Maybe<CTerm>[], arg3: Maybe<CTerm>[], stmt:CTerm[]}
-            | CFunctionDefinition{specifiers:CTerm[], declarator:CTerm[], declaration-list:CTerm[], statement:CTerm[]}
-            | CAccessor{accessor:String, field:String, arg:CTerm[]};
+            | CCompound{terms:OwnedData<List<CTerm>>[]}
+            | CPointer{qualifiers:OwnedData<Maybe<List<CTerm>>>[], next:OwnedData<Maybe<CTerm>>[]}
+            | CInitializer{designator:OwnedData<List<CTerm>>[], initializer:OwnedData<CTerm>[]}
+            | CInitializerList{terms:OwnedData<List<CTerm>>[]}
+            | CUnaryPostfix{op:String, arg:OwnedData<CTerm>[]}
+            | CUnaryPrefix{op:String, arg:OwnedData<CTerm>[]}
+            | CBinaryOp{op:String, arg1:OwnedData<CTerm>[], arg2:OwnedData<CTerm>[]}
+            | CTernaryOp{op:String, arg1:OwnedData<CTerm>[], arg2:OwnedData<CTerm>[], arg3: OwnedData<CTerm>[]}
+            | CFor{op:String, arg1:OwnedData<Maybe<CTerm>>[], arg2:OwnedData<Maybe<CTerm>>[], arg3: OwnedData<Maybe<CTerm>>[], stmt:OwnedData<CTerm>[]}
+            | CFunctionDefinition{specifiers:OwnedData<CTerm>[], declarator:OwnedData<CTerm>[], declaration-list:OwnedData<CTerm>[], statement:OwnedData<CTerm>[]}
+            | CAccessor{accessor:String, field:String, arg:OwnedData<CTerm>[]};
 
 let cmp(l: CTerm, r: CTerm): Ord = (
    if l.discriminator-case-tag != r.discriminator-case-tag then cmp(l.discriminator-case-tag, r.discriminator-case-tag)
@@ -94,7 +94,7 @@ let std-c-parse(tokens: List<Token>): Nil = (
    };
 );
 
-let std-c-is-reserved-word(tk: String): U64 = (
+let std-c-is-reserved-word(tk: String): Bool = (
    let reserved = false;
    if tk == "auto" then (reserved = true);
    if tk == "double" then (reserved = true);
@@ -145,34 +145,34 @@ let std-c-is-reserved-word(tk: String): U64 = (
    reserved
 );
 
-let std-c-has-class(tks: String, cls: String): U64 = (
-   let tk = untern(tks);
+let std-c-has-class(tks: String, cls: String): Bool = (
+   let tk = tks.into(type(CString));
    match cls {
-      "identifier" => tk == r/^[a-zA-Z_][a-zA-Z0-9_]*/ && not(std-c-is-reserved-word(tks));
+      "identifier" => tk == r/^[a-zA-Z_][a-zA-Z0-9_]*/ and not(std-c-is-reserved-word(tks));
       "integer" => tk == r/^[0-9]+([uU]|[lL]|wb|WB)*/                # decimal constant
-                || tk == r/^[0][0-7]+([uU]|[lL]|wb|WB)*/             # octal constant
-                || tk == r/^[0][x][0-9a-fA-F]+([uU]|[lL]|wb|WB)*/    # hexadecimal constant
-                || tk == r/^[0][bB][01]+([uU]|[lL]|wb|WB)*/;         # binary constant
+                or tk == r/^[0][0-7]+([uU]|[lL]|wb|WB)*/             # octal constant
+                or tk == r/^[0][x][0-9a-fA-F]+([uU]|[lL]|wb|WB)*/    # hexadecimal constant
+                or tk == r/^[0][bB][01]+([uU]|[lL]|wb|WB)*/;         # binary constant
       "character" => tk == r/^(u8|u|U|L)?[']([^']|([\\][']))+[']/;    # character constant
       "floating" => tk == r/^[0-9]+([.][0-9]+)?([eE][0-9]+)?[fF]?/                                        # decimal constant
-                 || tk == r/^[0][x][0-9a-fA-F]+([.][0-9a-fA-F]+)?([eE][0-9a-fA-F]+)?([pP][0-9]+)[fF]?/;   # hexadecimal constant
+                 or tk == r/^[0][x][0-9a-fA-F]+([.][0-9a-fA-F]+)?([eE][0-9a-fA-F]+)?([pP][0-9]+)[fF]?/;   # hexadecimal constant
       "string" => tk == r/^[RLuU8]*["]([^"\\]|([\\].))*["]/;
       "enumeration" => std-c-enumeration-constant-index.has(tks);
-      _ => tk == cls;
+      _ => tks == cls;
    }
 );
 
-let std-c-can-take(tokens: List<Token>, cls: String): U64 = (
-   non-zero(tokens) && std-c-has-class(head(tokens).skey, cls)
+let std-c-can-take(tokens: List<Token>, cls: String): Bool = (
+   non-zero(tokens) and std-c-has-class(head(tokens).skey, cls)
 );
 
 let std-c-take-expect(tokens: List<Token>, cls: String): List<Token> = (
-   if non-zero(tokens) && std-c-has-class(head(tokens).skey, cls) then tail(tokens)
+   if non-zero(tokens) and std-c-has-class(head(tokens).skey, cls) then tail(tokens)
    else (print("Expected token [\{cls}] at \{tokens.formatted-location}\n"); exit(1); tokens);
 );
 
 let std-c-take-maybe(tokens: List<Token>, cls: String): List<Token> = (
-   if non-zero(tokens) && std-c-has-class(head(tokens).skey, cls) then tail(tokens)
+   if non-zero(tokens) and std-c-has-class(head(tokens).skey, cls) then tail(tokens)
    else tokens;
 );
 
@@ -188,13 +188,13 @@ let std-c-parse-attribute(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> 
    # https://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html
    # just ignore attributes for now
    let no = (None : Maybe<CTerm>)();
-   while std-c-can-take(tokens, "__attribute__") || std-c-can-take(tokens, "__asm__") {
+   while std-c-can-take(tokens, "__attribute__") or std-c-can-take(tokens, "__asm__") {
       if std-c-can-take(tokens, "__attribute__") {
          tokens = std-c-take-expect(tokens, "__attribute__");
          tokens = std-c-take-expect(tokens, "(");
          tokens = std-c-take-expect(tokens, "(");
          let depth = 2_u64;
-         while non-zero(tokens) && depth > 0 {
+         while non-zero(tokens) and depth > 0 {
             if head(tokens).key == c"(" then depth = depth + 1;
             if head(tokens).key == c")" then depth = depth - 1;
             tokens = tail(tokens);
@@ -203,7 +203,7 @@ let std-c-parse-attribute(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> 
          tokens = std-c-take-expect(tokens, "__asm__");
          tokens = std-c-take-expect(tokens, "(");
          let depth = 1_u64;
-         while non-zero(tokens) && depth > 0 {
+         while non-zero(tokens) and depth > 0 {
             if head(tokens).key == c"(" then depth = depth + 1;
             if head(tokens).key == c")" then depth = depth - 1;
             tokens = tail(tokens);
@@ -222,12 +222,12 @@ let std-c-parse-function-definition(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
       let declaration-list = std-c-parse-declaration-list(tokens); tokens = declaration-list.second;
       let attr = std-c-parse-attribute(tokens); tokens = attr.second;
       let compound-statement = std-c-parse-compound-statement(tokens); tokens = compound-statement.second;
-      if declarator.first.is-some && compound-statement.first.is-some
+      if declarator.first.is-some and compound-statement.first.is-some
       then Tuple( Some(CFunctionDefinition(
-         close(declaration-specifiers.first.get-or-panic),
-         close(declarator.first.get-or-panic),
-         close(CMaybe(close(declaration-list.first))),
-         close(compound-statement.first.get-or-panic)
+         close-owned(declaration-specifiers.first.get-or-panic),
+         close-owned(declarator.first.get-or-panic),
+         close-owned(CMaybe(close-owned(declaration-list.first))),
+         close-owned(compound-statement.first.get-or-panic)
       )), tokens )
       else Tuple( no, original-tokens )
    } else Tuple( no, original-tokens );
@@ -241,7 +241,7 @@ let std-c-parse-declaration(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>
       let init-declarator-list = std-c-parse-init-declarator-list(tokens); tokens = init-declarator-list.second;
       let attr = std-c-parse-attribute(tokens); tokens = attr.second;
       tokens = std-c-take-expect(tokens, ";");
-      Tuple( Some(CBinaryOp("Declaration", close(declaration-specifiers.first.get-or-panic), close(CMaybe(close(init-declarator-list.first))) )), tokens )
+      Tuple( Some(CBinaryOp("Declaration", close-owned(declaration-specifiers.first.get-or-panic), close-owned(CMaybe(close-owned(init-declarator-list.first))) )), tokens )
    } else {
       let ad = std-c-parse-static-assert-declaration(tokens); tokens = ad.second;
       tokens = std-c-take-maybe(tokens, ";");
@@ -260,7 +260,7 @@ let std-c-parse-declaration-specifiers(tokens: List<Token>): Tuple<Maybe<CTerm>,
          spec = std-c-parse-declaration-specifier(tokens); tokens = spec.second;
          if spec.first.is-some { specs = cons( spec.first.get-or-panic, specs ); };
       };
-      Tuple( Some(CList(close(specs.reverse))), tokens )
+      Tuple( Some(CList(close-owned(specs.reverse))), tokens )
    } else Tuple( no, tokens )
 );
 
@@ -277,8 +277,8 @@ let std-c-parse-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>>
    let no = (None : Maybe<CTerm>)();
    let pointer = std-c-parse-pointer(tokens); tokens = pointer.second;
    let dd = std-c-parse-direct-declarator(tokens); tokens = dd.second;
-   if pointer.first.is-some && dd.first.is-some
-   then Tuple( Some(CBinaryOp("Declarator*", close(pointer.first.get-or-panic), close(dd.first.get-or-panic))), tokens )
+   if pointer.first.is-some and dd.first.is-some
+   then Tuple( Some(CBinaryOp("Declarator*", close-owned(pointer.first.get-or-panic), close-owned(dd.first.get-or-panic))), tokens )
    else dd
 );
 
@@ -292,7 +292,7 @@ let std-c-parse-declaration-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<T
          decls = cons(declaration.first.get-or-panic, decls);
          declaration = std-c-parse-declaration(tokens); tokens = declaration.second;
       };
-      Tuple( Some(CList(close(decls))), tokens )
+      Tuple( Some(CList(close-owned(decls))), tokens )
    } else Tuple( no, tokens )
 );
 
@@ -307,7 +307,7 @@ let std-c-parse-compound-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List
          declaration-or-statement = std-c-parse-declaration-or-statement(tokens); tokens = declaration-or-statement.second;
       };
       tokens = std-c-take-expect(tokens, "}");
-      Tuple( Some(CCompound(close(stmts.reverse))), tokens );
+      Tuple( Some(CCompound(close-owned(stmts.reverse))), tokens );
    } else Tuple( no, tokens)
 );
 
@@ -327,7 +327,7 @@ let std-c-parse-init-declarator-list(tokens: List<Token>): Tuple<Maybe<CTerm>,Li
          id = std-c-parse-init-declarator(tokens); tokens = id.second;
          if id.first.is-some { ids = cons( id.first.get-or-panic, ids ) };
       };
-      Tuple( Some(CList(close(ids.reverse))), tokens )
+      Tuple( Some(CList(close-owned(ids.reverse))), tokens )
    } else Tuple(no, tokens);
 );
 
@@ -339,7 +339,7 @@ let std-c-parse-init-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<To
          let op = head(tokens).skey; tokens = std-c-take-expect(tokens, "=");
          let initializer = std-c-parse-initializer(tokens); tokens = initializer.second;
          if initializer.first.is-none then std-c-take-expect(tokens, "[Initializer]");
-         Tuple( Some(CBinaryOp( op, close(declarator.first.get-or-panic), close(initializer.first.get-or-panic) )), tokens )
+         Tuple( Some(CBinaryOp( op, close-owned(declarator.first.get-or-panic), close-owned(initializer.first.get-or-panic) )), tokens )
       } else declarator
    } else declarator
 );
@@ -357,7 +357,7 @@ let std-c-parse-static-assert-declaration(tokens: List<Token>): Tuple<Maybe<CTer
       tokens = std-c-take-expect(tokens, "string");
       tokens = std-c-take-expect(tokens, ")");
       tokens = std-c-take-expect(tokens, ";");
-      Tuple( Some(CBinaryOp( op, close(constant-expression.first.get-or-panic), close(CString(s)) )), tokens )
+      Tuple( Some(CBinaryOp( op, close-owned(constant-expression.first.get-or-panic), close-owned(CString(s)) )), tokens )
    } else Tuple( no, tokens )
 );
 
@@ -379,7 +379,7 @@ let std-c-parse-type-qualifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Tok
    else if std-c-can-take(tokens, "restrict") then (let t = head(tokens).skey; tokens = std-c-take-expect(tokens, "restrict"); Tuple(Some(CType1(t)), tokens) )
    else if std-c-can-take(tokens, "__restrict") then (let t = head(tokens).skey; tokens = std-c-take-expect(tokens, "__restrict"); Tuple(Some(CType1(t)), tokens) )
    else if std-c-can-take(tokens, "volatile") then (let t = head(tokens).skey; tokens = std-c-take-expect(tokens, "volatile"); Tuple(Some(CType1(t)), tokens) )
-   else if std-c-can-take(tokens, "_Atomic") && not(std-c-can-take(tail(tokens), "("))
+   else if std-c-can-take(tokens, "_Atomic") and not(std-c-can-take(tail(tokens), "("))
    then (let t = head(tokens).skey; tokens = std-c-take-expect(tokens, "_Atomic"); Tuple(Some(CType1(t)), tokens) )
    else Tuple(no, tokens)
 );
@@ -403,7 +403,7 @@ let std-c-parse-alignment-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
       let tn = std-c-parse-type-name(tokens);
       if tn.first.is-none { tn = std-c-parse-constant-expression(tokens); tokens = tn.second; };
       if tn.first.is-none { tokens = std-c-take-expect(tokens, "[Alignment Specifier]"); };
-      Tuple( Some( CUnaryPrefix("_Alignas",close(tn.first.get-or-panic)) ), tokens )
+      Tuple( Some( CUnaryPrefix("_Alignas",close-owned(tn.first.get-or-panic)) ), tokens )
    } else Tuple(no, tokens)
 );
 
@@ -423,30 +423,30 @@ let std-c-parse-direct-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
       } else Tuple( no, original-tokens )
    } else Tuple( yes, tokens );
    tokens = be.second;
-   while be.first.is-some && (std-c-can-take(tokens,"(") || std-c-can-take(tokens, "[")) {
-      if std-c-can-take(tokens,"[") && std-c-can-take(tail(tokens),"*") {
+   while be.first.is-some and (std-c-can-take(tokens,"(") or std-c-can-take(tokens, "[")) {
+      if std-c-can-take(tokens,"[") and std-c-can-take(tail(tokens),"*") {
          tokens = std-c-take-expect(tokens, "[");
          tokens = std-c-take-expect(tokens, "*");
          tokens = std-c-take-expect(tokens, "]");
-         be = Tuple( Some(CUnaryPrefix("Declarator:*", close(be.first.get-or-panic))), tokens )
-      } else if std-c-can-take(tokens,"[") && std-c-can-take(tail(tokens),"static") {
+         be = Tuple( Some(CUnaryPrefix("Declarator:*", close-owned(be.first.get-or-panic))), tokens )
+      } else if std-c-can-take(tokens,"[") and std-c-can-take(tail(tokens),"static") {
          tokens = std-c-take-expect(tokens, "[");
          tokens = std-c-take-expect(tokens, "static");
          let tql = std-c-parse-type-qualifier-list(tokens); tokens = tql.second;
          let ae = std-c-parse-assignment-expression(tokens); tokens = ae.second;
          tokens = std-c-take-expect(tokens, "]");
-         if ae.first.is-some && tql.first.is-some
+         if ae.first.is-some and tql.first.is-some
          then { be = Tuple( Some(CTernaryOp(
             "Declarator:static",
-             close(be.first.get-or-panic),
-             close(CList(close(tql.first.get-or-panic))),
-             close(ae.first.get-or-panic)
+             close-owned(be.first.get-or-panic),
+             close-owned(CList(close-owned(tql.first.get-or-panic))),
+             close-owned(ae.first.get-or-panic)
          )), tokens )}
          else if ae.first.is-some
          then { be = Tuple( Some(CBinaryOp(
             "Declarator:static",
-             close(be.first.get-or-panic),
-             close(ae.first.get-or-panic)
+             close-owned(be.first.get-or-panic),
+             close-owned(ae.first.get-or-panic)
          )), tokens )}
          else {be = Tuple( no, tokens )}
       } else if std-c-can-take(tokens,"[") {
@@ -460,14 +460,14 @@ let std-c-parse-direct-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
          else { false; };
          let ae = std-c-parse-assignment-expression(tokens); tokens = ae.second;
          tokens = std-c-take-expect(tokens, "]");
-         if tql.first.is-some && pointer
-         then {be = Tuple( Some(CBinaryOp("Declarator[:*", close(be.first.get-or-panic), close(CList(close(tql.first.get-or-panic))))), tokens )}
-         else if tql.first.is-some && static && ae.first.is-some
-         then {be = Tuple( Some(CTernaryOp("Declarator[:*", close(be.first.get-or-panic), close(CList(close(tql.first.get-or-panic))), close(ae.first.get-or-panic))), tokens )}
-         else if tql.first.is-some && ae.first.is-some
-         then {be = Tuple( Some(CTernaryOp("Declarator[", close(be.first.get-or-panic), close(CList(close(tql.first.get-or-panic))), close(ae.first.get-or-panic))), tokens )}
+         if tql.first.is-some and pointer
+         then {be = Tuple( Some(CBinaryOp("Declarator[:*", close-owned(be.first.get-or-panic), close-owned(CList(close-owned(tql.first.get-or-panic))))), tokens )}
+         else if tql.first.is-some and static and ae.first.is-some
+         then {be = Tuple( Some(CTernaryOp("Declarator[:*", close-owned(be.first.get-or-panic), close-owned(CList(close-owned(tql.first.get-or-panic))), close-owned(ae.first.get-or-panic))), tokens )}
+         else if tql.first.is-some and ae.first.is-some
+         then {be = Tuple( Some(CTernaryOp("Declarator[", close-owned(be.first.get-or-panic), close-owned(CList(close-owned(tql.first.get-or-panic))), close-owned(ae.first.get-or-panic))), tokens )}
          else if ae.first.is-some
-         then {be = Tuple( Some(CBinaryOp("Declarator[", close(be.first.get-or-panic), close(ae.first.get-or-panic))), tokens )}
+         then {be = Tuple( Some(CBinaryOp("Declarator[", close-owned(be.first.get-or-panic), close-owned(ae.first.get-or-panic))), tokens )}
          else {be = Tuple( no, tokens )}
       } else if std-c-can-take(tokens,"(") {
          tokens = std-c-take-expect(tokens, "(");
@@ -478,14 +478,14 @@ let std-c-parse-direct-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
             tokens = ptl.second;
          } else {
             if let Tuple{first:Some{content=content}, second=second} = std-c-parse-identifier-list(tokens) {
-               te = Some(CIList(close(content)));
+               te = Some(CIList(close-owned(content)));
                tokens = second;
             };
          };
          tokens = std-c-take-expect(tokens, ")");
          if te.is-some
-         then {be = Tuple( Some(CBinaryOp("Declarator(", close(be.first.get-or-panic), close(te.get-or-panic))), tokens )}
-         else {be = Tuple( Some(CUnaryPrefix("Declarator(", close(be.first.get-or-panic))), tokens )}
+         then {be = Tuple( Some(CBinaryOp("Declarator(", close-owned(be.first.get-or-panic), close-owned(te.get-or-panic))), tokens )}
+         else {be = Tuple( Some(CUnaryPrefix("Declarator(", close-owned(be.first.get-or-panic))), tokens )}
       }
    };
    be
@@ -511,10 +511,10 @@ let std-c-parse-designative-initializer(tokens: List<Token>): Tuple<Maybe<CTerm>
    let no = (None : Maybe<CTerm>)();
    let designation = std-c-parse-designation(tokens); tokens = designation.second;
    let initializer = std-c-parse-initializer(tokens); tokens = initializer.second;
-   if designation.first.is-some && initializer.first.is-some
-   then Tuple( Some(CInitializer(close(designation.first.get-or-panic),close(initializer.first.get-or-panic))), tokens )
+   if designation.first.is-some and initializer.first.is-some
+   then Tuple( Some(CInitializer(close-owned(designation.first.get-or-panic),close-owned(initializer.first.get-or-panic))), tokens )
    else if initializer.first.is-some
-   then Tuple( Some(CInitializer(close([] : List<CTerm>),close(initializer.first.get-or-panic))), tokens )
+   then Tuple( Some(CInitializer(close-owned([] : List<CTerm>),close-owned(initializer.first.get-or-panic))), tokens )
    else Tuple( no, tokens );
 );
 
@@ -542,27 +542,27 @@ let std-c-parse-initializer(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>
       };
       initializer-list.second = std-c-take-expect(tokens, "}");
       if initializer-list.first.is-some
-      then Tuple( Some(CInitializerList(close(initializer-list.first.get-or-panic))), tokens )
+      then Tuple( Some(CInitializerList(close-owned(initializer-list.first.get-or-panic))), tokens )
       else Tuple( no, tokens );
    } else std-c-parse-assignment-expression(tokens);
 );
 
 let std-c-parse-atomic-type-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let no = (None : Maybe<CTerm>)();
-   if std-c-can-take(tokens, "_Atomic") && std-c-can-take(tail(tokens), "(") then {
+   if std-c-can-take(tokens, "_Atomic") and std-c-can-take(tail(tokens), "(") then {
       let op = head(tokens).skey; tokens = std-c-take-expect(tokens, "_Atomic");
       tokens = std-c-take-expect(tokens, "(");
       let tn = std-c-parse-type-name(tokens); tokens = tn.second;
       tokens = std-c-take-expect(tokens, ")");
       if tn.first.is-some
-      then Tuple( Some(CUnaryPrefix(op, close(tn.first.get-or-panic))), tokens )
+      then Tuple( Some(CUnaryPrefix(op, close-owned(tn.first.get-or-panic))), tokens )
       else Tuple( no, tokens )
    } else Tuple( no, tokens )
 );
 
 let std-c-parse-struct-or-union-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let no = (None : Maybe<CTerm>)();
-   if std-c-can-take(tokens, "struct") || std-c-can-take(tokens, "union") {
+   if std-c-can-take(tokens, "struct") or std-c-can-take(tokens, "union") {
       let op = head(tokens).skey; tokens = tail(tokens);
       let attr = std-c-parse-attribute(tokens); tokens = attr.second;
       let id = if std-c-can-take(tokens, "identifier") {
@@ -578,7 +578,7 @@ let std-c-parse-struct-or-union-specifier(tokens: List<Token>): Tuple<Maybe<CTer
          tokens = std-c-take-expect(tokens, "}");
       };
       let attr2 = std-c-parse-attribute(tokens); tokens = attr2.second;
-      Tuple( Some(CBinaryOp(op, close(CIdentifier(id)), close(CMaybe(close(sdl))))), tokens )
+      Tuple( Some(CBinaryOp(op, close-owned(CIdentifier(id)), close-owned(CMaybe(close-owned(sdl))))), tokens )
    } else Tuple( no, tokens )
 );
 
@@ -595,7 +595,7 @@ let std-c-parse-struct-declaration-list(tokens: List<Token>): Tuple<Maybe<CTerm>
             tokens = sq.second;
          };
       };
-      Tuple( Some(CList(close(sql.reverse))), tokens )
+      Tuple( Some(CList(close-owned(sql.reverse))), tokens )
    } else Tuple ( no, tokens )
 );
 
@@ -606,8 +606,8 @@ let std-c-parse-struct-declaration(tokens: List<Token>): Tuple<Maybe<CTerm>,List
       let sdl = std-c-parse-struct-declarator-list(tokens); tokens = sdl.second;
       tokens = std-c-take-expect(tokens, ";");
       if sdl.first.is-some
-      then Tuple( Some(CBinaryOp( "StructDeclaration", close(CList(close(sql.first.get-or-panic))), close(sdl.first.get-or-panic) )), tokens )
-      else Tuple( Some(CUnaryPrefix( "StructDeclaration", close(CList(close(sql.first.get-or-panic))) )), tokens )
+      then Tuple( Some(CBinaryOp( "StructDeclaration", close-owned(CList(close-owned(sql.first.get-or-panic))), close-owned(sdl.first.get-or-panic) )), tokens )
+      else Tuple( Some(CUnaryPrefix( "StructDeclaration", close-owned(CList(close-owned(sql.first.get-or-panic))) )), tokens )
    } else std-c-parse-static-assert-declaration(tokens);
 );
 
@@ -625,9 +625,9 @@ let std-c-parse-enumerator-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,Li
          tokens = std-c-take-expect(tokens, "}");
          if el.first.is-some
          then el.first.get-or-panic
-         else CList(close([] : List<CTerm>));
-      } else CList(close([] : List<CTerm>));
-      Tuple( Some(CBinaryOp(op, close(CIdentifier(id)), close(es) )), tokens )
+         else CList(close-owned([] : List<CTerm>));
+      } else CList(close-owned([] : List<CTerm>));
+      Tuple( Some(CBinaryOp(op, close-owned(CIdentifier(id)), close-owned(es) )), tokens )
    } else Tuple( no, tokens )
 );
 
@@ -642,7 +642,7 @@ let std-c-parse-enumerator-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<To
          tokens = e.second;
          if e.first.is-some { es = cons( e.first.get-or-panic, es ); };
       };
-      e = Tuple( Some(CList(close(es))), tokens );
+      e = Tuple( Some(CList(close-owned(es))), tokens );
    };
    e
 );
@@ -660,7 +660,7 @@ let std-c-parse-enumerator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>>
          std-c-parse-constant-expression(tokens);
       } else Tuple( no, tokens );
       tokens = ce.second;
-      Tuple( Some(CBinaryOp("Enumerator", close(CIdentifier(ec)), close(CMaybe(close(ce.first))) )), tokens )
+      Tuple( Some(CBinaryOp("Enumerator", close-owned(CIdentifier(ec)), close-owned(CMaybe(close-owned(ce.first))) )), tokens )
    } else Tuple( no, tokens )
 );
 
@@ -670,7 +670,7 @@ let std-c-parse-type-name(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> 
    if sql.first.is-some then {
       tokens = sql.second;
       let ad = std-c-parse-abstract-declarator(tokens); tokens = ad.second;
-      Tuple( Some(CBinaryOp( "TypeName", close(CList(close(sql.first.get-or-panic))), close(CMaybe(close(ad.first))) )), tokens )
+      Tuple( Some(CBinaryOp( "TypeName", close-owned(CList(close-owned(sql.first.get-or-panic))), close-owned(CMaybe(close-owned(ad.first))) )), tokens )
    } else Tuple( no, tokens )
 );
 
@@ -704,7 +704,7 @@ std-c-typedef-name-index = std-c-typedef-name-index.bind("__builtin_va_list", tr
 
 let std-c-parse-typedef-name(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let no = (None : Maybe<CTerm>)();
-   if non-zero(tokens) && std-c-typedef-name-index.has(head(tokens).skey) {
+   if non-zero(tokens) and std-c-typedef-name-index.has(head(tokens).skey) {
       Tuple( Some(CType1(head(tokens).skey)), tail(tokens) )
    } else Tuple( no, tokens )
 );
@@ -723,7 +723,7 @@ let std-c-parse-type-specifier(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Tok
    else if std-c-can-take(tokens, "_Complex") then (let t = head(tokens).skey; tokens = std-c-take-expect(tokens, "_Complex"); Tuple(Some(CType1(t)), tokens) )
    else if std-c-can-take(tokens, "_Imaginary") then (let t = head(tokens).skey; tokens = std-c-take-expect(tokens, "_Imaginary"); Tuple(Some(CType1(t)), tokens) )
    else if let Tuple{first:Some{ats=content},tokens2=second} = std-c-parse-atomic-type-specifier(tokens) then Tuple(Some(ats), tokens2)
-   else if std-c-can-take(tokens, "struct") || std-c-can-take(tokens, "union") then std-c-parse-struct-or-union-specifier(tokens)
+   else if std-c-can-take(tokens, "struct") or std-c-can-take(tokens, "union") then std-c-parse-struct-or-union-specifier(tokens)
    else if std-c-can-take(tokens, "enum") then std-c-parse-enumerator-specifier(tokens)
    else std-c-parse-typedef-name(tokens)
 );
@@ -734,7 +734,7 @@ let std-c-parse-pointer(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = 
       tokens = std-c-take-expect(tokens, "*");
       let type-qualifier-list = std-c-parse-type-qualifier-list(tokens); tokens = type-qualifier-list.second;
       let next-pointer = std-c-parse-pointer(tokens); tokens = next-pointer.second;
-      Tuple( Some(CPointer( close(type-qualifier-list.first), close(next-pointer.first) )), tokens )
+      Tuple( Some(CPointer( close-owned(type-qualifier-list.first), close-owned(next-pointer.first) )), tokens )
    } else Tuple(no, tokens)   
 );
 
@@ -742,8 +742,8 @@ let std-c-parse-abstract-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
    let no = (None : Maybe<CTerm>)();
    let p = std-c-parse-pointer(tokens); tokens = p.second;
    let dac = std-c-parse-direct-abstract-declarator(tokens); tokens = dac.second;
-   if p.first.is-some && dac.first.is-some
-   then Tuple( Some(CBinaryOp("AbstractDeclarator",close(p.first.get-or-panic),close(dac.first.get-or-panic))), tokens )
+   if p.first.is-some and dac.first.is-some
+   then Tuple( Some(CBinaryOp("AbstractDeclarator",close-owned(p.first.get-or-panic),close-owned(dac.first.get-or-panic))), tokens )
    else if dac.first.is-some
    then Tuple( dac.first, tokens )
    else Tuple( no, tokens )
@@ -770,7 +770,7 @@ let std-c-parse-direct-abstract-declarator(tokens: List<Token>): Tuple<Maybe<CTe
       let ad = std-c-parse-abstract-declarator(tokens);
       # '(', parameter-type-list, ')'
       if ad.first.is-none {
-         ad.first = Some(CUnaryPrefix("AbstractDeclarator",close(CZOp(op))));
+         ad.first = Some(CUnaryPrefix("AbstractDeclarator",close-owned(CZOp(op))));
       };
       ad.second = std-c-take-expect(tokens, ")");
       ad
@@ -779,10 +779,10 @@ let std-c-parse-direct-abstract-declarator(tokens: List<Token>): Tuple<Maybe<CTe
       if std-c-can-take(tokens, "*") {
          let p = head(tokens).skey; tokens = std-c-take-expect(tokens, "*");
          tokens = std-c-take-expect(tokens, "]");
-         Tuple( Some(CBinaryOp("AbstractDeclarator",close(CZOp(op)),close(CType1(p)))), tokens )
+         Tuple( Some(CBinaryOp("AbstractDeclarator",close-owned(CZOp(op)),close-owned(CType1(p)))), tokens )
       } else if std-c-can-take(tokens, "]") {
          tokens = std-c-take-expect(tokens, "]");
-         Tuple( Some(CUnaryPrefix("AbstractDeclarator",close(CZOp(op)))), tokens )
+         Tuple( Some(CUnaryPrefix("AbstractDeclarator",close-owned(CZOp(op)))), tokens )
       } else if std-c-can-take(tokens, "static") {
          Tuple( no, tokens )
       } else {
@@ -810,10 +810,10 @@ let std-c-parse-parameter-type-list(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
    let ptl = std-c-parse-parameter-list(tokens);
    if ptl.first.is-some {
       tokens = ptl.second;
-      if std-c-can-take(tokens, ",") && std-c-can-take(tail(tokens),"...") {
+      if std-c-can-take(tokens, ",") and std-c-can-take(tail(tokens),"...") {
          tokens = std-c-take-expect(tokens, ",");
          tokens = std-c-take-expect(tokens, "...");
-         Tuple( Some(CUnaryPrefix( "ParameterTypeList...", close(ptl.first.get-or-panic) )), tokens )
+         Tuple( Some(CUnaryPrefix( "ParameterTypeList...", close-owned(ptl.first.get-or-panic) )), tokens )
       } else ptl
    } else Tuple( no, tokens )
 );
@@ -824,7 +824,7 @@ let std-c-parse-struct-declarator-list(tokens: List<Token>): Tuple<Maybe<CTerm>,
    if sq.first.is-some {
       let sql = [sq.first.get-or-panic];
       tokens = sq.second;
-      while sq.first.is-some && std-c-can-take(tokens, ",") {
+      while sq.first.is-some and std-c-can-take(tokens, ",") {
          tokens = std-c-take-expect(tokens, ",");
          sq = std-c-parse-struct-declarator(tokens);
          if sq.first.is-some {
@@ -832,7 +832,7 @@ let std-c-parse-struct-declarator-list(tokens: List<Token>): Tuple<Maybe<CTerm>,
             tokens = sq.second;
          };
       };
-      Tuple( Some(CList(close(sql.reverse))), tokens )
+      Tuple( Some(CList(close-owned(sql.reverse))), tokens )
    } else Tuple ( no, tokens )
 );
 
@@ -842,7 +842,7 @@ let std-c-parse-struct-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
       let op = head(tokens).skey; tokens = std-c-take-expect(tokens, ":");
       let ce = std-c-parse-constant-expression(tokens);
       if ce.first.is-some
-      then Tuple( Some(CUnaryPrefix("StructDeclarator:", close(ce.first.get-or-panic))), tokens )
+      then Tuple( Some(CUnaryPrefix("StructDeclarator:", close-owned(ce.first.get-or-panic))), tokens )
       else Tuple( no, tokens )
    } else {
       let decl = std-c-parse-declarator(tokens); tokens = decl.second;
@@ -851,10 +851,10 @@ let std-c-parse-struct-declarator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
          let ce-next = std-c-parse-constant-expression(tokens); tokens = ce-next.second;
          ce-next.first;
       } else no;
-      if decl.first.is-some && ce.is-some
-      then Tuple( Some(CBinaryOp("StructDeclarator:", close(decl.first.get-or-panic), close(ce.get-or-panic))), tokens )
+      if decl.first.is-some and ce.is-some
+      then Tuple( Some(CBinaryOp("StructDeclarator:", close-owned(decl.first.get-or-panic), close-owned(ce.get-or-panic))), tokens )
       else if decl.first.is-some
-      then Tuple( Some(CUnaryPrefix("StructDeclarator", close(decl.first.get-or-panic))), tokens )
+      then Tuple( Some(CUnaryPrefix("StructDeclarator", close-owned(decl.first.get-or-panic))), tokens )
       else Tuple( no, tokens )
    }
 );
@@ -913,7 +913,7 @@ let std-c-parse-primary-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List
    if ts.first.is-none then (ts = std-c-parse-constant(tokens));
    if ts.first.is-none then (ts = std-c-parse-identifier(tokens));
    if ts.first.is-none then (ts = std-c-parse-string(tokens));
-   if ts.first.is-none && std-c-can-take(tokens, "(") {
+   if ts.first.is-none and std-c-can-take(tokens, "(") {
       let tokens2 = std-c-take-expect(tokens, "(");
       ts = std-c-parse-expression(tokens2);
       if ts.first.is-some {
@@ -930,12 +930,12 @@ let std-c-parse-parameter-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Tok
    if ptl.first.is-some {
       let pts = [ptl.first.get-or-panic];
       tokens = ptl.second;
-      while std-c-can-take(tokens, ",") && not(std-c-can-take(tail(tokens),"...")) {
+      while std-c-can-take(tokens, ",") and not(std-c-can-take(tail(tokens),"...")) {
          tokens = std-c-take-expect(tokens, ",");
          ptl = std-c-parse-parameter-declaration(tokens); tokens = ptl.second;
          if ptl.first.is-some { pts = cons( ptl.first.get-or-panic, pts ); };
       };
-      Tuple( Some(CList(close(pts.reverse))), tokens )
+      Tuple( Some(CList(close-owned(pts.reverse))), tokens )
    } else Tuple( no, tokens )
 );
 
@@ -948,19 +948,19 @@ let std-c-parse-parameter-declaration(tokens: List<Token>): Tuple<Maybe<CTerm>,L
       if declarator.first.is-none { declarator = std-c-parse-abstract-declarator(tokens); };
       tokens = declarator.second;
       if declarator.first.is-some {
-         Tuple( Some(CBinaryOp("ParameterDeclaration", close(ds.first.get-or-panic), close(declarator.first.get-or-panic) )), tokens )
-      } else Tuple( Some(CUnaryPrefix("ParameterDeclaration", close(ds.first.get-or-panic) )), tokens );
+         Tuple( Some(CBinaryOp("ParameterDeclaration", close-owned(ds.first.get-or-panic), close-owned(declarator.first.get-or-panic) )), tokens )
+      } else Tuple( Some(CUnaryPrefix("ParameterDeclaration", close-owned(ds.first.get-or-panic) )), tokens );
    } else Tuple( no, tokens )
 );
 
 let std-c-parse-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-assignment-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
+   while expression.first.is-some and (
       std-c-can-take(tokens, ",")
    ) {
       let op = head(tokens).skey; tokens = tail(tokens);
       let re = std-c-parse-assignment-expression(tokens); tokens = re.second;
-      let e = CBinaryOp( op, close(expression.first.get-or-panic), close(re.first.get-or-panic) );
+      let e = CBinaryOp( op, close-owned(expression.first.get-or-panic), close-owned(re.first.get-or-panic) );
       expression = Tuple( Some(e), tokens );
    };
    expression
@@ -968,22 +968,22 @@ let std-c-parse-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>>
 
 let std-c-parse-assignment-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let ue = std-c-parse-unary-expression(tokens);
-   if ue.first.is-some && (
+   if ue.first.is-some and (
       std-c-can-take(ue.second, "=")
-   || std-c-can-take(ue.second, "*=")
-   || std-c-can-take(ue.second, "/=")
-   || std-c-can-take(ue.second, "%=")
-   || std-c-can-take(ue.second, "+=")
-   || std-c-can-take(ue.second, "-=")
-   || std-c-can-take(ue.second, "<<=")
-   || std-c-can-take(ue.second, ">>=")
-   || std-c-can-take(ue.second, "&=")
-   || std-c-can-take(ue.second, "^=")
-   || std-c-can-take(ue.second, "|=")) {
+   or std-c-can-take(ue.second, "*=")
+   or std-c-can-take(ue.second, "/=")
+   or std-c-can-take(ue.second, "%=")
+   or std-c-can-take(ue.second, "+=")
+   or std-c-can-take(ue.second, "-=")
+   or std-c-can-take(ue.second, "<<=")
+   or std-c-can-take(ue.second, ">>=")
+   or std-c-can-take(ue.second, "&=")
+   or std-c-can-take(ue.second, "^=")
+   or std-c-can-take(ue.second, "|=")) {
       let op = head(ue.second).skey;
       let rest = std-c-parse-assignment-expression(tail(ue.second));
       if rest.first.is-some {
-         Tuple( Some(CBinaryOp(op, close(ue.first.get-or-panic), close(rest.first.get-or-panic))), rest.second )
+         Tuple( Some(CBinaryOp(op, close-owned(ue.first.get-or-panic), close-owned(rest.first.get-or-panic))), rest.second )
       } else std-c-parse-conditional-expression(tokens);
    } else std-c-parse-conditional-expression(tokens);
 );
@@ -994,24 +994,24 @@ let std-c-parse-constant-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
 
 let std-c-parse-conditional-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let base = std-c-parse-logical-or-expression(tokens); tokens = base.second;
-   if base.first.is-some && std-c-can-take(tokens, "?") {
+   if base.first.is-some and std-c-can-take(tokens, "?") {
       let op = head(tokens).skey; tokens = std-c-take-expect(tokens, "?");
       (let e1, tokens) = std-c-parse-expression(tokens);
       tokens = std-c-take-expect(tokens, ":");
       (let e2, tokens) = std-c-parse-conditional-expression(tokens);
-      base = Tuple( Some(CTernaryOp(op, close(base.first.get-or-panic), close(e1.get-or-panic), close(e2.get-or-panic))), tokens );
+      base = Tuple( Some(CTernaryOp(op, close-owned(base.first.get-or-panic), close-owned(e1.get-or-panic), close-owned(e2.get-or-panic))), tokens );
    };
    base
 );
 
 let std-c-parse-logical-or-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-logical-and-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
-      std-c-can-take(tokens, "||")
+   while expression.first.is-some and (
+      std-c-can-take(tokens, "or")
    ) {
       let op = head(tokens).skey; tokens = tail(tokens);
       let re = std-c-parse-logical-and-expression(tokens); tokens = re.second;
-      let e = CBinaryOp( op, close(expression.first.get-or-panic), close(re.first.get-or-panic) );
+      let e = CBinaryOp( op, close-owned(expression.first.get-or-panic), close-owned(re.first.get-or-panic) );
       expression = Tuple( Some(e), tokens );
    };
    expression
@@ -1019,12 +1019,12 @@ let std-c-parse-logical-or-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,L
 
 let std-c-parse-logical-and-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-inclusive-or-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
+   while expression.first.is-some and (
       std-c-can-take(tokens, "&&")
    ) {
       let op = head(tokens).skey; tokens = tail(tokens);
       let re = std-c-parse-inclusive-or-expression(tokens); tokens = re.second;
-      let e = CBinaryOp( op, close(expression.first.get-or-panic), close(re.first.get-or-panic) );
+      let e = CBinaryOp( op, close-owned(expression.first.get-or-panic), close-owned(re.first.get-or-panic) );
       expression = Tuple( Some(e), tokens );
    };
    expression
@@ -1032,12 +1032,12 @@ let std-c-parse-logical-and-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,
 
 let std-c-parse-inclusive-or-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-exclusive-or-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
+   while expression.first.is-some and (
       std-c-can-take(tokens, "|")
    ) {
       let op = head(tokens).skey; tokens = tail(tokens);
       let re = std-c-parse-exclusive-or-expression(tokens); tokens = re.second;
-      let e = CBinaryOp( op, close(expression.first.get-or-panic), close(re.first.get-or-panic) );
+      let e = CBinaryOp( op, close-owned(expression.first.get-or-panic), close-owned(re.first.get-or-panic) );
       expression = Tuple( Some(e), tokens );
    };
    expression
@@ -1045,12 +1045,12 @@ let std-c-parse-inclusive-or-expression(tokens: List<Token>): Tuple<Maybe<CTerm>
 
 let std-c-parse-exclusive-or-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-and-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
+   while expression.first.is-some and (
       std-c-can-take(tokens, "^")
    ) {
       let op = head(tokens).skey; tokens = tail(tokens);
       let re = std-c-parse-and-expression(tokens); tokens = re.second;
-      let e = CBinaryOp( op, close(expression.first.get-or-panic), close(re.first.get-or-panic) );
+      let e = CBinaryOp( op, close-owned(expression.first.get-or-panic), close-owned(re.first.get-or-panic) );
       expression = Tuple( Some(e), tokens );
    };
    expression
@@ -1058,12 +1058,12 @@ let std-c-parse-exclusive-or-expression(tokens: List<Token>): Tuple<Maybe<CTerm>
 
 let std-c-parse-and-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-equality-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
+   while expression.first.is-some and (
       std-c-can-take(tokens, "&")
    ) {
       let op = head(tokens).skey; tokens = tail(tokens);
       let re = std-c-parse-equality-expression(tokens); tokens = re.second;
-      let e = CBinaryOp( op, close(expression.first.get-or-panic), close(re.first.get-or-panic) );
+      let e = CBinaryOp( op, close-owned(expression.first.get-or-panic), close-owned(re.first.get-or-panic) );
       expression = Tuple( Some(e), tokens );
    };
    expression
@@ -1071,12 +1071,12 @@ let std-c-parse-and-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Tok
 
 let std-c-parse-equality-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-relational-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
-      std-c-can-take(tokens, "==")  || std-c-can-take(tokens, "!=")
+   while expression.first.is-some and (
+      std-c-can-take(tokens, "==")  or std-c-can-take(tokens, "!=")
    ) {
       let op = head(tokens).skey; tokens = tail(tokens);
       let re = std-c-parse-relational-expression(tokens); tokens = re.second;
-      let e = CBinaryOp( op, close(expression.first.get-or-panic), close(re.first.get-or-panic) );
+      let e = CBinaryOp( op, close-owned(expression.first.get-or-panic), close-owned(re.first.get-or-panic) );
       expression = Tuple( Some(e), tokens );
    };
    expression
@@ -1084,13 +1084,13 @@ let std-c-parse-equality-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
 
 let std-c-parse-relational-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-shift-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
-      std-c-can-take(tokens, "<")  || std-c-can-take(tokens, ">") ||
-      std-c-can-take(tokens, "<=") || std-c-can-take(tokens, ">=")
+   while expression.first.is-some and (
+      std-c-can-take(tokens, "<")  or std-c-can-take(tokens, ">") or
+      std-c-can-take(tokens, "<=") or std-c-can-take(tokens, ">=")
    ) {
       let op = head(tokens).skey; tokens = tail(tokens);
       let re = std-c-parse-shift-expression(tokens); tokens = re.second;
-      let e = CBinaryOp( op, close(expression.first.get-or-panic), close(re.first.get-or-panic) );
+      let e = CBinaryOp( op, close-owned(expression.first.get-or-panic), close-owned(re.first.get-or-panic) );
       expression = Tuple( Some(e), tokens );
    };
    expression
@@ -1098,12 +1098,12 @@ let std-c-parse-relational-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,L
 
 let std-c-parse-shift-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-additive-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
-      std-c-can-take(tokens, "<<") || std-c-can-take(tokens, ">>")
+   while expression.first.is-some and (
+      std-c-can-take(tokens, "<<") or std-c-can-take(tokens, ">>")
    ) {
       let op = head(tokens).skey; tokens = tail(tokens);
       let re = std-c-parse-additive-expression(tokens); tokens = re.second;
-      let e = CBinaryOp( op, close(expression.first.get-or-panic), close(re.first.get-or-panic) );
+      let e = CBinaryOp( op, close-owned(expression.first.get-or-panic), close-owned(re.first.get-or-panic) );
       expression = Tuple( Some(e), tokens );
    };
    expression
@@ -1111,12 +1111,12 @@ let std-c-parse-shift-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<T
 
 let std-c-parse-additive-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-multiplicative-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
-      std-c-can-take(tokens, "+") || std-c-can-take(tokens, "-")
+   while expression.first.is-some and (
+      std-c-can-take(tokens, "+") or std-c-can-take(tokens, "-")
    ) {
       let op = head(tokens).skey; tokens = tail(tokens);
       let re = std-c-parse-multiplicative-expression(tokens); tokens = re.second;
-      let e = CBinaryOp( op, close(expression.first.get-or-panic), close(re.first.get-or-panic) );
+      let e = CBinaryOp( op, close-owned(expression.first.get-or-panic), close-owned(re.first.get-or-panic) );
       expression = Tuple( Some(e), tokens );
    };
    expression
@@ -1124,12 +1124,12 @@ let std-c-parse-additive-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
 
 let std-c-parse-multiplicative-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-cast-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
-      std-c-can-take(tokens, "*") || std-c-can-take(tokens, "/") || std-c-can-take(tokens, "%")
+   while expression.first.is-some and (
+      std-c-can-take(tokens, "*") or std-c-can-take(tokens, "/") or std-c-can-take(tokens, "%")
    ) {
       let op = head(tokens).skey; tokens = tail(tokens);
       let re = std-c-parse-cast-expression(tokens); tokens = re.second;
-      let e = CBinaryOp( op, close(expression.first.get-or-panic), close(re.first.get-or-panic) );
+      let e = CBinaryOp( op, close-owned(expression.first.get-or-panic), close-owned(re.first.get-or-panic) );
       expression = Tuple( Some(e), tokens );
    };
    expression
@@ -1142,19 +1142,19 @@ let std-c-parse-cast-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<To
       (let tt, scan-tokens) = std-c-parse-type-name(scan-tokens);
       scan-tokens = std-c-take-expect(scan-tokens, ")");
       (let ca, scan-tokens) = std-c-parse-cast-expression(scan-tokens);
-      if tt.is-some && ca.is-some
-      then Tuple( Some(CBinaryOp("cast", close(tt.get-or-panic), close(ca.get-or-panic))), scan-tokens )
+      if tt.is-some and ca.is-some
+      then Tuple( Some(CBinaryOp("cast", close-owned(tt.get-or-panic), close-owned(ca.get-or-panic))), scan-tokens )
       else std-c-parse-unary-expression(tokens);
    } else std-c-parse-unary-expression(tokens);
 );
 
 
 let std-c-parse-unary-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
-   if std-c-can-take(tokens, "++") || std-c-can-take(tokens, "--") || std-c-can-take(tokens,"+") || std-c-can-take(tokens,"-")
-   || std-c-can-take(tokens, "&") || std-c-can-take(tokens, "*") || std-c-can-take(tokens,"!") || std-c-can-take(tokens, "~") {
+   if std-c-can-take(tokens, "++") or std-c-can-take(tokens, "--") or std-c-can-take(tokens,"+") or std-c-can-take(tokens,"-")
+   or std-c-can-take(tokens, "&") or std-c-can-take(tokens, "*") or std-c-can-take(tokens,"!") or std-c-can-take(tokens, "~") {
       let op = head(tokens).skey; tokens = tail(tokens);
       let inner = std-c-parse-cast-expression(tokens);
-      if inner.first.is-some then Tuple( Some(CUnaryPrefix(op, close(inner.first.get-or-panic))), inner.second )
+      if inner.first.is-some then Tuple( Some(CUnaryPrefix(op, close-owned(inner.first.get-or-panic))), inner.second )
       else inner;
    } else if std-c-can-take(tokens, "sizeof") {
       let op = head(tokens).skey; tokens = tail(tokens);
@@ -1162,24 +1162,24 @@ let std-c-parse-unary-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<T
          tokens = std-c-take-expect(tokens, "(");
          (let tt, tokens) = std-c-parse-type-name(tokens);
          tokens = std-c-take-expect(tokens, ")");
-         if tt.is-some then Tuple( Some(CUnaryPrefix(op, close(tt.get-or-panic))), tokens )
+         if tt.is-some then Tuple( Some(CUnaryPrefix(op, close-owned(tt.get-or-panic))), tokens )
          else Tuple( tt, tokens );
       } else {
          let inner = std-c-parse-unary-expression(tokens);
-         if inner.first.is-some then Tuple( Some(CUnaryPrefix(op, close(inner.first.get-or-panic))), inner.second )
+         if inner.first.is-some then Tuple( Some(CUnaryPrefix(op, close-owned(inner.first.get-or-panic))), inner.second )
          else inner;
       };
-   } else if std-c-can-take(tokens, "alignof") || std-c-can-take(tokens, "_Alignof") {
+   } else if std-c-can-take(tokens, "alignof") or std-c-can-take(tokens, "_Alignof") {
       tokens = tail(tokens);
       if std-c-can-take(tokens, "(") {
          tokens = std-c-take-expect(tokens, "(");
          (let tt, tokens) = std-c-parse-type-name(tokens);
          tokens = std-c-take-expect(tokens, ")");
-         if tt.is-some then Tuple( Some(CUnaryPrefix("alignof", close(tt.get-or-panic))), tokens )
+         if tt.is-some then Tuple( Some(CUnaryPrefix("alignof", close-owned(tt.get-or-panic))), tokens )
          else Tuple( tt, tokens );
       } else {
          let inner = std-c-parse-unary-expression(tokens);
-         if inner.first.is-some then Tuple( Some(CUnaryPrefix("alignof", close(inner.first.get-or-panic))), inner.second )
+         if inner.first.is-some then Tuple( Some(CUnaryPrefix("alignof", close-owned(inner.first.get-or-panic))), inner.second )
          else inner;
       };
    } else std-c-parse-postfix-expression(tokens)
@@ -1188,19 +1188,19 @@ let std-c-parse-unary-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<T
 
 let std-c-parse-postfix-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let expression = std-c-parse-primary-expression(tokens); tokens = expression.second;
-   while expression.first.is-some && (
-      std-c-can-take(tokens, "[") || std-c-can-take(tokens, "(") ||
-      std-c-can-take(tokens, ".") || std-c-can-take(tokens, "->") ||
-      std-c-can-take(tokens, "++") || std-c-can-take(tokens, "--")
+   while expression.first.is-some and (
+      std-c-can-take(tokens, "[") or std-c-can-take(tokens, "(") or
+      std-c-can-take(tokens, ".") or std-c-can-take(tokens, "->") or
+      std-c-can-take(tokens, "++") or std-c-can-take(tokens, "--")
    ) {
-      if std-c-can-take(tokens, "++") || std-c-can-take(tokens, "--") {
-         let e = CUnaryPostfix( head(tokens).skey, close(expression.first.get-or-panic) );
+      if std-c-can-take(tokens, "++") or std-c-can-take(tokens, "--") {
+         let e = CUnaryPostfix( head(tokens).skey, close-owned(expression.first.get-or-panic) );
          tokens = tail(tokens);
          expression = Tuple( Some(e), tokens );
-      } else if std-c-can-take(tokens, ".") || std-c-can-take(tokens, "->") {
+      } else if std-c-can-take(tokens, ".") or std-c-can-take(tokens, "->") {
          let accessor = head(tokens).skey; tokens = tail(tokens);
          if non-zero(tokens) {
-            let e = CAccessor( accessor, head(tokens).skey, close(expression.first.get-or-panic) );
+            let e = CAccessor( accessor, head(tokens).skey, close-owned(expression.first.get-or-panic) );
             tokens = std-c-take-expect(tokens, "identifier");
             expression = Tuple( Some(e), tokens );
          } else std-c-take-expect(tokens, "identifier");
@@ -1209,14 +1209,14 @@ let std-c-parse-postfix-expression(tokens: List<Token>): Tuple<Maybe<CTerm>,List
          (let inner, tokens) = std-c-parse-expression(tokens);
          tokens = std-c-take-expect(tokens, "]");
          if inner.is-some {
-            expression = Tuple( Some(CBinaryOp("[]", close(expression.first.get-or-panic), close(inner.get-or-panic))), tokens );
+            expression = Tuple( Some(CBinaryOp("[]", close-owned(expression.first.get-or-panic), close-owned(inner.get-or-panic))), tokens );
          };
       } else {
          let op = head(tokens).skey; tokens = std-c-take-expect(tokens, "(");
          (let inner, tokens) = std-c-parse-argument-expression-list(tokens);
          tokens = std-c-take-expect(tokens, ")");
          if inner.is-some {
-            expression = Tuple( Some(CBinaryOp(op, close(expression.first.get-or-panic), close(inner.get-or-panic))), tokens );
+            expression = Tuple( Some(CBinaryOp(op, close-owned(expression.first.get-or-panic), close-owned(inner.get-or-panic))), tokens );
          };
       };
    };
@@ -1239,7 +1239,7 @@ let std-c-parse-argument-expression-list(tokens: List<Token>): Tuple<Maybe<CTerm
             tokens = sq.second;
          };
       };
-      Tuple( Some(CList(close(sql.reverse))), tokens )
+      Tuple( Some(CList(close-owned(sql.reverse))), tokens )
    } else Tuple ( no, tokens )
 );
 
@@ -1252,8 +1252,8 @@ let std-c-parse-generic-selection(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
       tokens = std-c-take-expect(tokens, ",");
       let ga = std-c-parse-generic-assoc-list(tokens); tokens = ga.second;
       tokens = std-c-take-expect(tokens, ")");
-      if ae.first.is-some && ga.first.is-some
-      then Tuple( Some(CBinaryOp(op, close(ae.first.get-or-panic), close(ga.first.get-or-panic))), tokens )
+      if ae.first.is-some and ga.first.is-some
+      then Tuple( Some(CBinaryOp(op, close-owned(ae.first.get-or-panic), close-owned(ga.first.get-or-panic))), tokens )
       else Tuple( no, tokens )
    } else Tuple( no, tokens )
 );
@@ -1269,7 +1269,7 @@ let std-c-parse-generic-assoc-list(tokens: List<Token>): Tuple<Maybe<CTerm>,List
          ga = std-c-parse-generic-association(tokens); tokens = ga.second;
          if ga.first.is-some then { gas = cons( ga.first.get-or-panic, gas ); };
       };
-      Tuple( Some(CList(close(gas.reverse))), tokens )
+      Tuple( Some(CList(close-owned(gas.reverse))), tokens )
    } else Tuple( no, tokens )
 );
 
@@ -1280,14 +1280,14 @@ let std-c-parse-generic-association(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
       tokens = std-c-take-expect(tokens, ":");
       let ae = std-c-parse-assignment-expression(tokens); tokens = ae.second;
       if ae.first.is-some
-      then Tuple( Some(CUnaryPrefix("GenericAssociation", close(ae.first.get-or-panic))), tokens )
+      then Tuple( Some(CUnaryPrefix("GenericAssociation", close-owned(ae.first.get-or-panic))), tokens )
       else Tuple( no, tokens )
    } else {
       let tn = std-c-parse-type-name(tokens); tokens = tn.second;
       tokens = std-c-take-expect(tokens, ":");
       let ae = std-c-parse-assignment-expression(tokens); tokens = ae.second;
-      if tn.first.is-some && ae.first.is-some
-      then Tuple( Some(CBinaryOp("GenericAssociation", close(tn.first.get-or-panic), close(ae.first.get-or-panic))), tokens )
+      if tn.first.is-some and ae.first.is-some
+      then Tuple( Some(CBinaryOp("GenericAssociation", close-owned(tn.first.get-or-panic), close-owned(ae.first.get-or-panic))), tokens )
       else Tuple( no, tokens )
    }
 );
@@ -1299,12 +1299,12 @@ let std-c-parse-designator(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>>
       let ce = std-c-parse-constant-expression(tokens); tokens = ce.second;
       tokens = std-c-take-expect(tokens, "]");
       if ce.first.is-some
-      then Tuple( Some(CUnaryPrefix(op,close(ce.first.get-or-panic))), tokens )
+      then Tuple( Some(CUnaryPrefix(op,close-owned(ce.first.get-or-panic))), tokens )
       else Tuple( no, tokens )
    } else if std-c-can-take(tokens,".") {
       let op = head(tokens).skey; tokens = std-c-take-expect(tokens, ".");
       let id = head(tokens).skey; tokens = std-c-take-expect(tokens, "identifier");
-      Tuple( Some(CUnaryPrefix(op,close(CIdentifier(id)))), tokens )
+      Tuple( Some(CUnaryPrefix(op,close-owned(CIdentifier(id)))), tokens )
    } else Tuple( no, tokens )
 );
 
@@ -1337,7 +1337,7 @@ let std-c-parse-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> 
    if e.first.is-none { e = std-c-parse-selection-statement(tokens); };
    if e.first.is-none { e = std-c-parse-labeled-statement(tokens); };
    if e.first.is-none { e = std-c-parse-expression-statement(tokens); };
-   if e.first.is-none && std-c-can-take(tokens,";") {
+   if e.first.is-none and std-c-can-take(tokens,";") {
       tokens = std-c-take-expect(tokens,";");
       e = Tuple( Some(CZOp(";")), tokens );
    };
@@ -1352,13 +1352,13 @@ let std-c-parse-expression-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,Li
 
 let std-c-parse-labeled-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Token>> = (
    let no = (None : Maybe<CTerm>)();
-   if std-c-can-take(tokens, "identifier") && std-c-can-take(tail(tokens), ":") {
+   if std-c-can-take(tokens, "identifier") and std-c-can-take(tail(tokens), ":") {
       let lname = head(tokens).skey; tokens = std-c-take-expect(tokens, "identifier");
       let op = "c::label"; tokens = std-c-take-expect(tokens, ":");
       let attr = std-c-parse-attribute(tokens); tokens = attr.second;
       let stmt = std-c-parse-statement(tokens); tokens = stmt.second;
       if stmt.first.is-some
-      then Tuple( Some(CBinaryOp(op,close(CIdentifier(lname)),close(stmt.first.get-or-panic))), tokens )
+      then Tuple( Some(CBinaryOp(op,close-owned(CIdentifier(lname)),close-owned(stmt.first.get-or-panic))), tokens )
       else Tuple( no, tokens );
    } else if std-c-can-take(tokens, "case") {
       let op = "c::case"; tokens = tail(tokens);
@@ -1366,8 +1366,8 @@ let std-c-parse-labeled-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
       tokens = std-c-take-expect(tokens, ":");
       let attr = std-c-parse-attribute(tokens); tokens = attr.second;
       let stmt = std-c-parse-statement(tokens); tokens = stmt.second;
-      if expr.first.is-some && stmt.first.is-some
-      then Tuple( Some(CBinaryOp(op,close(expr.first.get-or-panic),close(stmt.first.get-or-panic))), tokens )
+      if expr.first.is-some and stmt.first.is-some
+      then Tuple( Some(CBinaryOp(op,close-owned(expr.first.get-or-panic),close-owned(stmt.first.get-or-panic))), tokens )
       else Tuple( no, tokens );
    } else if std-c-can-take(tokens, "default") {
       let op = "c::default"; tokens = tail(tokens);
@@ -1375,7 +1375,7 @@ let std-c-parse-labeled-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<
       let attr = std-c-parse-attribute(tokens); tokens = attr.second;
       let stmt = std-c-parse-statement(tokens); tokens = stmt.second;
       if stmt.first.is-some
-      then Tuple( Some(CUnaryPrefix(op,close(stmt.first.get-or-panic))), tokens )
+      then Tuple( Some(CUnaryPrefix(op,close-owned(stmt.first.get-or-panic))), tokens )
       else Tuple( no, tokens );
    } else Tuple( no, tokens );
 );
@@ -1392,8 +1392,8 @@ let std-c-parse-selection-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
          tokens = std-c-take-expect(tokens, "else");
          std-c-parse-statement(tokens);
       } else Tuple( Some(CZOp(";")), tokens ); tokens = stmt1.second;
-      if expr.first.is-some && stmt0.first.is-some && stmt1.first.is-some
-      then Tuple( Some(CTernaryOp(op,close(expr.first.get-or-panic),close(stmt0.first.get-or-panic),close(stmt1.first.get-or-panic))), tokens )
+      if expr.first.is-some and stmt0.first.is-some and stmt1.first.is-some
+      then Tuple( Some(CTernaryOp(op,close-owned(expr.first.get-or-panic),close-owned(stmt0.first.get-or-panic),close-owned(stmt1.first.get-or-panic))), tokens )
       else Tuple( no, tokens );
    } else if std-c-can-take(tokens, "switch") {
       let op = "c::switch"; tokens = tail(tokens);
@@ -1401,8 +1401,8 @@ let std-c-parse-selection-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
       let expr = std-c-parse-expression(tokens); tokens = expr.second;
       tokens = std-c-take-expect(tokens, ")");
       let stmt = std-c-parse-statement(tokens); tokens = stmt.second;
-      if expr.first.is-some && stmt.first.is-some
-      then Tuple( Some(CBinaryOp(op,close(expr.first.get-or-panic),close(stmt.first.get-or-panic))), tokens )
+      if expr.first.is-some and stmt.first.is-some
+      then Tuple( Some(CBinaryOp(op,close-owned(expr.first.get-or-panic),close-owned(stmt.first.get-or-panic))), tokens )
       else Tuple( no, tokens );
    } else Tuple( no, tokens );
 );
@@ -1415,8 +1415,8 @@ let std-c-parse-iteration-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
       let expr = std-c-parse-expression(tokens); tokens = expr.second;
       tokens = std-c-take-expect(tokens, ")");
       let stmt = std-c-parse-statement(tokens); tokens = stmt.second;
-      if expr.first.is-some && stmt.first.is-some
-      then Tuple( Some(CBinaryOp(op,close(expr.first.get-or-panic),close(stmt.first.get-or-panic))), tokens )
+      if expr.first.is-some and stmt.first.is-some
+      then Tuple( Some(CBinaryOp(op,close-owned(expr.first.get-or-panic),close-owned(stmt.first.get-or-panic))), tokens )
       else Tuple( no, tokens );
    } else if std-c-can-take(tokens, "do") {
       let op = "c::do-while"; tokens = tail(tokens);
@@ -1426,8 +1426,8 @@ let std-c-parse-iteration-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
       let expr = std-c-parse-expression(tokens); tokens = expr.second;
       tokens = std-c-take-expect(tokens, ")");
       tokens = std-c-take-expect(tokens, ";");
-      if expr.first.is-some && stmt.first.is-some
-      then Tuple( Some(CBinaryOp(op,close(stmt.first.get-or-panic),close(expr.first.get-or-panic))), tokens )
+      if expr.first.is-some and stmt.first.is-some
+      then Tuple( Some(CBinaryOp(op,close-owned(stmt.first.get-or-panic),close-owned(expr.first.get-or-panic))), tokens )
       else Tuple( no, tokens );
    } else if std-c-can-take(tokens, "for") {
       let op = head(tokens).skey; tokens = tail(tokens);
@@ -1442,10 +1442,10 @@ let std-c-parse-iteration-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,Lis
       } else Tuple( no, tokens ); tokens = expr3.second;
       tokens = std-c-take-expect(tokens, ")");
       let stmt = std-c-parse-statement(tokens); tokens = stmt.second;
-      if decl.first.is-some && stmt.first.is-some
-      then Tuple( Some(CFor(op,close(decl.first),close(expr1.first),close(expr2.first),close(stmt.first.get-or-panic))), tokens )
+      if decl.first.is-some and stmt.first.is-some
+      then Tuple( Some(CFor(op,close-owned(decl.first),close-owned(expr1.first),close-owned(expr2.first),close-owned(stmt.first.get-or-panic))), tokens )
       else if stmt.first.is-some
-      then Tuple( Some(CFor(op,close(expr1.first),close(expr2.first),close(expr3.first),close(stmt.first.get-or-panic))), tokens )
+      then Tuple( Some(CFor(op,close-owned(expr1.first),close-owned(expr2.first),close-owned(expr3.first),close-owned(stmt.first.get-or-panic))), tokens )
       else Tuple( no, tokens );
    } else Tuple( no, tokens );
 );
@@ -1456,7 +1456,7 @@ let std-c-parse-jump-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Tok
       let op = intern(c"c::goto"); tokens = tail(tokens);
       let id = head(tokens).skey; tokens = std-c-take-expect(tokens, "identifier");
       tokens = std-c-take-expect(tokens, ";");
-      Tuple( Some(CUnaryPrefix(op,close(CIdentifier(id)))), tokens )
+      Tuple( Some(CUnaryPrefix(op,close-owned(CIdentifier(id)))), tokens )
    } else if std-c-can-take(tokens, "continue") {
       let op = intern(c"continue"); tokens = tail(tokens);
       tokens = std-c-take-expect(tokens, ";");
@@ -1470,7 +1470,7 @@ let std-c-parse-jump-statement(tokens: List<Token>): Tuple<Maybe<CTerm>,List<Tok
       let e = std-c-parse-expression(tokens); tokens = e.second;
       tokens = std-c-take-expect(tokens, ";");
       if e.first.is-some
-      then Tuple( Some(CUnaryPrefix("c::"+op,close(e.first.get-or-panic))), tokens )
+      then Tuple( Some(CUnaryPrefix("c::"+op,close-owned(e.first.get-or-panic))), tokens )
       else Tuple( Some(CZOp(op)), tokens )
    } else Tuple( no, tokens );
 );

--- a/PLUGINS/FRONTEND/C/c-smart-tokenize.lsts
+++ b/PLUGINS/FRONTEND/C/c-smart-tokenize.lsts
@@ -100,7 +100,7 @@ let std-c-tokenize-string(file-path: String, text: String): List<Token> = (
          text = rest;
       );
 
-      rest => ( fail("Unrecognized Token in File \{file-path}: \{clone-rope(rest[0_u64])}"); );
+      rest => ( fail("Unrecognized Token in File \{file-path}: \{clone-rope(rest[0])}"); );
    }; };
 
    let internal-tokens = [] : List<Token>;

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -143,9 +143,9 @@ let lsts-parse-doc(tokens: List<Token>): Tuple<AST, List<Token>> = (
    Tuple ( ast, tokens )
 );
 
-let lsts-has-assign(tokens: List<Token>): U64 = (
+let lsts-has-assign(tokens: List<Token>): Bool = (
    let depth = 0_i64;
-   let has-assign = 0;
+   let has-assign = false;
    while non-zero(tokens) { match tokens {
       [Token{key:c"["} .. rest] => (depth = depth + 1_i64; tokens = rest;);
       [Token{key:c"{"} .. rest] => (depth = depth + 1_i64; tokens = rest;);
@@ -157,7 +157,7 @@ let lsts-has-assign(tokens: List<Token>): U64 = (
       [Token{key:c","} .. rest] => (if depth <= 0_i64 {tokens = [] : List<Token>} else {tokens = rest;});
       [Token{key:c"."}.. Token{key:c"."} .. rest] => (if depth == 0_i64 {tokens = [] : List<Token>;} else {tokens = rest;});
       [Token{key:c"="}.. Token{key:c">"} .. rest] => (if depth == 0_i64 {tokens = [] : List<Token>;} else {tokens = rest;});
-      [Token{key:c"="} .. rest] => (if depth == 0_i64 {has-assign = 1; tokens = [] : List<Token>;} else {tokens = rest;});
+      [Token{key:c"="} .. rest] => (if depth == 0_i64 {has-assign = true; tokens = [] : List<Token>;} else {tokens = rest;});
       [Token{key:c"if"} .. rest] => (if depth == 0_i64 {tokens = [] : List<Token>;} else {tokens = rest;});
       [Token{key:c"then"} .. rest] => (if depth == 0_i64 {tokens = [] : List<Token>;} else {tokens = rest;});
       [Token{key:c"else"} .. rest] => (if depth == 0_i64 {tokens = [] : List<Token>;} else {tokens = rest;});
@@ -401,9 +401,9 @@ let lsts-parse-expression-possibly-tuple(tokens: List<Token>): Tuple<AST,List<To
    let base-rest = lsts-parse-expression(tokens);
    let base = base-rest.first;
    tokens = base-rest.second;
-   let is-tuple = 0;
+   let is-tuple = false;
    while lsts-parse-head(tokens) == c"," {
-      is-tuple = 1;
+      is-tuple = true;
       tokens = tail(tokens);
       base-rest = lsts-parse-expression(tokens);
       base = mk-cons(base, base-rest.first);
@@ -1041,9 +1041,9 @@ let lsts-parse-function-signature(fname: CString, tokens: List<Token>, loc: Sour
 
 let lsts-parse-let(tokens: List<Token>): (AST, List<Token>) = (
    lsts-parse-expect(c"let", tokens); let loc = head(tokens).location; tokens = tail(tokens);
-   let prop = 0;
+   let prop = false;
    if lsts-parse-head(tokens)==c"prop" {
-      prop = 1;
+      prop = true;
       lsts-parse-expect(c"prop", tokens); tokens = tail(tokens);
    };
    let misc-tt = ta;

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -67,18 +67,18 @@ let lsts-parse-doc-expr(tokens: List<Token>): Tuple<AST, List<(CString, AST)>, L
    let tags = [] : List<(CString, AST)>;
    let val = match lsts-parse-head(tokens) {
       c"__" => (
-         (let s, tokens) = lsts-parse-doc-wordf(tokens, c"__", c"__");
-         mk-app( mk-var("meta::style::underline"), mk-lit(s) )
+         (let s1, tokens) = lsts-parse-doc-wordf(tokens, c"__", c"__");
+         mk-app( mk-var("meta::style::underline"), mk-lit(s1) )
       );
 
       c"**" => (
-         (let s, tokens) = lsts-parse-doc-wordf(tokens, c"**", c"**");
-         mk-app( mk-var("meta::style::bold"), mk-lit(s) )
+         (let s2, tokens) = lsts-parse-doc-wordf(tokens, c"**", c"**");
+         mk-app( mk-var("meta::style::bold"), mk-lit(s2) )
       );
 
       c"[" => (
          tokens = tail(tokens);
-         let v = if lsts-parse-head(tokens) == c"[" {
+         let v1 = if lsts-parse-head(tokens) == c"[" {
             tokens = tail(tokens);
             let key = lsts-parse-head(tokens); tokens = tail(tokens);
             let val = mk-nil();
@@ -90,11 +90,11 @@ let lsts-parse-doc-expr(tokens: List<Token>): Tuple<AST, List<(CString, AST)>, L
             tags = cons( (key,val), tags );
             mk-nil();
          } else {
-            (let v, tokens) = lsts-parse-expression(tokens);
-            v
+            (let v2, tokens) = lsts-parse-expression(tokens);
+            v2
          };
          lsts-parse-expect(c"]", tokens); tokens = tail(tokens);
-         v
+         v1
       );
 
       word => (
@@ -820,8 +820,8 @@ let lsts-parse-typedef(tokens: List<Token>): (AST, List<Token>) = (
          (let vt, tokens) = lsts-parse-type(tokens);
          pt = pt && vt;
       } else {
-         (let v, tokens) = lsts-parse-identifier(tokens);
-         pt = tv(v);
+         (let v1, tokens) = lsts-parse-identifier(tokens);
+         pt = tv(v1);
          if lsts-parse-head(tokens)==c":" {
             lsts-parse-expect(c":", tokens); tokens = tail(tokens);
             (let vt, tokens) = lsts-parse-type(tokens);
@@ -836,8 +836,8 @@ let lsts-parse-typedef(tokens: List<Token>): (AST, List<Token>) = (
             (let vt, tokens) = lsts-parse-type(tokens);
             pt = pt && vt;
          } else {
-            (let v, tokens) = lsts-parse-identifier(tokens);
-            pt = tv(v);
+            (let v2, tokens) = lsts-parse-identifier(tokens);
+            pt = tv(v2);
             if lsts-parse-head(tokens)==c":" {
                lsts-parse-expect(c":", tokens); tokens = tail(tokens);
                (let vt, tokens) = lsts-parse-type(tokens);
@@ -1340,8 +1340,8 @@ let lsts-parse-match2-lhs-one(tokens: List<Token>): Tuple<AST,List<Token>> = (
       expr = mk-var(c"_").with-location(head(tokens).location);
       lsts-parse-expect(c"_", tokens); tokens = tail(tokens);
    } else if lsts-is-ident-head(lsts-parse-head(tokens)) {
-      (let name, tokens) = lsts-parse-identifier(tokens);
-      expr = mk-var(name).with-location(head(tokens).location);
+      (let name2, tokens) = lsts-parse-identifier(tokens);
+      expr = mk-var(name2).with-location(head(tokens).location);
    } else {
       lsts-parse-expect(c"[Left Hand Side]", tokens);
    };
@@ -1388,8 +1388,8 @@ let .is-lsts-constant(key: CString): Bool = (
 let .is-constant(t: AST): Bool = (
    match t {
       App{ left:Lit{key:c":"}, right:App{ left:Lit{}, right:AType{} } } => true;
-      Lit{key=key} => key.is-lsts-constant;
-      Var{key=key} => key.is-lsts-constant;
+      Lit{key1=key} => key1.is-lsts-constant;
+      Var{key2=key} => key2.is-lsts-constant;
       _ => false;
    }
 );

--- a/PLUGINS/FRONTEND/LSTS/lsts-smart-tokenize.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-smart-tokenize.lsts
@@ -6,14 +6,14 @@ let lsts-tokenize-string(file-path: CString, text: CString): List<Token> = (
 let lsts-tokenize-string(file-path: String, text: String): List<Token> = (
    smart-token-path-index = smart-token-path-index.bind( text.data as U64, file-path );
 
-   let push-newline = 0;
+   let push-newline = false;
    let tokens = [] : List<String>;
    while non-zero(text) {match text {
       "\s".. rest => text = rest;
       "\t".. rest => text = rest;
       "\n".. rest => (
          if push-newline {
-            push-newline = 0;
+            push-newline = false;
             tokens = cons("\n", tokens);
          };
          text = rest;
@@ -71,7 +71,7 @@ let lsts-tokenize-string(file-path: String, text: String): List<Token> = (
       "##".. rest => (
          tokens = cons("##", tokens);
          text = rest;
-         push-newline = 1;
+         push-newline = true;
       );
 
       (lit=r/^[r]?[cl]?["]([^"\\]|([\\].))*["]/).. rest => (

--- a/lib/std/array.lsts
+++ b/lib/std/array.lsts
@@ -100,3 +100,8 @@ let close(x: p): p[] = (
    r[0_u64] = x;
    r
 );
+let close-owned(x: p): p[] = (
+   let r = safe-alloc(1_u64, type(p));
+   r[0_u64] = x;
+   r
+);

--- a/lib/std/c-shim.lsts
+++ b/lib/std/c-shim.lsts
@@ -19,6 +19,7 @@ let :FFI fwrite(buff: ?[], size: U64, count: U64, f: IO::File): U64 = ();
 let :FFI fclose(f: IO::File): U32 = ();
 let :FFI execvp(file: U8[], argv: U8[][]): U32 = ();
 let :FFI mktemp(template: U8[]): U8[] = ();
+let :FFI mkstemp(template: U8[]): U8[] = ();
 let :FFI system(command: U8[]): U32 = ();
 let :FFI system(command: CString): U32 = ();
 

--- a/lib/std/c-shim.lsts
+++ b/lib/std/c-shim.lsts
@@ -20,4 +20,5 @@ let :FFI fclose(f: IO::File): U32 = ();
 let :FFI execvp(file: U8[], argv: U8[][]): U32 = ();
 let :FFI mktemp(template: U8[]): U8[] = ();
 let :FFI system(command: U8[]): U32 = ();
+let :FFI system(command: CString): U32 = ();
 

--- a/lib/std/smart-string.lsts
+++ b/lib/std/smart-string.lsts
@@ -101,11 +101,6 @@ let $"[:]"(x: String, low: I64, hi: I64): String = (
 let tail-string(x: String): String = x[ 1_i64 : x.length as I64 ];
 let tail(x: String): String = x[ 1_i64 : x.length as I64 ];
 
-let $"[]"(x: String, low: I64): U8 = (
-   if low < 0 then low = (x.length as I64) + low;
-   x[low as U64]
-);
-
 let $"[]"(x: String, low: U64): U8 = (
    let lowp = x.start + low;
    if lowp < x.start then fail("Index Out Of Bounds: String []");

--- a/lib2/core/baremetal.lsts
+++ b/lib2/core/baremetal.lsts
@@ -5,6 +5,9 @@ import stdlib.h;
 import string.h;
 import regex.h;
 
+# not sure why this is necessary, the C frontend must be missing this definition?
+let :FFI mktemp(template: U8[]): U8[] = ();
+
 import lib2/core/l.lsts;
 import lib2/core/phi.lsts;
 import lib2/core/platform-macros.lsts;

--- a/lib2/core/common-macros.lsts
+++ b/lib2/core/common-macros.lsts
@@ -159,15 +159,17 @@ deprecated macro (rl"match-pats-arm"(term,rl"macro::lhs-head"(x,rest))) ((
 
 deprecated macro (rl"match-pats-arm"(term,rl"macro::lhs-prefix-or-suffix"( rl":Literal:"(l), rest ))) ((
    $"let"(uuid(v))(term);
-   $"if"(uuid(v).has-prefix(l))
-        (match-pats-arm(uuid(v).remove-prefix(l),rest))
+   $"let"(uuid(p))(uuid(v).remove-prefix(l));
+   $"if"(uuid(p).is-some)
+        (match-pats-arm(uuid(p).get-or-panic,rest))
         (branchfalse())
 ));
 
 deprecated macro (rl"match-pats-arm"(term,rl"macro::lhs-prefix-or-suffix"( rest, rl":Literal:"(l) ))) ((
    $"let"(uuid(v))(term);
-   $"if"(uuid(v).has-suffix(l))
-        (match-pats-arm(uuid(v).remove-suffix(l),rest))
+   $"let"(uuid(p))(uuid(v).remove-suffix(l));
+   $"if"(uuid(p).is-some)
+        (match-pats-arm(uuid(p).get-or-panic,rest))
         (branchfalse())
 ));
 

--- a/lib2/core/maybe.lsts
+++ b/lib2/core/maybe.lsts
@@ -54,3 +54,17 @@ let .is-none(m: Maybe<x>): Bool = (
 let .is-some(m: Maybe<x>): Bool = (
    m.discriminator-case-tag == (m as Tag::Some).discriminator-case-tag
 );
+
+let .expect(l: Maybe<x>, msg: CString): x = (
+   match l {
+      Some{content=content} => content;
+      _ => fail(msg);
+   }
+);
+
+let .expect(l: Maybe<x>, msg: String): x = (
+   match l {
+      Some{content=content} => content;
+      _ => fail(msg);
+   }
+);

--- a/lib2/core/string.lsts
+++ b/lib2/core/string.lsts
@@ -178,10 +178,10 @@ let .has-suffix(base: String, sfx: String): Bool = (
    base[ (base.length - sfx.length) as I64 : base.length as I64 ] == sfx
 );
 
-let .remove-suffix(base: String, sfx: String): String = (
+let .remove-suffix(base: String, sfx: String): String? = (
    if base.has-suffix(sfx)
-   then base[ 0_i64 : (base.length - sfx.length) as I64 ]
-   else base
+   then Some(base[ 0_i64 : (base.length - sfx.length) as I64 ])
+   else (None : String?)
 );
 
 let .has-prefix(base: String, pfx: String): Bool = (
@@ -189,10 +189,10 @@ let .has-prefix(base: String, pfx: String): Bool = (
    base[ 0_i64 : pfx.length as I64 ] == pfx
 );
 
-let .remove-prefix(base: String, pfx: String): String = (
+let .remove-prefix(base: String, pfx: String): String? = (
    if base.has-prefix(pfx)
-   then base[ pfx.length as I64 : minimum-I64 ]
-   else base
+   then Some(base[ pfx.length as I64 : minimum-I64 ])
+   else (None : String?)
 );
 
 let tail(x: String): String = x[ 1_i64 : x.length as I64 ];


### PR DESCRIPTION
## Describe your changes
Features:
* compiler is passing initial compilation step with lib2
* this does not mean that lib2 migration is completely done yet
* the lib2 compiler has a bug somehow, so some library feature is broken semantically?
* however, it *does* mean that we have enough memory to compiler with lib2
* and that is all we need to start the gradual garbage collection integration
* no complicated backporting features from lib2 to lib1
* we can just keep moving forward

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed an AI-assisted self-review of my code.
```
Can you review my pull request and provide some suggestions?
https://patch-diff.githubusercontent.com/raw/Lambda-Mountain-Compiler-Backend/lambda-mountain/pull/1926.diff
```
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
