### PR TITLE
Avoid mini allocations to constants fdsklfew

### DIFF
--- a/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
@@ -68,7 +68,7 @@ let .rewrite-if-reserved(s: CString): CString = (
 let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
    let f = match t {
       Var{ key=key } => (
-         if typeof-term(t) <: t1(c"C",t0(c"void")) {
+         if typeof-term(t) <: type-c-void {
             mk-fragment().set(c"expression",SAtom(c"({})"));
          } else if typeof-term(t).is-t(c"C-FFI",0) {
             mk-fragment().set(c"expression",SAtom(key.replace(c"-",c"_").rewrite-if-reserved));
@@ -89,12 +89,12 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
       );
       App{ left:Abs{lhs=lhs:Var{name=key}, rhs:ASTNil{}}, rhs=right } => (
          let lt = typeof-term(lhs).without-modifiers;
-         let vid = if lt.is-t(c"Nil",0) or lt <: t1(c"C",t0(c"void")) then SAtom(c"({})") else if std-c-is-ctype(lt) then SAtom(name.replace(c"-",c"_").rewrite-if-reserved) else SAtom(uuid());
+         let vid = if lt.is-t(c"Nil",0) or lt <: type-c-void then SAtom(c"({})") else if std-c-is-ctype(lt) then SAtom(name.replace(c"-",c"_").rewrite-if-reserved) else SAtom(uuid());
          let v = mk-fragment().set(c"expression",vid);
          let f = mk-fragment();
          std-c-fragment-context = std-c-fragment-context.bind( lhs, v );
          ctx = ctx.bind( name, lt, v );
-         if lt.is-t(c"Nil",0) or lt.is-t(c"Never",0) or lt <: t1(c"C",t0(c"void")) {
+         if lt.is-t(c"Nil",0) or lt.is-t(c"Never",0) or lt <: type-c-void {
          } else if lt <: t1(c"C",t0(c":Label")) {
             f = f.set(c"expression", v.get(c"expression") + SAtom(c":"));
          } else {
@@ -110,7 +110,7 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
             _ => (
                let rf = std-c-compile-expr(ctx, rhs, false);
                f = f.set(c"frame", f.get(c"frame") + rf.get(c"frame"));
-               if lt.is-t(c"Nil",0) or lt.is-t(c"Never",0) or lt <: t1(c"C",t0(c"void")) {
+               if lt.is-t(c"Nil",0) or lt.is-t(c"Never",0) or lt <: type-c-void {
                   f = f.set(c"expression", SAtom(c"({") + rf.get(c"expression") + SAtom(c";({});})"));
                } else {
                   f = f.set(c"expression", SAtom(c"({")

--- a/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-expr.lsts
@@ -95,7 +95,7 @@ let std-c-compile-expr(ctx: FContext, t: AST, is-stmt: Bool): Fragment = (
          std-c-fragment-context = std-c-fragment-context.bind( lhs, v );
          ctx = ctx.bind( name, lt, v );
          if lt.is-t(c"Nil",0) or lt.is-t(c"Never",0) or lt <: type-c-void {
-         } else if lt <: t1(c"C",t0(c":Label")) {
+         } else if lt <: type-c-label {
             f = f.set(c"expression", v.get(c"expression") + SAtom(c":"));
          } else {
             (let pre, let post) = std-c-mangle-declaration(lt, t);

--- a/PLUGINS/BACKEND/C/std-c-compile-function-args.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-function-args.lsts
@@ -7,7 +7,7 @@ let std-c-compile-function-args(ctx: FContext, lhs: AST): S = (
          text = text + SAtom(c",");
          if can-unify( t1(c"C",t0(c"...")), kt ) {
             text = text + SAtom(c"...");
-         } else if can-unify( t1(c"C",t0(c"void")), kt ) {
+         } else if can-unify( type-c-void, kt ) {
             text = text + SAtom(c"void");
          } else {
             text = text + decl.first;
@@ -23,7 +23,7 @@ let std-c-compile-function-args(ctx: FContext, lhs: AST): S = (
          let text = SNil();
          if can-unify( t1(c"C",t0(c"...")), kt ) {
             text = text + SAtom(c"...");
-         } else if can-unify( t1(c"C",t0(c"void")), kt ) {
+         } else if can-unify( type-c-void, kt ) {
             text = text + SAtom(c"void");
          } else {
             text = text + decl.first;

--- a/PLUGINS/BACKEND/C/std-c-compile-function-args.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-function-args.lsts
@@ -5,7 +5,7 @@ let std-c-compile-function-args(ctx: FContext, lhs: AST): S = (
          let decl = std-c-mangle-declaration(kt, lhs);
          let text = std-c-compile-function-args(ctx, rest);
          text = text + SAtom(c",");
-         if can-unify( t1(c"C",t0(c"...")), kt ) {
+         if can-unify( type-c-vararg, kt ) {
             text = text + SAtom(c"...");
          } else if can-unify( type-c-void, kt ) {
             text = text + SAtom(c"void");
@@ -21,7 +21,7 @@ let std-c-compile-function-args(ctx: FContext, lhs: AST): S = (
       App{ left:Lit{key:c":"}, right:App{ v-t=left:Var{k2=key}, right:AType{kt=tt} } } => (
          let decl = std-c-mangle-declaration(kt, lhs);
          let text = SNil();
-         if can-unify( t1(c"C",t0(c"...")), kt ) {
+         if can-unify( type-c-vararg, kt ) {
             text = text + SAtom(c"...");
          } else if can-unify( type-c-void, kt ) {
             text = text + SAtom(c"void");

--- a/PLUGINS/BACKEND/C/std-c-compile-global.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-global.lsts
@@ -57,7 +57,7 @@ let std-c-compile-global(ctx: FContext, k: CString, term: AST): Nil = (
          text = text + post-decl;
          text = text + SAtom(c";\n");
          if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: type-c-void then ()
-         else if can-unify(t1(c"C",t0(c"typedef")), tt) or can-unify(t2(c"Array",t1(c"C",t0(c"typedef")),ta), tt) {
+         else if can-unify(type-c-typedef, tt) or can-unify(type-array-c-typedef, tt) {
             assemble-header-typedef-section = assemble-header-typedef-section + text;
          } else {
             assemble-gdecl-section = assemble-gdecl-section + text;
@@ -96,7 +96,7 @@ let std-c-compile-global(ctx: FContext, k: CString, term: AST): Nil = (
             if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: type-c-void then {
                text = SNil;
                text = SAtom(k) + SAtom(c" = ") + inner-expr.get(c"expression") + SAtom(c";\n");
-            } else if can-unify(t1(c"C",t0(c"typedef")), tt) or can-unify(t2(c"Array",t1(c"C",t0(c"typedef")),ta), tt) {
+            } else if can-unify(type-c-typedef, tt) or can-unify(type-array-c-typedef, tt) {
                assemble-header-typedef-section = assemble-header-typedef-section + text;
             } else {
                assemble-gdecl-section = assemble-gdecl-section + text;
@@ -115,7 +115,7 @@ let std-c-compile-global(ctx: FContext, k: CString, term: AST): Nil = (
             App{ left:Lit{key:c":"}, right:App{ left:ASTNil{}, right:AType{asc-tt=tt} } } => asc-tt.is-t(c"Nil",0);
             _ => true;
          };
-         if initialized or can-unify(t1(c"C",t0(c"typedef")), tt) {
+         if initialized or can-unify(type-c-typedef, tt) {
             let text = SNil();
             if not(config-strip-debug) and loc.filename != c"Unknown" {
                text = text + SAtom(c"\n#line ");
@@ -131,7 +131,7 @@ let std-c-compile-global(ctx: FContext, k: CString, term: AST): Nil = (
             text = text + SAtom(c"(");
             text = text + std-c-compile-function-args(ctx, lhs);
             text = text + SAtom(c");\n");
-            if can-unify(t1(c"C",t0(c"typedef")), tt) {
+            if can-unify(type-c-typedef, tt) {
                assemble-header-typedef-section = assemble-header-typedef-section + text;
             } else {
                assemble-gdecl-section = assemble-gdecl-section + text;

--- a/PLUGINS/BACKEND/C/std-c-compile-global.lsts
+++ b/PLUGINS/BACKEND/C/std-c-compile-global.lsts
@@ -56,7 +56,7 @@ let std-c-compile-global(ctx: FContext, k: CString, term: AST): Nil = (
          text = text + SAtom(k);
          text = text + post-decl;
          text = text + SAtom(c";\n");
-         if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: t1(c"C",t0(c"void")) then ()
+         if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: type-c-void then ()
          else if can-unify(t1(c"C",t0(c"typedef")), tt) or can-unify(t2(c"Array",t1(c"C",t0(c"typedef")),ta), tt) {
             assemble-header-typedef-section = assemble-header-typedef-section + text;
          } else {
@@ -72,14 +72,14 @@ let std-c-compile-global(ctx: FContext, k: CString, term: AST): Nil = (
          if tt.is-t(c"C-Fragment",0) {
             match t {
                Lit{key=key} => (
-                  if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: t1(c"C",t0(c"void")) then ()
+                  if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: type-c-void then ()
                   else assemble-gdecl-section = assemble-gdecl-section + SAtom(key);
                   gend = true;
                );
                _ => ();
             }
          };
-         if not(gend) and (kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: t1(c"C",t0(c"void"))) {
+         if not(gend) and (kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: type-c-void) {
             let inner-expr = std-c-compile-expr( ctx, t, false );
             let text = inner-expr.get(c"expression") + SAtom(c";\n");
             assemble-global-initializer-section = assemble-global-initializer-section + text;
@@ -93,7 +93,7 @@ let std-c-compile-global(ctx: FContext, k: CString, term: AST): Nil = (
             text = text + SAtom(c";\n");
 
             let inner-expr = std-c-compile-expr( ctx, t, false );
-            if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: t1(c"C",t0(c"void")) then {
+            if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: type-c-void then {
                text = SNil;
                text = SAtom(k) + SAtom(c" = ") + inner-expr.get(c"expression") + SAtom(c";\n");
             } else if can-unify(t1(c"C",t0(c"typedef")), tt) or can-unify(t2(c"Array",t1(c"C",t0(c"typedef")),ta), tt) {
@@ -176,11 +176,11 @@ let std-c-compile-global(ctx: FContext, k: CString, term: AST): Nil = (
          text = text + SAtom(k);
          text = text + post-decl;
          text = text + SAtom(c";\n");
-         if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: t1(c"C",t0(c"void")) then ()
+         if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: type-c-void then ()
          else assemble-gdecl-section = assemble-gdecl-section + text;
 
          let inner-expr = std-c-compile-expr( ctx, t, false );
-         if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: t1(c"C",t0(c"void")) {
+         if kt.is-t(c"Nil",0) or kt.is-t(c"Never",0) or kt <: type-c-void {
             text = inner-expr.get(c"expression") + SAtom(c";\n");
             assemble-global-initializer-section = assemble-global-initializer-section + text;
          } else {

--- a/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
+++ b/PLUGINS/BACKEND/C/std-c-mangle-type.lsts
@@ -15,7 +15,7 @@ let std-c-mangle-type-internal(tt: Type, blame: AST): S = (
 let std-c-mangle-type-internal-internal(tt: Type, blame: AST): S = (
    match tt {
       TAnd{ conjugate=conjugate } => (
-         let is-c = can-unify(t1(c"C",ta), tt);
+         let is-c = can-unify(type-c-tany, tt);
          let modifiers = SNil;
          let result = SNil;
          for vector c in conjugate {
@@ -101,7 +101,7 @@ let std-c-mangle-type-internal-internal(tt: Type, blame: AST): S = (
 let std-c-mangle-type-simple(tt: Type, blame: AST): S = (
    match tt {
       TAnd{ conjugate=conjugate } => (
-         let is-c = can-unify(t1(c"C",ta), tt);
+         let is-c = can-unify(type-c-tany, tt);
          let result = SNil();
          for vector c in conjugate {
             if is-c and c.simple-tag != c"C" {} else {

--- a/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
+++ b/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
@@ -21,7 +21,7 @@ let std-c-declare(t: CTerm): Nil = (
             );
             CIdentifier{name2=value} => (if not(std-c-declare-dedup-index.has-key(name2)) {
                std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name2, true);
-               if can-unify( t1(c"C",t0(c"typedef")), return-type ) {
+               if can-unify( type-c-typedef, return-type ) {
                   std-c-typedef-name-index = std-c-typedef-name-index.bind(name2, true);
                };
                ast-parsed-program = ast-parsed-program + Glb(
@@ -38,7 +38,7 @@ let std-c-declare(t: CTerm): Nil = (
                (let name3, let body) = std-c-sig-of-declarator(return-type, arg, ta, (None : Maybe<CTerm>)());
                if not(std-c-declare-dedup-index.has-key(name3.into(type(String)))) {
                   std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name3.into(type(String)), true);
-                  if can-unify( t1(c"C",t0(c"typedef")), return-type ) {
+                  if can-unify( type-c-typedef, return-type ) {
                      std-c-typedef-name-index = std-c-typedef-name-index.bind(name3.into(type(String)), true);
                   };
                   ast-parsed-program = ast-parsed-program + Glb(
@@ -50,7 +50,7 @@ let std-c-declare(t: CTerm): Nil = (
                (let name4, let body) = std-c-sig-of-declarator(return-type, arg1, ta, Some(arg2));
                if not(std-c-declare-dedup-index.has-key(name4.into(type(String)))) {
                   std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name4.into(type(String)), true);
-                  if can-unify( t1(c"C",t0(c"typedef")), return-type ) {
+                  if can-unify( type-c-typedef, return-type ) {
                      std-c-typedef-name-index = std-c-typedef-name-index.bind(name4.into(type(String)), true);
                   };
                   ast-parsed-program = ast-parsed-program + Glb(
@@ -63,7 +63,7 @@ let std-c-declare(t: CTerm): Nil = (
                (let name5, let body) = std-c-sig-of-declarator(return-type, arg1, ta, Some(arg2));
                if not(std-c-declare-dedup-index.has-key(name5.into(type(String)))) {
                   std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name5.into(type(String)), true);
-                  if can-unify( t1(c"C",t0(c"typedef")), return-type ) {
+                  if can-unify( type-c-typedef, return-type ) {
                      std-c-typedef-name-index = std-c-typedef-name-index.bind(name5.into(type(String)), true);
                   };
                   ast-parsed-program = ast-parsed-program + Glb(
@@ -74,7 +74,7 @@ let std-c-declare(t: CTerm): Nil = (
             CBinaryOp{op:"Declarator*", ptr=arg1, arg2:CIdentifier{name6=value} } => (
                if not(std-c-declare-dedup-index.has-key(name6)) {
                   std-c-declare-dedup-index = std-c-declare-dedup-index.bind(name6, true);
-                  if can-unify( t1(c"C",t0(c"typedef")), return-type ) {
+                  if can-unify( type-c-typedef, return-type ) {
                      std-c-typedef-name-index = std-c-typedef-name-index.bind(name6, true);
                   };
                   return-type = std-c-decorate-pointer(return-type, ptr);
@@ -130,7 +130,7 @@ let std-c-nametypes-of-params-list(params: List<CTerm>, is-vararg: Bool): List<(
       _ => print("std-c-sig-of-params-list: Unexpected Parameter \{p}\n");
    }};
    if is-vararg {
-      nametypes = cons((uuid(), t1(c"C",t0(c"..."))), nametypes);
+      nametypes = cons((uuid(), type-c-vararg), nametypes);
    };
    nametypes.reverse
 );
@@ -414,7 +414,7 @@ let std-c-expr-of-statement(t: CTerm): AST = (
          match std-c-expr-of-statement(arg1) {
             Var{key=key} => (
                mk-cons(
-                  mk-app( mk-app( mk-var("let"), mk-var(key) ), mk-nil().ascript(t1(c"C",t0(c":Label"))) ),
+                  mk-app( mk-app( mk-var("let"), mk-var(key) ), mk-nil().ascript(type-c-label) ),
                   std-c-expr-of-statement(arg2)
                )
             );
@@ -609,15 +609,15 @@ let std-c-decorate-pointer(tt: Type, ptr: CTerm): Type = (
 let std-c-type-of-integer(i: String): Type = (
    if i.has-prefix("-") {
       let n = to-u64(tail(i).into(type(CString)));
-      if n <= 128 then t1(c"C",t0(c"uint8_t")) else
-      if n <= 32768 then t1(c"C",t0(c"uint06_t")) else
-      if n <= 2147483648 then t1(c"C",t0(c"uint22_t")) else
-      t1(c"C",t0(c"uint64_t"))
+      if n <= 128 then type-c-uint8 else
+      if n <= 32768 then type-c-uint16 else
+      if n <= 2147483648 then type-c-uint32 else
+      type-c-uint64
    } else {
       let n = to-u64(i.into(type(CString)));
-      if n <= 255 then t1(c"C",t0(c"int8_t")) else
-      if n <= 65535 then t1(c"C",t0(c"int06_t")) else
-      if n <= 4294967295 then t1(c"C",t0(c"int22_t")) else
-      t1(c"C",t0(c"int64_t"))
+      if n <= 255 then type-c-int8 else
+      if n <= 65535 then type-c-int16 else
+      if n <= 4294967295 then type-c-int32 else
+      type-c-int64
    };
 );

--- a/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
+++ b/PLUGINS/FRONTEND/C/c-ast-to-lm-ast.lsts
@@ -159,7 +159,7 @@ let std-c-paramstype-of-params-list(params: List<CTerm>, is-vararg: Bool): Type 
          return = tt;
       }
    };
-   if non-zero(return) then return else t1(c"C",t0(c"void"))
+   if non-zero(return) then return else type-c-void
 );
 
 let std-c-type-of-arrow(spec: CTerm, decl: CTerm, params: List<CTerm>): (CString, Type) = (

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -1637,7 +1637,7 @@ let lsts-make-lit(t: Token): AST = (
                Var( c".into", with-location(mk-token(".into"),loc) ),
                mk-cons(
                   se-rest.first,
-                  mk-atype(t1(c"Type",t0(c"String")))
+                  mk-atype(type-type-string)
                )
             );
             if non-zero(base) {

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -331,7 +331,7 @@ let lsts-parse-type-conjugate(tokens: List<Token>): Tuple<Type,List<Token>> = (
       lsts-parse-expect(c"_", tokens); tokens = tail(tokens);
       ta
    } else if lsts-parse-head(tokens).has-prefix(c"'") and not(lsts-parse-head(tokens).has-suffix(c"'")) {
-      let new-tt = t1(c"Linear",t0(c"Phi::Live"));
+      let new-tt = type-linear-live;
       tokens = tail(tokens);
       new-tt
    } else if lsts-is-ident-head(lsts-parse-head(tokens)) and not(lsts-is-type-tag(lsts-parse-head(tokens))) {
@@ -952,7 +952,7 @@ let lsts-parse-typedef(tokens: List<Token>): (AST, List<Token>) = (
    for vector i in infers {
       if i.is-t(c"MustRelease",0) and not(implied-phi.slot(c"MustRelease::ToRelease",1).l1.is-t(c"Linear",1))
       then {
-         let mt = t1(c"MustRelease::ToRelease",t1(c"Linear",t0(c"Phi::Live")));
+         let mt = t1(c"MustRelease::ToRelease",type-linear-live);
          implied-phi = implied-phi && mt;
          implied-phi-index = implied-phi-index.bind(lhs-type.ground-tag-and-arity, mt);
       };

--- a/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
+++ b/PLUGINS/FRONTEND/LSTS/lsts-parse.lsts
@@ -321,7 +321,7 @@ let lsts-parse-type-conjugate(tokens: List<Token>): Tuple<Type,List<Token>> = (
          tokens = tnext-rest.second;
       };
       lsts-parse-expect(c")", tokens); tokens = tail(tokens);
-      if args.length==0 then t0(c"Nil")
+      if args.length==0 then type-nil
       else if args.length==1 then head(args)
       else ts( c"Tuple", args );
    } else if lsts-parse-head(tokens)==c"?" {
@@ -1025,7 +1025,7 @@ let lsts-parse-function-signature(fname: CString, tokens: List<Token>, loc: Sour
    let out = LstsFnSignature ( mk-nil(), ta, ta );
 
    lsts-parse-expect(c"(", tokens); tokens = tail(tokens);
-   out.args-type = t0(c"Nil");
+   out.args-type = type-nil;
    while non-zero(tokens) and lsts-parse-head(tokens)!=c")" {
       lsts-parse-expect(c"Identifier", lsts-is-ident-head(lsts-parse-head(tokens)), tokens);
       let arg-name = head(tokens); tokens = tail(tokens);
@@ -1059,7 +1059,7 @@ let lsts-parse-function-signature(fname: CString, tokens: List<Token>, loc: Sour
        if fname!=c"phi" then out.return-type = phi-as-state(out.return-type);
        tokens = rtype-rest.second;
    } else if non-zero(out.args-type) {
-       out.return-type = t0(c"Nil");
+       out.return-type = type-nil;
    };
 
    Tuple ( out, tokens )

--- a/SRC/tctx-unify.lsts
+++ b/SRC/tctx-unify.lsts
@@ -122,7 +122,7 @@ let unify-inner(fpt: Type, pt: Type, blame: AST): Maybe<TypeContext> = (
           second:rp1
       } => (
          if can-unify(lp1, rp1)
-         then { ctx = unify-inner(lp1,rp1,blame) && unify-inner(lpr, t0(c"Nil"), blame); }
+         then { ctx = unify-inner(lp1,rp1,blame) && unify-inner(lpr, type-nil, blame); }
          else { ctx = unify-inner(lpr,rp1,blame); }
       );
       Tuple{

--- a/SRC/type-can-unify.lsts
+++ b/SRC/type-can-unify.lsts
@@ -124,7 +124,7 @@ let can-unify(fpt: Type, pt: Type): Bool = (
           ]},
           second:rp1
       } => (
-         if can-unify(lp1,rp1) then can-unify(lpr,t0(c"Nil")) else can-unify(lpr,rp1)
+         if can-unify(lp1,rp1) then can-unify(lpr,type-nil) else can-unify(lpr,rp1)
       );
       Tuple{
           first:TGround{tag:c"...", parameters:[lp1..]},

--- a/SRC/type-constructor.lsts
+++ b/SRC/type-constructor.lsts
@@ -20,8 +20,14 @@ let t2(tag: CString, p1: Type, p2: Type): Type = TGround(tag, mk-vector(type(Typ
 # new allocations = 0
 let tv(name: CString): Type = TVar(name);
 
-# new allocations = 0
-let type-any-arrow = t2(c"Arrow", t0(c"Any"), t0(c"Any"));
+# new allocations = 0 (constant)
+let type-nil = t0(c"Nil");
+
+# new allocations = 0 (constant)
+let type-any = t0(c"Any");
+
+# new allocations = 0 (constant)
+let type-any-arrow = t2(c"Arrow", type-any, type-any);
 
 # new allocations = 0 if either argument is ?
 #                 | 1

--- a/SRC/type-constructor.lsts
+++ b/SRC/type-constructor.lsts
@@ -27,6 +27,9 @@ let type-nil = t0(c"Nil");
 let type-any = t0(c"Any");
 
 # new allocations = 0 (constant)
+let type-type-string = t1(c"Type",t0(c"String"));
+
+# new allocations = 0 (constant)
 let type-linear-moved = t1(c"Linear",t0(c"Phi::Moved"));
 
 # new allocations = 0 (constant)
@@ -34,6 +37,45 @@ let type-linear-live = t1(c"Linear",t0(c"Phi::Live"));
 
 # new allocations = 0 (constant)
 let type-c-void = t1(c"C",t0(c"void"));
+
+# new allocations = 0 (constant)
+let type-c-label = t1(c"C",t0(c":Label"));
+
+# new allocations = 0 (constant)
+let type-c-vararg = t1(c"C",t0(c"..."));
+
+# new allocations = 0 (constant)
+let type-c-tany = t1(c"C",ta);
+
+# new allocations = 0 (constant)
+let type-c-typedef = t1(c"C",t0(c"typedef"));
+
+# new allocations = 0 (constant)
+let type-array-c-typedef = t2(c"Array",t1(c"C",t0(c"typedef")),ta);
+
+# new allocations = 0 (constant)
+let type-c-int8 = t1(c"C",t0(c"int8_t"));
+
+# new allocations = 0 (constant)
+let type-c-int16 = t1(c"C",t0(c"int16_t"));
+
+# new allocations = 0 (constant)
+let type-c-int32 = t1(c"C",t0(c"int32_t"));
+
+# new allocations = 0 (constant)
+let type-c-int64 = t1(c"C",t0(c"int64_t"));
+
+# new allocations = 0 (constant)
+let type-c-uint8 = t1(c"C",t0(c"uint8_t"));
+
+# new allocations = 0 (constant)
+let type-c-uint16 = t1(c"C",t0(c"uint16_t"));
+
+# new allocations = 0 (constant)
+let type-c-uint32 = t1(c"C",t0(c"uint32_t"));
+
+# new allocations = 0 (constant)
+let type-c-uint64 = t1(c"C",t0(c"uint64_t"));
 
 # new allocations = 0 (constant)
 let type-any-arrow = t2(c"Arrow", type-any, type-any);

--- a/SRC/type-constructor.lsts
+++ b/SRC/type-constructor.lsts
@@ -27,6 +27,15 @@ let type-nil = t0(c"Nil");
 let type-any = t0(c"Any");
 
 # new allocations = 0 (constant)
+let type-linear-moved = t1(c"Linear",t0(c"Phi::Moved"));
+
+# new allocations = 0 (constant)
+let type-linear-live = t1(c"Linear",t0(c"Phi::Live"));
+
+# new allocations = 0 (constant)
+let type-c-void = t1(c"C",t0(c"void"));
+
+# new allocations = 0 (constant)
 let type-any-arrow = t2(c"Arrow", type-any, type-any);
 
 # new allocations = 0 if either argument is ?

--- a/SRC/type-move-linear.lsts
+++ b/SRC/type-move-linear.lsts
@@ -8,7 +8,7 @@ let .move-linear(tt: Type): Type = (
          };
          TAnd(new-conjugate)
       );
-      TGround{tag:c"Linear", parameters:[_..]} => t1(c"Linear",t0(c"Phi::Moved"));
+      TGround{tag:c"Linear", parameters:[_..]} => type-linear-moved;
       TGround{tag=tag, parameters=parameters} => (
          let new-parameters = mk-vector(type(Type));
          for vector p in parameters {

--- a/SRC/type-resurrect.lsts
+++ b/SRC/type-resurrect.lsts
@@ -2,7 +2,7 @@
 let .resurrect(tt: Type): Type = (
    match tt {
       TGround{tag:c"Linear", parameters:[TGround{tag:c"Phi::Moved",parameters:[]}..]} => (
-         t1(c"Linear", t0(c"Phi::Live"))
+         type-linear-live
       );
       TGround{tag=tag, parameters=parameters} => (
          ts(tag, parameters.resurrect);

--- a/SRC/typecheck-infer-expr.lsts
+++ b/SRC/typecheck-infer-expr.lsts
@@ -18,7 +18,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
          if not(is(rhs,new-rhs)) then { rhs = new-rhs; term = mk-app(mk-abs(def,mk-nil(),misc-tt),rhs); };
          (tctx, let tt) = std-bind-term(tctx, lname, rhs, def, term, hint);
          tctx = tctx.ascript(def, tt);
-         tctx = tctx.ascript(term, t0(c"Nil"));
+         tctx = tctx.ascript(term, type-nil);
       );
       App{o-t=left:Var{key:c"typeof"}, r=right} => (
          (tctx, let new-r) = std-infer-expr(tctx, r, is-scoped, Used, ta);
@@ -63,7 +63,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
       App{asc=left:Lit{key:c":"}, right:App{inner=left:ASTNil{},right:AType{tt=tt}}} => (
          tt = tt.rewrite-type-alias;
          add-concrete-type-instance(tt, term);
-         tctx = tctx.ascript(inner, t0(c"Nil"));
+         tctx = tctx.ascript(inner, type-nil);
          tctx = tctx.ascript(term, tt);
       );
       App{asc=left:Lit{key:c":"}, right:App{t=left,right:AType{tt=tt}}} => (
@@ -88,7 +88,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             let is-nullary = false;
             if typeof-term(t).is-arrow and not(tt.is-arrow) and non-zero(var-name-if-var-or-lit(t)) {
                # This case exists for nullary constructors like TAny : Type
-               let ftype = tctx.find-callable( var-name-if-var-or-lit(t), t0(c"Nil"), term, tt ).direct-type;
+               let ftype = tctx.find-callable( var-name-if-var-or-lit(t), type-nil, term, tt ).direct-type;
                tctx = tctx.ascript(term, ftype);
                is-nullary = true;
             } else if typeof-term(t) == type-any-arrow {
@@ -175,7 +175,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             };
             let lub = if typeof-term(f).is-t(c"Never",0) then typeof-term(t)
             else if typeof-term(t).is-t(c"Never",0) then typeof-term(f)
-            else if typeof-term(f).is-t(c"Nil",0) or typeof-term(t).is-t(c"Nil",0) then t0(c"Nil")
+            else if typeof-term(f).is-t(c"Nil",0) or typeof-term(t).is-t(c"Nil",0) then type-nil
             else { (tctx, let lub) = tctx.least-upper-bound(typeof-term(t), typeof-term(f), term); lub };
             tctx = tctx.ascript(term, lub);
             let term-phi-id = typeof-term(term).slot(c"Phi::Id",1).l1.simple-id;
@@ -189,9 +189,9 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             if non-zero(term-phi-id) and term-phi-id != f-phi-id then tctx = tctx.phi-move(typeof-term(f), f);
          }
       );
-      ASTEOF{} => tctx = tctx.ascript(term, t0(c"Nil"));
-      ASTNil{} => tctx = tctx.ascript(term, t0(c"Nil"));
-      Meta{} => tctx = tctx.ascript(term, t0(c"Nil"));
+      ASTEOF{} => tctx = tctx.ascript(term, type-nil);
+      ASTNil{} => tctx = tctx.ascript(term, type-nil);
+      Meta{} => tctx = tctx.ascript(term, type-nil);
       Typedef{} => ();
       AType{tt:TGround{tag:c"Type",parameters:[p1..]}} => tctx = tctx.ascript(term, t1(c"Type",p1.sanitize-phi));
       AType{tt=tt} => tctx = tctx.ascript(term, tt.sanitize-phi);
@@ -274,7 +274,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
             } else if not(non-zero(typeof-term(term))) {
                if hint.is-t(c"HashtableEq",2) and hint.is-datatype and key3==c"HashtableEqEOF"
                then {
-                  (tctx, let lit-tt) = tctx.apply-callable(key3, t0(c"Nil"), term, hint);
+                  (tctx, let lit-tt) = tctx.apply-callable(key3, type-nil, term, hint);
                   tctx = tctx.ascript(term, lit-tt);
                } else {
                   tctx = tctx.ascript(term, type-any-arrow);
@@ -340,7 +340,7 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                   let pre-retain-tctx = tctx;
                   (tctx, let new-r) = std-infer-call-arg(tctx, r, var-name-if-var-or-lit(l), rr-args-hint);
                   let ftype = tctx.find-callable( var-name-if-var-or-lit(l), typeof-term(new-r), term, direct-hint ).direct-type;
-                  if typeof-term(l) == t2(c"Arrow",t0(c"Any"),t0(c"Any")) {
+                  if typeof-term(l) == type-any-arrow {
                      tctx = tctx.ascript(l, ftype);
                   };
                   if ftype.domain.is-any-arg-t(c"MustNotRetain",0) {
@@ -398,16 +398,16 @@ let std-infer-expr(tctx: Maybe<TypeContext>, term: AST, is-scoped: Bool, used: I
                      let tmp-var = mk-var(tmp-id); ascript-force(tmp-var, typeof-term(term));
                      tctx = tctx.bind(tmp-id, ta, typeof-term(term), tmp-def);
                      mark-var-to-def-todo(tctx, tmp-id, ta, tmp-var);
-                     let tmp-nil = mk-nil(); ascript-force(tmp-nil, t0(c"Nil"));
-                     let declare = mk-abs(tmp-def, tmp-nil, ta); ascript-force(declare, t0(c"Nil"));
+                     let tmp-nil = mk-nil(); ascript-force(tmp-nil, type-nil);
+                     let declare = mk-abs(tmp-def, tmp-nil, ta); ascript-force(declare, type-nil);
                      if function-type.is-t(c"MustRetainOnCall",0) and not(hint.is-t(c"MustNotRetain",0)) and not(tctx.get-or(mk-tctx()).is-blob) {
                         (tctx, term) = maybe-retain(tctx, term);
                      };
-                     let bind = mk-app(declare, term); ascript-force(bind, t0(c"Nil"));
+                     let bind = mk-app(declare, term); ascript-force(bind, type-nil);
 
                      let new-term = bind;
                      if non-zero(prefix) {
-                        new-term = mk-cons(prefix, new-term); ascript-force(new-term, t0(c"Nil"));
+                        new-term = mk-cons(prefix, new-term); ascript-force(new-term, type-nil);
                      };
                      new-term = mk-cons(new-term, postfix); ascript-force(new-term, typeof-term(postfix));
                      new-term = mk-cons(new-term, tmp-var); ascript-force(new-term, typeof-term(term));

--- a/SRC/typecheck-release-locals.lsts
+++ b/SRC/typecheck-release-locals.lsts
@@ -24,7 +24,7 @@ let release-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AS
       let rhs = term;
       let def = mk-var(return-id);
       if not(return-type.is-t(c"Nil",0)) and not(return-type.is-t(c"Never",0)) {
-         term = mk-app( mk-abs(def, mk-nil(), ta), term ); tctx-after = tctx-after.ascript(term, t0(c"Nil"));
+         term = mk-app( mk-abs(def, mk-nil(), ta), term ); tctx-after = tctx-after.ascript(term, type-nil);
          (tctx-after, let binding-type) = std-bind-term(tctx-after, return-id, rhs, def, term, hint);
          tctx-after = tctx-after.ascript(def, binding-type);
       };
@@ -35,7 +35,7 @@ let release-locals(tctx-before: TypeContext?, tctx-after: TypeContext?, term: AS
             mk-app(mk-var(c"destroy"),mk-var(nd.key-or-zero))
          );
          (tctx-after, do-release) = std-infer-expr(tctx-after, do-release, false, Used, ta);
-         term = mk-cons(term, do-release); tctx-after = tctx-after.ascript(term, t0(c"Nil"));
+         term = mk-cons(term, do-release); tctx-after = tctx-after.ascript(term, type-nil);
       };
       let return-term = if not(return-type.is-t(c"Nil",0)) and not(return-type.is-t(c"Never",0))
       then mk-var(return-id)

--- a/SRC/typecheck-std-maybe-release-after-call.lsts
+++ b/SRC/typecheck-std-maybe-release-after-call.lsts
@@ -47,12 +47,12 @@ let std-release-after-call(tctx: TypeContext?, function-type: Type, param-types:
             let tmp-var2 = mk-var(tmp-id1); ascript-force(tmp-var2, args-type);
             tctx = tctx.bind(tmp-id1, ta, args-type, tmp-def);
             mark-var-to-def-todo(tctx, tmp-id1, ta, tmp-var2);
-            let tmp-nil = mk-nil(); ascript-force(tmp-nil, t0(c"Nil"));
-            let declare = mk-abs(tmp-def, tmp-nil, ta); ascript-force(declare, t0(c"Nil"));
-            let bind = mk-app(declare, args); ascript-force(bind, t0(c"Nil"));
+            let tmp-nil = mk-nil(); ascript-force(tmp-nil, type-nil);
+            let declare = mk-abs(tmp-def, tmp-nil, ta); ascript-force(declare, type-nil);
+            let bind = mk-app(declare, args); ascript-force(bind, type-nil);
 
             if non-zero(prefix)
-            then (prefix = mk-cons( prefix, bind ); ascript-force(prefix, t0(c"Nil"));)
+            then (prefix = mk-cons( prefix, bind ); ascript-force(prefix, type-nil);)
             else prefix = bind;
 
             (tmp-var2, args)
@@ -64,12 +64,12 @@ let std-release-after-call(tctx: TypeContext?, function-type: Type, param-types:
             tctx = tctx.bind(tmp-id2, ta, args-type, tmp-def);
             mark-var-to-def-todo(tctx, tmp-id2, ta, tmp-var2);
             mark-var-to-def-todo(tctx, tmp-id2, ta, tmp-direct);
-            let tmp-nil = mk-nil(); ascript-force(tmp-nil, t0(c"Nil"));
-            let declare = mk-abs(tmp-def, tmp-nil, ta); ascript-force(declare, t0(c"Nil"));
-            let bind = mk-app(declare, args); ascript-force(bind, t0(c"Nil"));
+            let tmp-nil = mk-nil(); ascript-force(tmp-nil, type-nil);
+            let declare = mk-abs(tmp-def, tmp-nil, ta); ascript-force(declare, type-nil);
+            let bind = mk-app(declare, args); ascript-force(bind, type-nil);
 
             if non-zero(prefix)
-            then (prefix = mk-cons( prefix, bind ); ascript-force(prefix, t0(c"Nil"));)
+            then (prefix = mk-cons( prefix, bind ); ascript-force(prefix, type-nil);)
             else prefix = bind;
 
             (tmp-var2, tmp-direct)
@@ -81,7 +81,7 @@ let std-release-after-call(tctx: TypeContext?, function-type: Type, param-types:
          let do-release = mk-app(release-var, tmp-release); ascript-force(do-release, release-return);
  
          if non-zero(postfix)
-         then (postfix = mk-cons( postfix, do-release ); ascript-force(postfix, t0(c"Nil"));)
+         then (postfix = mk-cons( postfix, do-release ); ascript-force(postfix, type-nil);)
          else postfix = do-release;
       };
 

--- a/SRC/typecheck-typeof-lhs.lsts
+++ b/SRC/typecheck-typeof-lhs.lsts
@@ -5,6 +5,6 @@ let typeof-lhs(lhs: AST, idx: U64): Type = match lhs {
    App{ left:Lit{key:c":"}, right:App{ right:AType{tt=tt} } } => tt.rewrite-type-alias.accept-interface(idx);
    App{ ps=left, right:App{ left:Lit{key:c":"}, right:App{ right:AType{tt=tt} } } } =>
      t2(c"Cons", typeof-lhs(ps,idx+1), tt.rewrite-type-alias.accept-interface(idx));
-   ASTNil{} => t0(c"Nil");
-   _ => (exit-error("typeof-lhs Unexpected LHS \{lhs}\n", lhs); t0(c"Nil"));
+   ASTNil{} => type-nil;
+   _ => (exit-error("typeof-lhs Unexpected LHS \{lhs}\n", lhs); type-nil);
 };


### PR DESCRIPTION
## Describe your changes
Features:
* remove small type allocations and replace with constants
* only small performance improvements

## Issue ticket number and link
https://github.com/Lambda-Mountain-Compiler-Backend/lambda-mountain/issues/1895

## Checklist before requesting a review
- [ x ] I have performed an AI-assisted self-review of my code.
```
Can you review my pull request and provide some suggestions?
https://patch-diff.githubusercontent.com/raw/Lambda-Mountain-Compiler-Backend/lambda-mountain/pull/1926.diff
```
- [ x ] If it is a new feature, I have added thorough tests.
- [ x ] I agree to release these changes under the terms of the permissive MIT license (1).

1. https://github.com/andrew-johnson-4/lambda-mountain/blob/main/LICENSE
