### PR TITLE
Gc disabled lib2 deploy dfjsisdll

### DIFF
--- a/LM23COMMON/typecheck-typecheck.lsts
+++ b/LM23COMMON/typecheck-typecheck.lsts
@@ -1,19 +1,12 @@
 
 let typecheck(): Nil = (
-   print("Typecheck 1\n");
    infer-global-context-prim(ast-parsed-program);
-   print("Typecheck 2\n");
    infer-global-context-td(ast-parsed-program);
-   print("Typecheck 3\n");
    infer-global-context(ast-parsed-program);
-   print("Typecheck 4\n");
    assert-no-infinite-types();
-   print("Typecheck 5\n");
    (global-flow-tctx, ast-parsed-program) = infer-global-terms(global-flow-tctx, ast-parsed-program);
    tctx-currently-processing-globals = false;
-   print("Typecheck 6\n");
    (global-flow-tctx, ast-parsed-program) = std-infer-expr(global-flow-tctx, ast-parsed-program, false, Used, ta);
-   print("Typecheck 7\n");
    # TODO: release globals for graceful exit
    while non-zero(stack-to-specialize) { match stack-to-specialize {
       # this can't be a normal for-loop because it gets extended during iteration
@@ -22,11 +15,7 @@ let typecheck(): Nil = (
          specialize(key, ctx, result-type, term);
       );
    }};
-   print("Typecheck 8\n");
    validate-interfaces();
-   print("Typecheck 9\n");
    assert-well-typed(ast-parsed-program);
-   print("Typecheck 10\n");
    decorate-var-to-def();
-   print("Typecheck 11\n");
 );

--- a/LM23COMMON/typecheck-typecheck.lsts
+++ b/LM23COMMON/typecheck-typecheck.lsts
@@ -1,12 +1,19 @@
 
 let typecheck(): Nil = (
+   print("Typecheck 1\n");
    infer-global-context-prim(ast-parsed-program);
+   print("Typecheck 2\n");
    infer-global-context-td(ast-parsed-program);
+   print("Typecheck 3\n");
    infer-global-context(ast-parsed-program);
+   print("Typecheck 4\n");
    assert-no-infinite-types();
+   print("Typecheck 5\n");
    (global-flow-tctx, ast-parsed-program) = infer-global-terms(global-flow-tctx, ast-parsed-program);
    tctx-currently-processing-globals = false;
+   print("Typecheck 6\n");
    (global-flow-tctx, ast-parsed-program) = std-infer-expr(global-flow-tctx, ast-parsed-program, false, Used, ta);
+   print("Typecheck 7\n");
    # TODO: release globals for graceful exit
    while non-zero(stack-to-specialize) { match stack-to-specialize {
       # this can't be a normal for-loop because it gets extended during iteration
@@ -15,7 +22,11 @@ let typecheck(): Nil = (
          specialize(key, ctx, result-type, term);
       );
    }};
+   print("Typecheck 8\n");
    validate-interfaces();
+   print("Typecheck 9\n");
    assert-well-typed(ast-parsed-program);
+   print("Typecheck 10\n");
    decorate-var-to-def();
+   print("Typecheck 11\n");
 );

--- a/LM23COMMON/unit-main-core.lsts
+++ b/LM23COMMON/unit-main-core.lsts
@@ -90,6 +90,7 @@ let main(argc: C_int, argv: CString[]): Nil = (
       );
       ModeParse{} => (
          for list fp3 in input.reverse { frontend(fp3); };
+         print("\{ast-parsed-program}\n");
       );
       _ => (
          for list fp4 in input.reverse { frontend(fp4); };

--- a/LM23COMMON/unit-main-core.lsts
+++ b/LM23COMMON/unit-main-core.lsts
@@ -40,6 +40,7 @@ let main(argc: C_int, argv: CString[]): Nil = (
       match argv[argi] {
          c"--typecheck" => config-mode = ModeTypecheck();
          c"--parse" => config-mode = ModeParse();
+         c"--preprocess" => config-mode = ModePreprocess();
          c"--compile" => config-mode = ModeCompile();
          c"--v0" => (config-v3 = false; config-v0 = true;);
          c"--v1" => (config-v3 = false; config-v1 = true;);
@@ -90,6 +91,11 @@ let main(argc: C_int, argv: CString[]): Nil = (
       );
       ModeParse{} => (
          for list fp3 in input.reverse { frontend(fp3); };
+         print("\{ast-parsed-program}\n");
+      );
+      ModePreprocess{} => (
+         for list fp32 in input.reverse { frontend(fp32); };
+         preprocess();
          print("\{ast-parsed-program}\n");
       );
       _ => (

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,16 @@ CFLAGS = -w -O2 -march=native -mtune=native
 LSTSFLAGS = MALLOC_CHECK_=3
 
 dev: install-production
-	lm --v23 --c -o deploy1.c SRC/index.lsts
+	lm --v2 --c -o deploy1.c SRC/index.lsts
 	$(CC) $(CFLAGS) deploy1.c -o deploy1
 	lm --parse SRC/index.lsts > production-parse.txt
 	./deploy1 --parse SRC/index.lsts > deploy-parse.txt
 	diff production-parse.txt deploy-parse.txt
 
 build: compile-production
-	time env $(LSTSFLAGS) ./production --v23 --c -o deploy1.c SRC/index.lsts
+	time env $(LSTSFLAGS) ./production --v2 --c -o deploy1.c SRC/index.lsts
 	$(CC) $(CFLAGS) deploy1.c -o deploy1
-	time env $(LSTSFLAGS) ./deploy1 --v23 --c -o deploy2.c SRC/index.lsts
+	time env $(LSTSFLAGS) ./deploy1 --v2 --c -o deploy2.c SRC/index.lsts
 	diff deploy1.c deploy2.c
 	mv deploy1.c BOOTSTRAP/cli.c
 	rm -f deploy1 deploy1.c deploy2.c
@@ -22,7 +22,7 @@ deploy: build smoke-test
 deploy-lite: build smoke-test-lite
 
 valgrind: install-bootstrap
-	valgrind --tool=callgrind lm --v23 SRC/index.lsts
+	valgrind --tool=callgrind lm --v2 SRC/index.lsts
 
 valgrind-view:
 	callgrind_annotate callgrind.out.18778
@@ -38,7 +38,7 @@ gprof-view-call-graph:
 	gprof -q bootstrap.exe gmon.out
 
 profile: install-bootstrap
-	perf record lm --v23 SRC/index.lsts
+	perf record lm --v2 SRC/index.lsts
 	./report.sh
 
 compile-bootstrap:

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ CFLAGS = -w -O2 -march=native -mtune=native
 LSTSFLAGS = MALLOC_CHECK_=3
 
 dev: install-production
-	lm --v2 --c -o deploy1.c SRC/index.lsts
+	lm --v23 --c -o deploy1.c SRC/index.lsts
 	$(CC) $(CFLAGS) deploy1.c -o deploy1
-	lm --parse SRC/index.lsts > production-parse.txt
-	./deploy1 --parse SRC/index.lsts > deploy-parse.txt
+	lm --preprocess SRC/index.lsts > production-parse.txt
+	./deploy1 --preprocess SRC/index.lsts > deploy-parse.txt
 	diff production-parse.txt deploy-parse.txt
 
 build: compile-production

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ CFLAGS = -w -O2 -march=native -mtune=native
 LSTSFLAGS = MALLOC_CHECK_=3
 
 dev: install-production
-	time lm --v2 tests/promises/string/prefix.lsts
+	time lm --v23 tests/promises/string/prefix.lsts
 	gcc tmp.c
 	$(LSTSFLAGS) ./a.out
 
 build: compile-production
-	time env $(LSTSFLAGS) ./production --v2 --c -o deploy1.c SRC/index.lsts
+	time env $(LSTSFLAGS) ./production --v23 --c -o deploy1.c SRC/index.lsts
 	$(CC) $(CFLAGS) deploy1.c -o deploy1
-	time env $(LSTSFLAGS) ./deploy1 --v2 --c -o deploy2.c SRC/index.lsts
+	time env $(LSTSFLAGS) ./deploy1 --v23 --c -o deploy2.c SRC/index.lsts
 	diff deploy1.c deploy2.c
 	mv deploy1.c BOOTSTRAP/cli.c
 	rm -f deploy1 deploy1.c deploy2.c
@@ -20,7 +20,7 @@ deploy: build smoke-test
 deploy-lite: build smoke-test-lite
 
 valgrind: install-bootstrap
-	valgrind --tool=callgrind lm --v2 SRC/index.lsts
+	valgrind --tool=callgrind lm --v23 SRC/index.lsts
 
 valgrind-view:
 	callgrind_annotate callgrind.out.18778
@@ -36,7 +36,7 @@ gprof-view-call-graph:
 	gprof -q bootstrap.exe gmon.out
 
 profile: install-bootstrap
-	perf record lm --v2 SRC/index.lsts
+	perf record lm --v23 SRC/index.lsts
 	./report.sh
 
 compile-bootstrap:

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@ CFLAGS = -w -O2 -march=native -mtune=native
 LSTSFLAGS = MALLOC_CHECK_=3
 
 dev: install-production
-	time lm --v23 tests/promises/string/prefix.lsts
-	gcc tmp.c
-	$(LSTSFLAGS) ./a.out
+	lm --v23 --c -o deploy1.c SRC/index.lsts
+	$(CC) $(CFLAGS) deploy1.c -o deploy1
+	lm --parse SRC/index.lsts > production-parse.txt
+	./deploy1 --parse SRC/index.lsts > deploy-parse.txt
+	diff production-parse.txt deploy-parse.txt
 
 build: compile-production
 	time env $(LSTSFLAGS) ./production --v23 --c -o deploy1.c SRC/index.lsts

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -168,15 +168,17 @@ let lsts-has-assign(tokens: List<Token>): Bool = (
 );
 
 let lsts-substitute-type-aliases(s: CString): CString = (
-   if s.has-suffix(c"_ss") then intern(s)[:-3_i64].into(type(CString)) else
-   s.remove-suffix(c"_u64").get-or(c"")
-    .remove-suffix(c"_u32").get-or(c"")
-    .remove-suffix(c"_u16").get-or(c"")
-    .remove-suffix(c"_u8").get-or(c"")
-    .remove-suffix(c"_i64").get-or(c"")
-    .remove-suffix(c"_i32").get-or(c"")
-    .remove-suffix(c"_i16").get-or(c"")
-    .remove-suffix(c"_i8").get-or(c"")
+   if s.has-suffix(c"_ss") then s.remove-suffix(c"_ss").get-or(s) else (
+      s = s.remove-suffix(c"_u64").get-or(s);
+      s = s.remove-suffix(c"_u32").get-or(s);
+      s = s.remove-suffix(c"_u16").get-or(s);
+      s = s.remove-suffix(c"_u8").get-or(s);
+      s = s.remove-suffix(c"_i64").get-or(s);
+      s = s.remove-suffix(c"_i32").get-or(s);
+      s = s.remove-suffix(c"_i16").get-or(s);
+      s = s.remove-suffix(c"_i8").get-or(s);
+      s
+   )
 );
 
 let lsts-is-type-tag(s: CString): Bool = (


### PR DESCRIPTION
## Describe your changes
Features:
* fix a bug in LSTS parse that was dropping type names `AST` would become `$""`
* confirm both parse and preprocess as equivalent between lib1 and lib2

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1775

## Checklist before requesting a review
- [ x ] I have performed an AI-assisted self-review of my code.
```
Can you review my pull request and provide some suggestions?
https://patch-diff.githubusercontent.com/raw/Lambda-Mountain-Compiler-Backend/lambda-mountain/pull/1926.diff
```
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
