### PR TITLE
Type list to vector dfklsdi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LSTSFLAGS = MALLOC_CHECK_=3
 # recommendation: ulimit -s unlimited
 
 dev: install-production
-	lm --v23 tests/promises/vector/constructor.lsts
+	lm tests/promises/vector/constructor.lsts
 	$(CC) $(CFLAGS) tmp.c
 	./a.out
 

--- a/SRC/dev-prop-tctx-least-upper-bound.lsts
+++ b/SRC/dev-prop-tctx-least-upper-bound.lsts
@@ -78,7 +78,8 @@ let .least-upper-bound(tctx: TypeContext?, left: Vector<Type>, right: Vector<Typ
       let success = true;
       while rli < left.length {
          (tctx, let tt) = tctx.least-upper-bound(left[rli],right[rli],blame);
-         if non-zero(tt) then next = next.push(tt);
+         if not(non-zero(left[rli])) and not(non-zero(right[rli])) then next = next.push(ta);
+         else if non-zero(tt) then next = next.push(tt);
          else success = false;
          rli = rli + 1;
       };

--- a/SRC/typecheck-infer-expr.lsts
+++ b/SRC/typecheck-infer-expr.lsts
@@ -395,7 +395,6 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          tctx = tctx.phi-move(typeof-term(term),term);
       }
    }};
-   print("Inferred \{term} : \{typeof-term(term)}\n");
    (tctx, term);
 );
 

--- a/SRC/typecheck-infer-expr.lsts
+++ b/SRC/typecheck-infer-expr.lsts
@@ -395,6 +395,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          tctx = tctx.phi-move(typeof-term(term),term);
       }
    }};
+   print("Inferred \{term} : \{typeof-term(term)}\n");
    (tctx, term);
 );
 

--- a/SRC/typecheck-typecheck.lsts
+++ b/SRC/typecheck-typecheck.lsts
@@ -1,19 +1,12 @@
 
 let typecheck(): Nil = (
-   print("Typecheck 1\n");
    infer-global-context-prim(ast-parsed-program);
-   print("Typecheck 2\n");
    infer-global-context-td(ast-parsed-program);
-   print("Typecheck 3\n");
    infer-global-context(ast-parsed-program);
-   print("Typecheck 4\n");
    assert-no-infinite-types();
-   print("Typecheck 5\n");
    (global-flow-tctx, ast-parsed-program) = infer-global-terms(global-flow-tctx, ast-parsed-program);
    tctx-currently-processing-globals = false;
-   print("Typecheck 6\n");
    (global-flow-tctx, ast-parsed-program) = std-infer-expr(global-flow-tctx, ast-parsed-program, false, Used, ta);
-   print("Typecheck 7\n");
    # TODO: release globals for graceful exit
    while non-zero(stack-to-specialize) { match stack-to-specialize {
       # this can't be a normal for-loop because it gets extended during iteration
@@ -22,11 +15,7 @@ let typecheck(): Nil = (
          specialize(key, ctx, result-type, term);
       );
    }};
-   print("Typecheck 8\n");
    validate-interfaces();
-   print("Typecheck 9\n");
    assert-well-typed(ast-parsed-program);
-   print("Typecheck 10\n");
    decorate-var-to-def();
-   print("Typecheck 11\n");
 );

--- a/SRC/unit-main-core.lsts
+++ b/SRC/unit-main-core.lsts
@@ -99,12 +99,10 @@ let main(argc: C_int, argv: CString[]): Nil = (
          print("\{ast-parsed-program}\n");
       );
       _ => (
-         print("Begin Parse\n");
          for list fp4 in input.reverse { frontend(fp4); };
-         print("End Parse, Begin Preprocess\n");
          match config-mode {
             ModeTypecheck{} => (preprocess(); typecheck(););
-            ModeCompile{} => (preprocess(); print("End Preprocess, Begin Typecheck\n"); typecheck(); print("End Typecheck, Begin Backend\n"); plugin-current-backend(); );
+            ModeCompile{} => (preprocess(); typecheck(); plugin-current-backend(); );
          };
       );
    };

--- a/lib/core/vector.lsts
+++ b/lib/core/vector.lsts
@@ -204,6 +204,17 @@ let .reverse(v: Vector<t>): Vector<t> = (
 
 # new allocations = 0
 let .into(v: Vector<t>, tt: Type<Vector<t>>): Vector<t> = v;
+let .into(v: Vector<t>, tt: Type<String>): String = (
+   let s = "[";
+   let i = 0_sz;
+   for vector t in v {
+      if i>0 then s = s + ",";
+      s = s + t.into(type(String));
+      i = i + 1;
+   };
+   s = s + "]";
+   s
+);
 
 let .contains(v: Vector<t>, i: t): Bool = (
    let result = false;


### PR DESCRIPTION
## Describe your changes
Features:
* the compiler internals now self-host with Type.Ground using Vector instead of List
* there is some sort of phi problem still that isn't affected the compiler atm because gc is disabled
* switching to vector here freed up 3GB of space and is significantly faster overall
  
## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1895

## Checklist before requesting a review
- [ x ] I have performed an AI-assisted self-review of my code.
```
Can you review my pull request and provide some suggestions?
https://patch-diff.githubusercontent.com/raw/Lambda-Mountain-Compiler-Backend/lambda-mountain/pull/1926.diff
```
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
