### PR TITLE
universal zero initializer is much faster than memset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ dev: install-production
 	#lm --showalloc SRC/unit-tctx-core.lsts > out.txt
 	#lm --showalloc SRC/unit-prop-core.lsts > out.txt
 	#lm --showalloc SRC/unit-ascript-core.lsts > out.txt
-	lm --showalloc --v23 SRC/index.lsts > out.txt
+	#lm --showalloc SRC/index.lsts > out.txt
+	lm tests/promises/typechecking/misc-linear-error-1.lsts
 
 build: compile-production
 	time env $(LSTSFLAGS) ./production --v23 --c -o deploy1.c SRC/index.lsts

--- a/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
@@ -102,9 +102,7 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
             f = f.set(c"frame",
                       f.get(c"frame") + pre + SAtom(c" ")
                     + v.get(c"expression")
-                    + SAtom(c" ") + post + SAtom(c";")
-                    + SAtom(c"memset(&") + v.get(c"expression")
-                    + SAtom(c",0,sizeof(") + v.get(c"expression") + SAtom(c"));")
+                    + SAtom(c" ") + post + SAtom(c"={0};")
             );
          };
          match rhs {

--- a/SRC/typecheck-infer-expr.lsts
+++ b/SRC/typecheck-infer-expr.lsts
@@ -173,6 +173,8 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             };
             if non-zero(term-phi-id) and term-phi-id != t-phi-id then tctx = tctx.phi-move(typeof-term(t), t);
             if non-zero(term-phi-id) and term-phi-id != f-phi-id then tctx = tctx.phi-move(typeof-term(f), f);
+            if (typeof-term(term).is-t(c"Nil",0) or typeof-term(term).is-t(c"Never",0)) and non-zero(t-phi-id) then tctx = tctx.phi-move(typeof-term(t), t);
+            if (typeof-term(term).is-t(c"Nil",0) or typeof-term(term).is-t(c"Never",0)) and non-zero(f-phi-id) then tctx = tctx.phi-move(typeof-term(f), f);
          }
       );
       ASTEOF{} => tctx = tctx.ascript(term, t0(c"Nil"));

--- a/SRC/typecheck-infer-type-definition.lsts
+++ b/SRC/typecheck-infer-type-definition.lsts
@@ -168,12 +168,7 @@ let infer-type-yield-constructor(base-type: Type, case-tag: CString, case-number
    body = mk-cons(body, mk-lit(c" ").ascript(t0(c"L") && t0(c"Literal")));
    body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L") && t0(c"Literal")));
    body = mk-cons(body, mk-app(mk-var(c"mangle-post"),mk-atype(t1(c"Type",base-type))) );
-   body = mk-cons(body, mk-lit(c";").ascript(t0(c"L") && t0(c"Literal")));
-   body = mk-cons(body, mk-lit(c"memset(&").ascript(t0(c"L") && t0(c"Literal")));
-   body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L") && t0(c"Literal")));
-   body = mk-cons(body, mk-lit(c",0,sizeof ").ascript(t0(c"L") && t0(c"Literal")));
-   body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L") && t0(c"Literal")));
-   body = mk-cons(body, mk-lit(c");").ascript(t0(c"L") && t0(c"Literal")));
+   body = mk-cons(body, mk-lit(c"={0};").ascript(t0(c"L") && t0(c"Literal")));
 
    if has-tag-case {
       body = mk-cons(body, mk-lit(return-id).ascript(t0(c"L") && t0(c"Literal")) );

--- a/tests/promises/typechecking/misc-linear-error-1.lsts
+++ b/tests/promises/typechecking/misc-linear-error-1.lsts
@@ -1,11 +1,6 @@
 
 import lib/core/bedrock.lsts;
 
-let f(tokens: List<Token>, cls: String): List<Token> = (
-   tokens
-);
-
-let g(tokens: List<Token>): Nil = (
-   let initializer = (Some(0), Some(0));
-   if initializer.first.is-none then f(tokens, "[Initializer]");
+let f(): Nil = (
+   if true then "";
 );

--- a/tests/promises/typechecking/misc-linear-error-1.lsts
+++ b/tests/promises/typechecking/misc-linear-error-1.lsts
@@ -1,0 +1,11 @@
+
+import lib/core/bedrock.lsts;
+
+let f(tokens: List<Token>, cls: String): List<Token> = (
+   tokens
+);
+
+let g(tokens: List<Token>): Nil = (
+   let initializer = (Some(0), Some(0));
+   if initializer.first.is-none then f(tokens, "[Initializer]");
+);


### PR DESCRIPTION
## Describe your changes
Features:
* replace `memset` calls with universal zero initializer (7% speedup overall)

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1895

## Checklist before requesting a review
- [ x ] I have performed an AI-assisted self-review of my code.
```
Can you review my pull request and provide some suggestions?
https://patch-diff.githubusercontent.com/raw/Lambda-Mountain-Compiler-Backend/lambda-mountain/pull/1926.diff
```
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
